### PR TITLE
UISP: “slow” suspension clamps to 0.1 Mbps; docs updated (EN/ES)

### DIFF
--- a/docs-es/v2.0/TechnicalDocs/integrations.md
+++ b/docs-es/v2.0/TechnicalDocs/integrations.md
@@ -83,7 +83,7 @@ strategy = "full"
 # Suspension strategy:
 # * "none" - do not handle suspensions
 # * "ignore" - do not add suspended customers to the network map
-# * "slow" - limit suspended customers to 1mbps
+# * "slow" - limit suspended customers to 0.1 Mbps
 suspended_strategy = "none"
 
 # UISP's reported AP capacities for AirMax can be a bit optimistic. For AirMax APs, we limit

--- a/docs-es/v2.0/integrations-es.md
+++ b/docs-es/v2.0/integrations-es.md
@@ -150,7 +150,7 @@ Configure cómo LibreQoS maneja las cuentas de clientes suspendidos:
 |------------|-------------|-------------|
 | `none` | No manejar suspensiones | Cuando el manejo de suspensiones se gestiona en otro lugar |
 | `ignore` | No agregar clientes suspendidos al mapa de red | Reduce el número de colas y mejora el rendimiento para redes con muchas cuentas suspendidas |
-| `slow` | Limitar clientes suspendidos a 1mbps | Mantiene conectividad para cuentas suspendidas mientras limita el uso de ancho de banda |
+| `slow` | Limitar clientes suspendidos a 0.1 Mbps | Mantiene conectividad para cuentas suspendidas mientras limita el uso de ancho de banda |
 
 **Cómo Elegir una Estrategia de Suspensión:**
 - Use `none` si su router de borde u otro sistema maneja las suspensiones

--- a/docs/v2.0/integrations.md
+++ b/docs/v2.0/integrations.md
@@ -151,7 +151,7 @@ Configure how LibreQoS handles suspended customer accounts:
 |----------|-------------|----------|
 | `none` | Do not handle suspensions | When suspension handling is managed elsewhere |
 | `ignore` | Do not add suspended customers to network map | Reduces queue count and improves performance for networks with many suspended accounts |
-| `slow` | Limit suspended customers to 1mbps | Maintains connectivity for suspended accounts while limiting bandwidth usage |
+| `slow` | Limit suspended customers to 0.1 Mbps | Maintains connectivity for suspended accounts while limiting bandwidth usage |
 
 **Choosing a Suspension Strategy:**
 - Use `none` if your edge router or another system handles suspensions

