### PR TITLE
Uisp integration: check ap['device']['site'] for None

### DIFF
--- a/v1.3/integrationUISP.py
+++ b/v1.3/integrationUISP.py
@@ -32,10 +32,13 @@ def createTree(sites,accessPoints,bandwidthDL,bandwidthUL,siteParentDict,siteIDt
 			thisOnesParent = None
 	aps = []
 	for ap in accessPoints:
-		thisOnesParent = ap['device']['site']['name']
-		if thisOnesParent == currentNodeName:
-			if ap['device']['model'] in knownAPmodels:
-				aps.append(ap['device']['name'])
+		if ap['device']['site'] is None:
+			print("Unable to read site information for: " + ap['device']['name'])
+		else:
+			thisOnesParent = ap['device']['site']['name']
+			if thisOnesParent == currentNodeName:
+				if ap['device']['model'] in knownAPmodels:
+					aps.append(ap['device']['name'])
 	apDict = {}
 	for ap in aps:
 		maxDL = min(bandwidthDL[ap],bandwidthDL[currentNodeName])


### PR DESCRIPTION
Running integrationUISP.py against our controller resulted in a crash. Two devices didn't yield proper site information in their `ap['device']['site']` record. Both devices were not-yet associated with UISP, so they didn't *have* site information yet. This commit adds a test for this condition, and emits a warning instead of crashing. Tested against my WISPs UISP controller.