### PR TITLE
Fix Insight license cap handling for max_circuits=None and make grant refresh independent of stats submission state

### DIFF
--- a/src/rust/lqosd/src/lts2_sys/control_channel.rs
+++ b/src/rust/lqosd/src/lts2_sys/control_channel.rs
@@ -205,6 +205,8 @@ async fn persistent_connection(
                     }
                 }
             };
+            // Request the current grant as soon as the connection is established.
+            queue_license_grant_request(&socket_sender_tx);
 
             // Message pump
             'message_pump: loop {
@@ -623,9 +625,7 @@ async fn persistent_connection(
                                 }
                             }
                         }
-                        if permitted {
-                            queue_license_grant_request(&socket_sender_tx);
-                        }
+                        queue_license_grant_request(&socket_sender_tx);
                     }
                 }
             } // End of message pump


### PR DESCRIPTION
Summary

- Fixes a bug where licensed deployments were still capped at 1000 mapped circuits when the grant had max_circuits=None.
- Ensures license/grant refresh is driven by license_key presence and control-channel connectivity, not by stats
submission eligibility.

What Changed

- rust/lqos_bakery/src/lib.rs
- Changed mapped-circuit limit model from usize to Option<usize>.
- New behavior:
- Unlicensed -> cap = 1000
- Licensed + max_circuits=Some(n) -> cap = n
- Licensed + max_circuits=None -> uncapped
- Updated cap enforcement paths (full reload, structural rebuild, incremental additions) to support uncapped mode.
- Updated limit logging to emit unlimited when uncapped.
- Added unit test: mapped_circuit_limit_none_is_unlimited.
- rust/lqosd/src/lts2_sys/license_grant.rs
- current_license_limits() now falls back to live license status when no valid offline grant is present.
- This allows licensed state to be recognized even when a local grant with explicit limits is missing/expired.
- rust/lqosd/src/lts2_sys/control_channel.rs
- Send LicenseGrantRequest immediately after connection setup.
- Send LicenseGrantRequest on each license heartbeat tick regardless of permitted state.
- Keeps grant retrieval active as long as a valid license_key is configured.

Behavioral Impact

- Licensed nodes are no longer incorrectly capped at 1000 when Insight reports licensed but does not provide
max_circuits.
- License/grant refresh is more robust after restarts/network flaps and less dependent on other telemetry flows.