### PR TITLE
Uisp full2 squashing

### DIFF
--- a/src/rust/lqos_config/src/etc/v15/uisp_integration.rs
+++ b/src/rust/lqos_config/src/etc/v15/uisp_integration.rs
@@ -21,6 +21,9 @@ pub struct UispIntegration {
     #[serde(default = "default_ignore_calculated_capacity")]
     pub ignore_calculated_capacity: bool,
     pub insecure_ssl: Option<bool>,
+
+    pub enable_squashing: Option<bool>,
+    pub do_not_squash_sites: Option<Vec<String>>,
 }
 
 fn default_ignore_calculated_capacity() -> bool {
@@ -53,6 +56,8 @@ impl Default for UispIntegration {
             use_ptmp_as_parent: false,
             ignore_calculated_capacity: false,
             insecure_ssl: None,
+            enable_squashing: None,
+            do_not_squash_sites: None,
         }
     }
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_uisp.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_uisp.js
@@ -93,6 +93,9 @@ function updateConfig() {
         return { cpe, parent };
     }) : [];
 
+    const doNotSquashSites = document.getElementById("uispDoNotSquashSites").value.trim();
+    const doNotSquashSitesArray = doNotSquashSites ? doNotSquashSites.split(',').map(s => s.trim()) : null;
+
     // Update the config object
     window.config.uisp_integration = {
         ...(window.config.uisp_integration || {}),  // Preserve existing values
@@ -113,6 +116,8 @@ function updateConfig() {
         exclude_sites: excludeSitesArray,
         squash_sites: squashSitesArray && squashSitesArray.length > 0 ? squashSitesArray : null,
         exception_cpes: exceptionCpesArray,
+        enable_squashing: document.getElementById("uispEnableSquashing").checked,
+        do_not_squash_sites: doNotSquashSitesArray && doNotSquashSitesArray.length > 0 ? doNotSquashSitesArray : null,
     };
 }
 
@@ -149,6 +154,8 @@ loadConfig(() => {
         document.getElementById("uispExcludeSites").value = uisp.exclude_sites?.join(", ") || "";
         document.getElementById("uispSquashSites").value = uisp.squash_sites?.join(", ") || "";
         document.getElementById("uispExceptionCpes").value = uisp.exception_cpes?.map(e => `${e.cpe}:${e.parent}`).join(", ") || "";
+        document.getElementById("uispEnableSquashing").checked = uisp.enable_squashing ?? false;
+        document.getElementById("uispDoNotSquashSites").value = uisp.do_not_squash_sites?.join(", ") || "";
 
         // Add save button click handler
         document.getElementById('saveButton').addEventListener('click', () => {

--- a/src/rust/lqosd/src/node_manager/static2/config_uisp.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_uisp.html
@@ -104,6 +104,18 @@
                 <div class="form-text">Comma-separated list of CPE exceptions in "cpe:parent" format</div>
             </div>
 
+            <div class="mb-3 form-check">
+                <input type="checkbox" class="form-check-input" id="uispEnableSquashing">
+                <label class="form-check-label" for="uispEnableSquashing">Enable Squashing</label>
+                <div class="form-text">Enable site squashing functionality</div>
+            </div>
+
+            <div class="mb-3">
+                <label for="uispDoNotSquashSites" class="form-label">Do Not Squash Sites</label>
+                <input type="text" class="form-control" id="uispDoNotSquashSites">
+                <div class="form-text">Comma-separated list of site IDs that should not be squashed</div>
+            </div>
+
             <button type="button" id="saveButton" class="btn btn-outline-primary">Save Changes</button>
         </form>
     </div>

--- a/src/rust/uisp_integration/src/strategies/full2.rs
+++ b/src/rust/uisp_integration/src/strategies/full2.rs
@@ -162,7 +162,6 @@ pub async fn build_full_network_v2(
     if config.uisp_integration.enable_squashing.unwrap_or(false) {
         find_point_to_point_squash_candidates(&mut graph, &aps_with_clients, &config);
     }
-    panic!();
 
     // Visualizer
     save_dot_file(&graph)?;


### PR DESCRIPTION
Adds two configuration items to the `[uisp_integration]` config section:

```toml
enable_squashing = true
do_not_squash_sites = ["SITE1"] # Can be omitted or left []
```

If enabled, it looks for "pure point to point" topologies within the overall map. For example:
PAQUIN -> Paquin-to-calvin -> Calvin-to-Paquin -> CALVIN.

If NONE of the sites listed occur in the `do_not_squash_sites` list, and the two intermediate points are ONLY linked to their parents and each other (no clients, no other links) then the link will be squashed down to PAQUIN -> CALVIN.