### PR TITLE
Fix: All websocket connections now check for an http vs https prefix.

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/lq_js_common/dashboard/ws.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/lq_js_common/dashboard/ws.js
@@ -1,4 +1,5 @@
 // Setup any WS feeds for this page
+import { ws_proto } from '../../pubsub/ws.js';
 let ws = null;
 
 export function subscribeWS(channels, handler) {
@@ -9,7 +10,7 @@ export function subscribeWS(channels, handler) {
         ws.close();
     }
 
-    ws = new WebSocket('ws://' + window.location.host + '/websocket/ws');
+    ws = new WebSocket(ws_proto() + window.location.host + '/websocket/ws');
     ws.onopen = () => {
         for (let i=0; i<channels.length; i++) {
             ws.send("{ \"channel\" : \"" + channels[i] + "\"}");


### PR DESCRIPTION
This may help with #831 - and is generally a good idea for people who want to put Caddy or similar in front of lqosd.