### PR TITLE
Fixes UISP burst conversion units.

### DIFF
--- a/src/rust/uisp_integration/src/strategies/flat.rs
+++ b/src/rust/uisp_integration/src/strategies/flat.rs
@@ -115,11 +115,11 @@ pub async fn build_flat_network(
                             .unwrap_or(0.0);
                         let burst_down = qos
                             .downloadBurstSize
-                            .map(|v| (v as f32) * 8.0 / 1000.0)
+                            .map(|v| (v as f32) * 8.0 / 1_000_000.0)
                             .unwrap_or(0.0);
                         let burst_up = qos
                             .uploadBurstSize
-                            .map(|v| (v as f32) * 8.0 / 1000.0)
+                            .map(|v| (v as f32) * 8.0 / 1_000_000.0)
                             .unwrap_or(0.0);
                         if base_down > 0.0 || base_up > 0.0 {
                             download_min = f32::max(


### PR DESCRIPTION
Fixes UISP burst conversion units. UISP sends burst in bytes/sec, but LibreQoS interpreted the value as kilobytes. Conversion has been corrected to bytes/sec → Mbps. Resolves excessive burst ceilings on subscriber plans.