### PR TITLE
shapeRouterOrStation is never used - remove it

### DIFF
--- a/v1.3/integrationUISP.py
+++ b/v1.3/integrationUISP.py
@@ -2,7 +2,7 @@ import requests
 import os
 import csv
 import ipaddress
-from ispConfig import UISPbaseURL, uispAuthToken, shapeRouterOrStation, allowedSubnets, ignoreSubnets, excludeSites, findIPv6usingMikrotik, bandwidthOverheadFactor, exceptionCPEs
+from ispConfig import UISPbaseURL, uispAuthToken, allowedSubnets, ignoreSubnets, excludeSites, findIPv6usingMikrotik, bandwidthOverheadFactor, exceptionCPEs
 import shutil
 import json
 if findIPv6usingMikrotik == True:

--- a/v1.3/ispConfig.example.py
+++ b/v1.3/ispConfig.example.py
@@ -65,9 +65,6 @@ automaticImportUISP = False
 uispAuthToken = ''
 # Everything before /nms/ on your UISP instance
 UISPbaseURL = 'https://examplesite.com'
-# UISP | Whether to shape router at customer premises, or instead shape the station radio. When station radio is in
-# router mode, use 'station'. Otherwise, use 'router'.
-shapeRouterOrStation = 'router'
 # List any sites that should not be included, with each site name surrounded by '' and seperated by commas
 excludeSites = []
 # If you use IPv6, this can be used to find associated IPv6 prefixes for your clients' IPv4 addresses, and match them to those devices


### PR DESCRIPTION
`shapeRouterOrStation` is defined in ispConfig.example.py and imported into integrationUISP.py - but is never accessed. This PR removes it from the example file and removes the unused import, since it doesn't do anything.

Signed-off-by: Herbert Wolverson <herberticus@gmail.com>