--- a/src/rust/uisp_integration/src/strategies/ap_only.rs
+++ b/src/rust/uisp_integration/src/strategies/ap_only.rs
@@ -72,6 +72,30 @@ pub async fn build_ap_only_network(
                 .filter(|d| d.site_id == *client_id)
                 .collect::<Vec<_>>();
             for device in devices.iter().filter(|d| d.has_address()) {
+                // Compute rates
+                let mut download_max = site.max_down_mbps as f32
+                    * config.uisp_integration.bandwidth_overhead_factor;
+                let mut upload_max = site.max_up_mbps as f32
+                    * config.uisp_integration.bandwidth_overhead_factor;
+                let mut download_min = download_max
+                    * config.uisp_integration.commit_bandwidth_multiplier;
+                let mut upload_min = upload_max
+                    * config.uisp_integration.commit_bandwidth_multiplier;
+
+                // Clamp for suspended "slow" users
+                if site.suspended && config.uisp_integration.suspended_strategy.eq_ignore_ascii_case("slow") {
+                    download_max = 0.1;
+                    upload_max = 0.1;
+                    download_min = 0.1;
+                    upload_min = 0.1;
+                } else {
+                    // Apply floors for regular cases
+                    download_max = f32::max(0.1, download_max);
+                    upload_max = f32::max(0.1, upload_max);
+                    download_min = f32::max(0.1, download_min);
+                    upload_min = f32::max(0.1, upload_min);
+                }
+
                 let sd = ShapedDevice {
                     circuit_id: site.id.clone(),
                     circuit_name: site.name.clone(),
@@ -81,14 +105,10 @@ pub async fn build_ap_only_network(
                     mac: device.mac.clone(),
                     ipv4: device.ipv4_list(),
                     ipv6: device.ipv6_list(),
-                    download_min: f32::max(0.1, site.max_down_mbps as f32
-                        * config.uisp_integration.commit_bandwidth_multiplier),
-                    upload_min: f32::max(0.1, site.max_up_mbps as f32
-                        * config.uisp_integration.commit_bandwidth_multiplier),
-                    download_max: f32::max(0.1, site.max_down_mbps as f32
-                        * config.uisp_integration.bandwidth_overhead_factor),
-                    upload_max: f32::max(0.1, site.max_up_mbps as f32
-                        * config.uisp_integration.bandwidth_overhead_factor),
+                    download_min,
+                    upload_min,
+                    download_max,
+                    upload_max,
                     comment: "".to_string(),
                 };
                 shaped_devices.push(sd);

--- a/src/rust/uisp_integration/src/strategies/full/shaped_devices_writer.rs
+++ b/src/rust/uisp_integration/src/strategies/full/shaped_devices_writer.rs
@@ -87,20 +87,29 @@ fn traverse(
                 let device = &devices[*device];
                 if device.has_address() {
                     // Calculate fractional rates preserving decimal precision
-                    let download_max_f32 = sites[idx].max_down_mbps as f32
+                    let mut download_max = sites[idx].max_down_mbps as f32
                         * config.uisp_integration.bandwidth_overhead_factor;
-                    let upload_max_f32 = sites[idx].max_up_mbps as f32
+                    let mut upload_max = sites[idx].max_up_mbps as f32
                         * config.uisp_integration.bandwidth_overhead_factor;
-                    let download_min_f32 = download_max_f32
+                    let mut download_min = download_max
                         * config.uisp_integration.commit_bandwidth_multiplier;
-                    let upload_min_f32 = upload_max_f32
+                    let mut upload_min = upload_max
                         * config.uisp_integration.commit_bandwidth_multiplier;
                     
-                    // Apply minimum rate safeguards (0.1 Mbps minimum)
-                    let download_max = f32::max(0.1, download_max_f32);
-                    let upload_max = f32::max(0.1, upload_max_f32);
-                    let download_min = f32::max(0.1, download_min_f32);
-                    let upload_min = f32::max(0.1, upload_min_f32);
+                    // If suspended with "slow" strategy, clamp min/max to exactly 0.1 Mbps
+                    if sites[idx].suspended &&
+                        config.uisp_integration.suspended_strategy.eq_ignore_ascii_case("slow") {
+                        download_max = 0.1;
+                        upload_max = 0.1;
+                        download_min = 0.1;
+                        upload_min = 0.1;
+                    } else {
+                        // Apply minimum rate safeguards (0.1 Mbps minimum)
+                        download_max = f32::max(0.1, download_max);
+                        upload_max = f32::max(0.1, upload_max);
+                        download_min = f32::max(0.1, download_min);
+                        upload_min = f32::max(0.1, upload_min);
+                    }
                     
                     let sd = ShapedDevice {
                         circuit_id: sites[idx].id.clone(),
@@ -130,21 +139,21 @@ fn traverse(
                     format!("{}_Infrastructure", sites[idx].name.clone())
                 };
                 if device.has_address() {
-                    // Calculate fractional rates preserving decimal precision
-                    let download_max_f32 = sites[idx].max_down_mbps as f32
+                    // Calculate fractional rates preserving decimal precision (infrastructure)
+                    let mut download_max = sites[idx].max_down_mbps as f32
                         * config.uisp_integration.bandwidth_overhead_factor;
-                    let upload_max_f32 = sites[idx].max_up_mbps as f32
+                    let mut upload_max = sites[idx].max_up_mbps as f32
                         * config.uisp_integration.bandwidth_overhead_factor;
-                    let download_min_f32 = download_max_f32
+                    let mut download_min = download_max
                         * config.uisp_integration.commit_bandwidth_multiplier;
-                    let upload_min_f32 = upload_max_f32
+                    let mut upload_min = upload_max
                         * config.uisp_integration.commit_bandwidth_multiplier;
                     
-                    // Apply minimum rate safeguards (0.1 Mbps minimum, higher for infrastructure)
-                    let download_max = f32::max(0.2, download_max_f32);
-                    let upload_max = f32::max(0.2, upload_max_f32);
-                    let download_min = f32::max(0.2, download_min_f32);
-                    let upload_min = f32::max(0.2, upload_min_f32);
+                    // Apply minimum rate safeguards (0.2 Mbps minimum, higher for infrastructure)
+                    download_max = f32::max(0.2, download_max);
+                    upload_max = f32::max(0.2, upload_max);
+                    download_min = f32::max(0.2, download_min);
+                    upload_min = f32::max(0.2, upload_min);
                     
                     let sd = ShapedDevice {
                         circuit_id: format!("{}-inf", sites[idx].id),


### PR DESCRIPTION
Summary

- Clamp rates for suspended “slow” users to 0.1 Mbps:
    - Applies to both min/max and down/up in ShapedDevices.csv.
    - Implemented in:
      - rust/uisp_integration/src/strategies/full/shaped_devices_writer.rs
      - rust/uisp_integration/src/strategies/ap_only.rs
      - rust/uisp_integration/src/strategies/ap_site.rs
- No upstream schema changes:
    - network.json and UispSite u64 speeds unchanged; clamp occurs at CSV emission.
    - Infrastructure entries retain higher minimums; only client entries are clamped.
- Documentation updates to reflect 0.1 Mbps:
    - /opt/libreqos/docs/v2.0/integrations.md (EN)
    - /opt/libreqos/docs-es/v2.0/integrations-es.md (ES)
    - /opt/libreqos/docs-es/v2.0/TechnicalDocs/integrations.md (ES)

Notes

- Overhead and commit multipliers do not raise the “slow” suspended rate above 0.1 Mbps due to the explicit clamp.