### PR TITLE
Fix UISP overwrite guard skipping ShapedDevices.csv (FIXES #899)

### DIFF
--- a/src/rust/uisp_integration/src/strategies/ap_only.rs
+++ b/src/rust/uisp_integration/src/strategies/ap_only.rs
@@ -22,44 +22,46 @@ pub async fn build_ap_only_network(
 
     // Write network.json
     let network_path = Path::new(&config.lqos_directory).join("network.json");
-    if network_path.exists() && !config.integration_common.always_overwrite_network_json {
+    let skip_network_write =
+        network_path.exists() && !config.integration_common.always_overwrite_network_json;
+    if skip_network_write {
         warn!(
             "Network.json exists, and always overwrite network json is not true - not writing network.json"
         );
-        return Ok(());
-    }
-    let mut root = serde_json::Map::new();
-    for ap in mappings.keys() {
-        if let Some(ap_device) = uisp_data.devices.iter().find(|d| d.name == *ap) {
-            let mut ap_object = serde_json::Map::new();
-            // Empy children
-            ap_object.insert("children".to_string(), serde_json::Map::new().into());
+    } else {
+        let mut root = serde_json::Map::new();
+        for ap in mappings.keys() {
+            if let Some(ap_device) = uisp_data.devices.iter().find(|d| d.name == *ap) {
+                let mut ap_object = serde_json::Map::new();
+                // Empy children
+                ap_object.insert("children".to_string(), serde_json::Map::new().into());
 
-            // Limits
-            ap_object.insert(
-                "downloadBandwidthMbps".to_string(),
-                serde_json::Value::Number(ap_device.download.into()),
-            );
-            ap_object.insert(
-                "uploadBandwidthMbps".to_string(),
-                serde_json::Value::Number(ap_device.upload.into()),
-            );
+                // Limits
+                ap_object.insert(
+                    "downloadBandwidthMbps".to_string(),
+                    serde_json::Value::Number(ap_device.download.into()),
+                );
+                ap_object.insert(
+                    "uploadBandwidthMbps".to_string(),
+                    serde_json::Value::Number(ap_device.upload.into()),
+                );
 
-            // Metadata
-            ap_object.insert("type".to_string(), "AP".to_string().into());
-            ap_object.insert("uisp_device".to_string(), ap_device.id.clone().into());
+                // Metadata
+                ap_object.insert("type".to_string(), "AP".to_string().into());
+                ap_object.insert("uisp_device".to_string(), ap_device.id.clone().into());
 
-            // Save the entry
-            root.insert(ap.to_string(), ap_object.into());
+                // Save the entry
+                root.insert(ap.to_string(), ap_object.into());
+            }
         }
+        let json = serde_json::to_string_pretty(&root).unwrap();
+        write(network_path, json).map_err(|e| {
+            error!("Unable to write network.json");
+            error!("{e:?}");
+            UispIntegrationError::WriteNetJson
+        })?;
+        info!("Written network.json");
     }
-    let json = serde_json::to_string_pretty(&root).unwrap();
-    write(network_path, json).map_err(|e| {
-        error!("Unable to write network.json");
-        error!("{e:?}");
-        UispIntegrationError::WriteNetJson
-    })?;
-    info!("Written network.json");
 
     // Write ShapedDevices.csv
     let file_path = Path::new(&config.lqos_directory).join("ShapedDevices.csv");

--- a/src/rust/uisp_integration/src/strategies/ap_site.rs
+++ b/src/rust/uisp_integration/src/strategies/ap_site.rs
@@ -59,15 +59,15 @@ pub async fn build_ap_site_network(
         warn!(
             "Network.json exists, and always overwrite network json is not true - not writing network.json"
         );
-        return Ok(());
+    } else {
+        let json = serde_json::to_string_pretty(&net_json).unwrap();
+        write(network_path, json).map_err(|e| {
+            error!("Unable to write network.json");
+            error!("{e:?}");
+            UispIntegrationError::WriteNetJson
+        })?;
+        info!("Written network.json");
     }
-    let json = serde_json::to_string_pretty(&net_json).unwrap();
-    write(network_path, json).map_err(|e| {
-        error!("Unable to write network.json");
-        error!("{e:?}");
-        UispIntegrationError::WriteNetJson
-    })?;
-    info!("Written network.json");
 
     let _ = write_shaped_devices(&config, &mut shaped_devices);
     info!("Wrote {} lines to ShapedDevices.csv", shaped_devices.len());

--- a/src/rust/uisp_integration/src/strategies/full2.rs
+++ b/src/rust/uisp_integration/src/strategies/full2.rs
@@ -356,15 +356,15 @@ pub async fn build_full_network_v2(
         warn!(
             "Network.json exists, and always overwrite network json is not true - not writing network.json"
         );
-        return Ok(());
+    } else {
+        let json = serde_json::to_string_pretty(&network_json).unwrap();
+        write(network_path, json).map_err(|e| {
+            error!("Unable to write network.json");
+            error!("{e:?}");
+            UispIntegrationError::WriteNetJson
+        })?;
+        info!("Written network.json");
     }
-    let json = serde_json::to_string_pretty(&network_json).unwrap();
-    write(network_path, json).map_err(|e| {
-        error!("Unable to write network.json");
-        error!("{e:?}");
-        UispIntegrationError::WriteNetJson
-    })?;
-    info!("Written network.json");
 
     // Shaped Devices
     let mut shaped_devices = Vec::new();


### PR DESCRIPTION
FIXES #899

There was an early return messing up the logic with `always_overwrite_network_json` that prevented it from creating devices. This PR fixes it.