### PR TITLE
Fix Network Tree fractional Mbps handling (prevent sub-2 Mbps from showing as Unlimited)

### DIFF
--- a/src/rust/lqos_config/src/network_json/network_json_node.rs
+++ b/src/rust/lqos_config/src/network_json/network_json_node.rs
@@ -18,7 +18,7 @@ pub struct NetworkJsonNode {
     pub virtual_node: bool,
 
     /// The maximum throughput allowed per `network.json` for this node
-    pub max_throughput: (u32, u32), // In mbps
+    pub max_throughput: (f64, f64), // In mbps
 
     /// Current throughput (in bytes/second) at this node
     pub current_throughput: DownUpOrder<u64>, // In bytes
@@ -70,14 +70,12 @@ impl NetworkJsonNode {
     /// Make a deep copy of a `NetworkJsonNode`, converting atomics
     /// into concrete values.
     pub fn clone_to_transit(&self) -> NetworkJsonTransport {
-        let download = self.rtt_buffer.percentile(
-            RttBucket::Current,
-            FlowbeeEffectiveDirection::Download,
-            50,
-        );
-        let upload = self
-            .rtt_buffer
-            .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 50);
+        let download =
+            self.rtt_buffer
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50);
+        let upload =
+            self.rtt_buffer
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 50);
 
         let rtts = match (download, upload) {
             (None, None) => Vec::new(),

--- a/src/rust/lqos_config/src/network_json/network_json_transport.rs
+++ b/src/rust/lqos_config/src/network_json/network_json_transport.rs
@@ -12,7 +12,7 @@ pub struct NetworkJsonTransport {
     #[serde(rename = "virtual", default)]
     pub is_virtual: bool,
     /// Max throughput for node (not clamped)
-    pub max_throughput: (u32, u32),
+    pub max_throughput: (f64, f64),
     /// Current node throughput
     pub current_throughput: (u64, u64),
     /// Current node packets

--- a/src/rust/lqosd/src/lts2_sys/control_channel.rs
+++ b/src/rust/lqosd/src/lts2_sys/control_channel.rs
@@ -1165,7 +1165,7 @@ async fn tree_snapshot_streaming(
     #[derive(Serialize, Deserialize)]
     struct LiveNetworkTransport {
         name: String,
-        max_throughput: (u32, u32),
+        max_throughput: (f64, f64),
         current_throughput: (u64, u64),
         current_packets: (u64, u64),
         current_tcp_packets: (u64, u64),

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -1016,8 +1016,8 @@ fn tree_capacity_data() -> Vec<lqos_bus::NodeCapacity> {
             let node = node.clone_to_transit();
             let down = node.current_throughput.0 as f64 * 8.0 / 1_000_000.0;
             let up = node.current_throughput.1 as f64 * 8.0 / 1_000_000.0;
-            let max_down = node.max_throughput.0 as f64;
-            let max_up = node.max_throughput.1 as f64;
+            let max_down = node.max_throughput.0;
+            let max_up = node.max_throughput.1;
             let median_rtt = if node.rtts.is_empty() {
                 0.0
             } else {

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_network.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_network.js
@@ -7,6 +7,7 @@ import {
 
 let network_json = null;
 let shaped_devices = null;
+const MIN_NODE_MBPS = 0.1;
 
 function renderNetworkNode(level, depth) {
     let html = `<div class="card mb-3" style="margin-left: ${depth * 30}px;">`;
@@ -89,13 +90,13 @@ function promoteNode(nodeId) {
 
 function nodeSpeedChange(nodeId, direction) {
     let newVal = prompt(`New ${direction === 'd' ? 'download' : 'upload'} value in Mbps`);
-    newVal = parseInt(newVal);
+    newVal = parseFloat(newVal);
     if (isNaN(newVal)) {
         alert("Please enter a valid number");
         return;
     }
-    if (newVal < 1) {
-        alert("Value must be greater than 1");
+    if (newVal < MIN_NODE_MBPS) {
+        alert(`Value must be at least ${MIN_NODE_MBPS} Mbps`);
         return;
     }
 

--- a/src/rust/lqosd/src/node_manager/js_build/src/configuration.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/configuration.js
@@ -6,6 +6,7 @@ let lqosd_config = null;
 let shaped_devices = null;
 let network_json = null;
 let qoo_profiles = null;
+const MIN_NODE_MBPS = 0.1;
 
 const wsClient = get_ws_client();
 
@@ -535,9 +536,9 @@ function flattenNetwork() {
 
 function addNetworkNode() {
     let newName = $("#njsNewNodeName").val();
-    let newDown = parseInt($("#njsNewNodeDown").val());
-    let newUp = parseInt($("#njsNewNodeUp").val());
-    if (newName.length > 0 && newDown > 1 && newUp > 1) {
+    let newDown = parseFloat($("#njsNewNodeDown").val());
+    let newUp = parseFloat($("#njsNewNodeUp").val());
+    if (newName.length > 0 && !isNaN(newDown) && !isNaN(newUp) && newDown >= MIN_NODE_MBPS && newUp >= MIN_NODE_MBPS) {
         network_json[newName] = {
             downloadBandwidthMbps: newDown,
             uploadBandwidthMbps: newUp,
@@ -574,14 +575,14 @@ function promoteNode(nodeId) {
 }
 
 function nodeSpeedChange(nodeId, direction) {
-    let newVal = prompt("New download value in Mbps");
-    newVal = parseInt(newVal);
+    let newVal = prompt(`New ${direction === 'd' ? 'download' : 'upload'} value in Mbps`);
+    newVal = parseFloat(newVal);
     if (isNaN(newVal)) {
-        alert("That's not an integer!");
+        alert("Please enter a valid number");
         return;
     }
-    if (newVal < 1) {
-        alert("New value must be greater than 1");
+    if (newVal < MIN_NODE_MBPS) {
+        alert(`New value must be at least ${MIN_NODE_MBPS} Mbps`);
         return;
     }
 

--- a/src/rust/lqosd/src/node_manager/ws/ticker/tree_capacity.rs
+++ b/src/rust/lqosd/src/node_manager/ws/ticker/tree_capacity.rs
@@ -21,8 +21,8 @@ pub async fn tree_capacity(channels: Arc<PubSub>) {
                 let node = node.clone_to_transit();
                 let down = node.current_throughput.0 as f64 * 8.0 / 1_000_000.0;
                 let up = node.current_throughput.1 as f64 * 8.0 / 1_000_000.0;
-                let max_down = node.max_throughput.0 as f64;
-                let max_up = node.max_throughput.1 as f64;
+                let max_down = node.max_throughput.0;
+                let max_up = node.max_throughput.1;
                 let median_rtt = if node.rtts.is_empty() {
                     0.0
                 } else {

--- a/src/rust/lqosd/src/shaped_devices_tracker/mod.rs
+++ b/src/rust/lqosd/src/shaped_devices_tracker/mod.rs
@@ -212,7 +212,7 @@ pub fn get_top_n_root_queues(n_queues: usize) -> BusResponse {
                 NetworkJsonTransport {
                     name: "Others".into(),
                     is_virtual: false,
-                    max_throughput: (0, 0),
+                    max_throughput: (0.0, 0.0),
                     current_throughput: other_bw,
                     current_packets: other_packets,
                     current_tcp_packets: other_tcp_packets,


### PR DESCRIPTION

## Summary

This PR fixes a Network Tree regression where node bandwidth values below 2 Mbps (especially fractional values like 1.5) could appear as Unlimited.

Root cause: network.json node bandwidth fields were parsed as integers only. Fractional values were coerced to 0, and the UI correctly interprets 0 as Unlimited.

## What changed

1. Enabled fractional node throughput end-to-end in network map parsing/ transport.

- max_throughput changed from (u32, u32) to (f64, f64) in:
  - rust/lqos_config/src/network_json/network_json_node.rs
  - rust/lqos_config/src/network_json/network_json_transport.rs
- Replaced integer-only parser with fractional parser in:
  - rust/lqos_config/src/network_json.rs
  - New parser accepts decimal JSON numbers (and numeric strings), rejects invalid/negative values to 0.0.
- Updated utilization math to use float capacities.

2. Updated dependent tree-capacity/stream transport paths for float throughput.

- rust/lqosd/src/lts2_sys/control_channel.rs
- rust/lqosd/src/main.rs
- rust/lqosd/src/node_manager/ws/ticker/tree_capacity.rs
- rust/lqosd/src/shaped_devices_tracker/mod.rs

3. Updated node-edit UI to accept fractional Mbps.

- Switched node bandwidth edits from parseInt to parseFloat.
- Replaced integer/min-2 style checks with minimum 0.1 Mbps.
- Files:
  - rust/lqosd/src/node_manager/js_build/src/config_network.js
  - rust/lqosd/src/node_manager/js_build/src/configuration.js

4. Added regression test coverage.

- New test in rust/lqos_config/src/network_json.rs verifies:
  - fractional downloadBandwidthMbps/uploadBandwidthMbps parse correctly,
  - values remain non-zero and serialize correctly through transport.