### PR TITLE
Splynx: Enable Network Sites Topology + Fix Parent Mapping and Tariff Unit Conversion

### DIFF
--- a/src/integrationCommon.py
+++ b/src/integrationCommon.py
@@ -309,18 +309,17 @@ class NetworkGraph:
 						type=NodeType.site
 					)
 					siteNode.parentIndex = node.parentIndex
-				node.parentId = siteNode.id
-				if node.type == NodeType.clientWithChildren:
+					node.parentId = siteNode.id
 					node.type = NodeType.client
-				
-				# Store reparenting operations for batch processing
-				children = self._children_cache.get(i, [])
-				for child_idx in children:
-					child = self.nodes[child_idx]
-					if child.type in (NodeType.client, NodeType.clientWithChildren, NodeType.site):
-						reparent_map[child_idx] = siteNode.id
-				
-				toAdd.append(siteNode)
+					
+					# Store reparenting operations for batch processing
+					children = self._children_cache.get(i, [])
+					for child_idx in children:
+						child = self.nodes[child_idx]
+						if child.type in (NodeType.client, NodeType.clientWithChildren, NodeType.site):
+							reparent_map[child_idx] = siteNode.id
+					
+					toAdd.append(siteNode)
 		
 		# Batch add new nodes
 		for n in toAdd:
@@ -542,8 +541,8 @@ class NetworkGraph:
 						device["ipv6"],
 						int(1),
 						int(1),
-						int(float(circuit["download"]) * client_bandwidth_multiplier()),
-						int(float(circuit["upload"]) * client_bandwidth_multiplier()),
+						max(1.0, round(float(circuit["download"]), 2)),
+						max(1.0, round(float(circuit["upload"]), 2)),
 						""
 					]
 					wr.writerow(row)


### PR DESCRIPTION
  Summary

  - Fix Splynx integration to support Network Sites by default for ap_site/full.
  - Resolve incorrect parent mapping and ensure clients attach to APs correctly.
  - Fix CSV validation errors and align max speed reporting with Splynx tariff
    units.

  Key Changes

  1. Network Sites support (Splynx)
      - Fetch and use admin/networking/network-sites.
      - Build Site → AP → Client hierarchy using network_site_id and
        access_device.
      - Auto‑fallback to legacy topology if Network Sites are unavailable.
      - AP IDs are prefixed (ap_<id>) in Network Sites mode to prevent ID
        collisions.
  2. AP detection improvements
      - Treat any monitoring device referenced by services (access_device) as an
        AP, even if the device’s access_device flag isn’t set.
  3. Fix parent corruption bug
      - Corrected indentation in
        integrationCommon.py::__clientsWithChildrenToSites that was overwriting
        parentId for unrelated nodes.
  4. ShapedDevices.csv validation fix
      - Max rates are no longer truncated.
      - Min rate stays at 1 Mbps (unchanged).
      - Max rates now written as rounded floats (base speed) to avoid 0 and
        validation failures.
  5. Correct Splynx tariff unit conversion
      - Splynx tariffs now use /1000 (decimal Kbps) instead of /1024, fixing 100
        Mbps showing as 97.66.

  Behavioral Notes

  - Network Sites mode is now the default for ap_site and full (automatic
    fallback to legacy).
  - ap_only remains unchanged (no site layer).
  - Max bandwidth values now reflect true tariff speeds without truncation.

  Files Touched

  - integrationSplynx.py
  - integrationCommon.py