### PR TITLE
Fix: The build_dpkg and build_rust scripts now use the same API binayy, and share a lot more common code.

### DIFF
--- a/src/build_dpkg.sh
+++ b/src/build_dpkg.sh
@@ -226,12 +226,13 @@ EOF
 popd || exit
 
 ####################################################
-# Bundle the API into src/bin
-echo "Fetching lqos_api (api.zip) ..."
-curl -fsSL -o /tmp/lqos_api.zip "https://download.libreqos.com/api.zip"
-unzip -o /tmp/lqos_api.zip -d "$LQOS_DIR/bin"
-chmod +x "$LQOS_DIR/bin/lqos_api" || true
-rm -f /tmp/lqos_api.zip
+# Bundle the API into the package
+echo "Fetching lqos_api via update_api.sh ..."
+bash ./update_api.sh --bin-dir "$LQOS_DIR/bin" --no-restart
+if [[ ! -x "$LQOS_DIR/bin/lqos_api" ]]; then
+  echo "Error: lqos_api was not installed into the package at $LQOS_DIR/bin/lqos_api"
+  exit 1
+fi
 
 ####################################################
 # Assemble the package

--- a/src/update_api.sh
+++ b/src/update_api.sh
@@ -2,14 +2,57 @@
 
 set -euo pipefail
 
-# Fetch and install the lqos_api binary into src/bin
+# Fetch and install the lqos_api binary into src/bin (or an alternate destination)
 # - Downloads https://download.libreqos.com/api2.zip
 # - Extracts the single file lqos_api
-# - Places it into ./bin alongside other binaries
+# - Places it into ./bin alongside other binaries (override with --bin-dir)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BIN_DIR="$SCRIPT_DIR/bin"
 TMP_ZIP="$(mktemp /tmp/lqos_api.XXXXXX.zip)"
+
+BIN_DIR="${LQOS_API_BIN_DIR:-$SCRIPT_DIR/bin}"
+RESTART_SERVICE="${LQOS_API_RESTART_SERVICE:-1}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--bin-dir DIR] [--no-restart]
+
+Options:
+  --bin-dir DIR   Destination directory for lqos_api (default: $SCRIPT_DIR/bin)
+  --no-restart    Do not restart the lqos_api systemd service
+
+Environment:
+  LQOS_API_BIN_DIR            Same as --bin-dir
+  LQOS_API_RESTART_SERVICE    1 to restart service (default), 0 to skip
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bin-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --bin-dir requires a directory argument"
+        usage
+        exit 2
+      fi
+      BIN_DIR="$2"
+      shift 2
+      ;;
+    --no-restart)
+      RESTART_SERVICE=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+done
 
 echo "Downloading lqos_api..."
 if ! curl -fsSL -o "$TMP_ZIP" "https://download.libreqos.com/api2.zip"; then
@@ -32,22 +75,26 @@ unzip -p "$TMP_ZIP" lqos_api > "$BIN_DIR/lqos_api.new"
 chmod +x "$BIN_DIR/lqos_api.new"
 mv "$BIN_DIR/lqos_api.new" "$BIN_DIR/lqos_api"
 
-# Function copied from build_rust.sh
-service_exists() {
-    local n=$1
-    if [[ $(systemctl list-units --all -t service --full --no-legend "$n.service" | sed 's/^\s*//g' | cut -f1 -d' ') == $n.service ]]; then
-        return 0
-    else
-        return 1
-    fi
-}
+if [[ "$RESTART_SERVICE" == "1" ]]; then
+  # Function copied from build_rust.sh
+  service_exists() {
+      local n=$1
+      if [[ $(systemctl list-units --all -t service --full --no-legend "$n.service" | sed 's/^\s*//g' | cut -f1 -d' ') == $n.service ]]; then
+          return 0
+      else
+          return 1
+      fi
+  }
 
-echo "Restart lqos_api service (if present)"
-if service_exists lqos_api; then
-    echo "lqos_api is running as a service. Restarting it. You may need to enter your sudo password."
-    sudo systemctl restart lqos_api
+  echo "Restart lqos_api service (if present)"
+  if service_exists lqos_api; then
+      echo "lqos_api is running as a service. Restarting it. You may need to enter your sudo password."
+      sudo systemctl restart lqos_api
+  else
+      echo "lqos_api service not found; skipping restart."
+  fi
 else
-    echo "lqos_api service not found; skipping restart."
+  echo "Skipping lqos_api service restart."
 fi
 
 rm -f "$TMP_ZIP"


### PR DESCRIPTION
Common build path for the API in both build_rust.sh and build_dpkg.sh.