### PR TITLE
UISPbaseUrl vs uispBaseUrl

### DIFF
--- a/v1.3/ispConfig.example.py
+++ b/v1.3/ispConfig.example.py
@@ -64,7 +64,7 @@ splynx_api_url = 'https://YOUR_URL.splynx.app'
 automaticImportUISP = False
 uispAuthToken = ''
 # Everything before /nms/ on your UISP instance
-uispBaseURL = 'https://examplesite.com'
+UISPbaseURL = 'https://examplesite.com'
 # UISP | Whether to shape router at customer premises, or instead shape the station radio. When station radio is in
 # router mode, use 'station'. Otherwise, use 'router'.
 shapeRouterOrStation = 'router'


### PR DESCRIPTION
`ispConfig.py` lists the example URL as "uispBaseUrl". `integrationUISP.py` imports "UISPbaseUrl". This PR updates the example to show the correct variable name.

Signed-off-by: Herbert Wolverson <herberticus@gmail.com>