### PR TITLE
Fix optional Splynx config handling in editor and deserialization

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/config/config_helper.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config/config_helper.js
@@ -25,12 +25,33 @@ function sendWsRequest(responseEvent, request, onComplete, onError) {
     wsClient.send(request);
 }
 
+function ensureOptionalConfigSections(config) {
+    if (!config || typeof config !== "object") {
+        return config;
+    }
+
+    if (!config.splynx_integration || typeof config.splynx_integration !== "object") {
+        config.splynx_integration = {};
+    }
+
+    const splynx = config.splynx_integration;
+    if (typeof splynx.enable_splynx !== "boolean") splynx.enable_splynx = false;
+    if (typeof splynx.api_key !== "string") splynx.api_key = "";
+    if (typeof splynx.api_secret !== "string") splynx.api_secret = "";
+    if (typeof splynx.url !== "string") splynx.url = "";
+    if (typeof splynx.strategy !== "string" || splynx.strategy.length === 0) {
+        splynx.strategy = "ap_only";
+    }
+
+    return config;
+}
+
 export function loadConfig(onComplete, onError) {
     sendWsRequest(
         "GetConfig",
         { GetConfig: {} },
         (msg) => {
-            window.config = msg.data;
+            window.config = ensureOptionalConfigSections(msg.data);
             if (onComplete) onComplete(msg);
         },
         onError,

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_splynx.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_splynx.js
@@ -45,35 +45,27 @@ function updateConfig() {
 renderConfigMenu('splynx');
 
 loadConfig(() => {
+    if (!window.config) {
+        console.error("Configuration not loaded");
+        return;
+    }
+
     // window.config now contains the configuration.
     // Populate form fields with config values
-    if (window.config && window.config.splynx_integration) {
-        const splynx = window.config.splynx_integration;
-        
-        // Boolean field
-        document.getElementById("enableSplynx").checked = 
-            splynx.enable_splynx ?? false;
+    const splynx = window.config.splynx_integration;
+    document.getElementById("enableSplynx").checked = splynx.enable_splynx ?? false;
+    document.getElementById("apiKey").value = splynx.api_key ?? "";
+    document.getElementById("apiSecret").value = splynx.api_secret ?? "";
+    document.getElementById("splynxUrl").value = splynx.url ?? "";
+    document.getElementById("topologyStrategy").value = splynx.strategy ?? "ap_only";
 
-        // String fields
-        document.getElementById("apiKey").value =
-            splynx.api_key ?? "";
-        document.getElementById("apiSecret").value =
-            splynx.api_secret ?? "";
-        document.getElementById("splynxUrl").value = 
-            splynx.url ?? "";
-        document.getElementById("topologyStrategy").value = 
-            splynx.strategy ?? "ap_only";
-
-        // Add save button click handler
-        document.getElementById('saveButton').addEventListener('click', () => {
-            if (validateConfig()) {
-                updateConfig();
-                saveConfig(() => {
-                    alert("Configuration saved successfully!");
-                });
-            }
-        });
-    } else {
-        console.error("Splynx integration configuration not found in window.config");
-    }
+    // Add save button click handler
+    document.getElementById('saveButton').addEventListener('click', () => {
+        if (validateConfig()) {
+            updateConfig();
+            saveConfig(() => {
+                alert("Configuration saved successfully!");
+            });
+        }
+    });
 });

--- a/src/rust/lqosd/src/node_manager/js_build/src/configuration.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/configuration.js
@@ -171,6 +171,27 @@ function getConfigPath(path) {
     return { found: true, value: current };
 }
 
+function ensureSplynxSection(config) {
+    if (!config || typeof config !== "object") {
+        return config;
+    }
+
+    if (!config.splynx_integration || typeof config.splynx_integration !== "object") {
+        config.splynx_integration = {};
+    }
+
+    const splynx = config.splynx_integration;
+    if (typeof splynx.enable_splynx !== "boolean") splynx.enable_splynx = false;
+    if (typeof splynx.api_key !== "string") splynx.api_key = "";
+    if (typeof splynx.api_secret !== "string") splynx.api_secret = "";
+    if (typeof splynx.url !== "string") splynx.url = "";
+    if (typeof splynx.strategy !== "string" || splynx.strategy.length === 0) {
+        splynx.strategy = "ap_only";
+    }
+
+    return config;
+}
+
 function doBindings() {
     let active = true;
 
@@ -1304,7 +1325,7 @@ function start() {
                 "GetConfig",
                 { GetConfig: {} },
                 (cfgMsg) => {
-                    lqosd_config = cfgMsg.data;
+                    lqosd_config = ensureSplynxSection(cfgMsg.data);
                     console.log("Bindings Done");
                     sendWsRequest(
                         "ListNics",


### PR DESCRIPTION
Allow not having a Splynx config (so as to not break existing configs)