### PR TITLE
Feat: Integration common network root promotion

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -183,6 +183,7 @@ class NetworkGraph:
 		# by name. Entries are re-mapped to match the named
 		# parents. You can use this to build a tree from a
 		# blob of raw data.
+		cached_root_list = promote_to_root_list()
 		for child in self.nodes:
 			if child.parentId != "":
 				for (i, node) in enumerate(self.nodes):
@@ -190,7 +191,7 @@ class NetworkGraph:
 					# the node is set to 0, which is the root node. Otherwise,
 					# the parent is set to the node with the same id as the
 					# parentId of the child node.
-					if child.parentId in promote_to_root_list():
+					if self.nodes[self.findNodeIndexById(child.parentId)].displayName in cached_root_list:
 						child.parentIndex = 0
 					elif node.id == child.parentId:
 						child.parentIndex = i

--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -5,7 +5,7 @@ from typing import List, Any
 from liblqos_python import allowed_subnets, ignore_subnets, generated_pn_download_mbps, generated_pn_upload_mbps, \
 	circuit_name_use_address, upstream_bandwidth_capacity_download_mbps, upstream_bandwidth_capacity_upload_mbps, \
 	find_ipv6_using_mikrotik, exclude_sites, bandwidth_overhead_factor, committed_bandwidth_multiplier, \
-	exception_cpes
+	exception_cpes, promote_to_root_list
 import ipaddress
 import enum
 import os
@@ -186,7 +186,13 @@ class NetworkGraph:
 		for child in self.nodes:
 			if child.parentId != "":
 				for (i, node) in enumerate(self.nodes):
-					if node.id == child.parentId:
+					# If the node is in `promote_to_root_list`, the parent for
+					# the node is set to 0, which is the root node. Otherwise,
+					# the parent is set to the node with the same id as the
+					# parentId of the child node.
+					if child.parentId in promote_to_root_list():
+						child.parentIndex = 0
+					elif node.id == child.parentId:
 						child.parentIndex = i
 
 	def findNodeIndexById(self, id: str) -> int:

--- a/src/rust/lqos_config/src/etc/v15/integration_common.rs
+++ b/src/rust/lqos_config/src/etc/v15/integration_common.rs
@@ -12,6 +12,9 @@ pub struct IntegrationConfig {
 
     /// Queue refresh interval in minutes
     pub queue_refresh_interval_mins: u32,
+
+    /// Root node promotion
+    pub promote_to_root: Option<Vec<String>>,
 }
 
 impl Default for IntegrationConfig {
@@ -20,6 +23,7 @@ impl Default for IntegrationConfig {
             circuit_name_as_address: false,
             always_overwrite_network_json: false,
             queue_refresh_interval_mins: 30,
+            promote_to_root: None,
         }
     }
 }

--- a/src/rust/lqos_python/src/lib.rs
+++ b/src/rust/lqos_python/src/lib.rs
@@ -98,6 +98,7 @@ fn liblqos_python(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(automatic_import_wispgate))?;
     m.add_wrapped(wrap_pyfunction!(wispgate_api_token))?;
     m.add_wrapped(wrap_pyfunction!(wispgate_api_url))?;
+    m.add_wrapped(wrap_pyfunction!(promote_to_root_list))?;
 
     Ok(())
 }
@@ -772,4 +773,13 @@ fn wispgate_api_url() -> PyResult<String> {
         return Ok(String::new());
     };
     Ok(wisp_gate.wispgate_api_url.clone())
+}
+
+#[pyfunction]
+fn promote_to_root_list() -> PyResult<Vec<String>> {
+    let config = lqos_config::load_config().unwrap();
+    let Some(promote_to_root) = config.integration_common.promote_to_root.as_ref() else {
+        return Ok(vec![]);
+    };
+    Ok(promote_to_root.clone())
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_integration.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_integration.js
@@ -7,6 +7,15 @@ function validateConfig() {
         alert("Queue Refresh Interval must be a number greater than 0");
         return false;
     }
+    
+    // Validate promote_to_root entries
+    const rawPromote = document.getElementById("promoteToRoot").value;
+    const hasInvalidEntries = rawPromote.split('\n')
+        .some(line => line.trim().length === 0 && rawPromote.trim().length > 0);
+    if (hasInvalidEntries) {
+        alert("Please remove empty lines from Promote to Root Nodes");
+        return false;
+    }
     return true;
 }
 
@@ -15,7 +24,14 @@ function updateConfig() {
     window.config.integration_common = {
         circuit_name_as_address: document.getElementById("circuitNameAsAddress").checked,
         always_overwrite_network_json: document.getElementById("alwaysOverwriteNetworkJson").checked,
-        queue_refresh_interval_mins: parseInt(document.getElementById("queueRefreshInterval").value)
+        queue_refresh_interval_mins: parseInt(document.getElementById("queueRefreshInterval").value),
+        promote_to_root: (() => {
+            const raw = document.getElementById("promoteToRoot").value;
+            const list = raw.split('\n')
+                .map(line => line.trim())
+                .filter(line => line.length > 0);
+            return list.length > 0 ? list : null;
+        })()
     };
 }
 
@@ -34,6 +50,10 @@ loadConfig(() => {
         // Numeric field
         document.getElementById("queueRefreshInterval").value = 
             integration.queue_refresh_interval_mins ?? 30;
+
+        // Promote to root field
+        const promoteRoot = integration.promote_to_root ? integration.promote_to_root.join('\n') : '';
+        document.getElementById("promoteToRoot").value = promoteRoot;
 
         // Add save button click handler
         document.getElementById('saveButton').addEventListener('click', () => {

--- a/src/rust/lqosd/src/node_manager/static2/config_integration.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_integration.html
@@ -43,6 +43,12 @@
                 <div class="form-text">How frequently to refresh queue data from the integration</div>
             </div>
 
+            <div class="mb-3">
+                <label for="promoteToRoot" class="form-label">Promote to Root Nodes</label>
+                <textarea class="form-control" id="promoteToRoot" rows="3"></textarea>
+                <div class="form-text">Enter one circuit ID per line to promote to root nodes</div>
+            </div>
+
             <button type="button" id="saveButton" class="btn btn-outline-primary">Save Changes</button>
         </form>
     </div>


### PR DESCRIPTION
In some cases, a top level node created by an integration may have too much traffic to be supported by a single CPU core / HTB. To work around this, we have added the functionality for an operator to promote the children of a given top level node to parent off the root directly.

To promote the child nodes of a site to each be parent off of root, simply list these site names in the `promote_to_root` variable in /etc/lqos.conf
```
[integration_common]
promote_to_root = ["SiteName"]
```