### PR TITLE
Fix #857, #858 - Duplicate NIC entries and harden Web Users setup/auth behavior

### DIFF
--- a/src/rust/lqosd/src/node_manager/auth.rs
+++ b/src/rust/lqosd/src/node_manager/auth.rs
@@ -183,6 +183,27 @@ pub async fn login_from_token(token: &str) -> LoginResult {
     login_result
 }
 
+/// Reload the cached users from disk after user-management changes.
+pub async fn refresh_cached_users() {
+    let mut lock = WEB_USERS.lock().await;
+    match WebUsers::does_users_file_exist() {
+        Ok(true) => match WebUsers::load_or_create() {
+            Ok(users) => {
+                *lock = Some(users);
+            }
+            Err(e) => {
+                warn!("Unable to refresh users cache: {e}");
+            }
+        },
+        Ok(false) => {
+            *lock = None;
+        }
+        Err(e) => {
+            warn!("Unable to check users file while refreshing cache: {e}");
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct LoginAttempt {
     pub username: String,

--- a/src/rust/lqosd/src/node_manager/local_api/config.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/config.rs
@@ -3,9 +3,10 @@ use crate::shaped_devices_tracker::SHAPED_DEVICES;
 use axum::http::StatusCode;
 use default_net::get_interfaces;
 use lqos_bus::{BusRequest, bus_request};
-use lqos_config::{Config, ConfigShapedDevices, ShapedDevice, WebUser, WebUsers};
+use lqos_config::{Config, ConfigShapedDevices, ShapedDevice, UserRole, WebUser, WebUsers};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 pub fn admin_check_data(login: LoginResult) -> bool {
@@ -25,16 +26,33 @@ pub fn list_nics_data(login: LoginResult) -> Result<Vec<(String, String, String)
     if login != LoginResult::Admin {
         return Err(StatusCode::FORBIDDEN);
     }
-    let result = get_interfaces()
-        .iter()
-        .map(|eth| {
-            let mac = if let Some(mac) = &eth.mac_addr {
-                mac.to_string()
-            } else {
-                String::new()
-            };
-            (eth.name.clone(), format!("{:?}", eth.if_type), mac)
-        })
+
+    // Some systems can report the same interface more than once. The UI keys
+    // off interface name, so dedupe by name here before returning results.
+    let mut deduped: BTreeMap<String, (String, String)> = BTreeMap::new();
+    for eth in get_interfaces() {
+        let mac = eth
+            .mac_addr
+            .map(|m| m.to_string())
+            .unwrap_or_else(String::new);
+        let if_type = format!("{:?}", eth.if_type);
+
+        deduped
+            .entry(eth.name)
+            .and_modify(|(existing_type, existing_mac)| {
+                if existing_mac.is_empty() && !mac.is_empty() {
+                    *existing_mac = mac.clone();
+                }
+                if existing_type == "Unknown" && if_type != "Unknown" {
+                    *existing_type = if_type.clone();
+                }
+            })
+            .or_insert((if_type, mac));
+    }
+
+    let result = deduped
+        .into_iter()
+        .map(|(name, (if_type, mac))| (name, if_type, mac))
         .collect();
     Ok(result)
 }
@@ -141,6 +159,22 @@ pub fn update_user_data(login: LoginResult, data: UserRequest) -> Result<String,
         return Err(StatusCode::FORBIDDEN);
     }
     let mut users = WebUsers::load_or_create().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let all_users = users.get_users();
+
+    // Prevent turning the last administrator into a non-admin account.
+    if let Some(existing_user) = all_users.iter().find(|u| u.username == data.username) {
+        if existing_user.role == UserRole::Admin {
+            let admin_count = all_users
+                .iter()
+                .filter(|u| u.role == UserRole::Admin)
+                .count();
+            let requested_role: UserRole = data.role.clone().into();
+            if admin_count <= 1 && requested_role != UserRole::Admin {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+        }
+    }
+
     let password = data.password.as_deref().filter(|p| !p.is_empty());
     users
         .update_user_with_optional_password(&data.username, password, data.role.into())
@@ -153,6 +187,21 @@ pub fn delete_user_data(login: LoginResult, username: String) -> Result<String, 
         return Err(StatusCode::FORBIDDEN);
     }
     let mut users = WebUsers::load_or_create().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let all_users = users.get_users();
+
+    // Prevent deleting the final administrator account.
+    if let Some(existing_user) = all_users.iter().find(|u| u.username == username) {
+        if existing_user.role == UserRole::Admin {
+            let admin_count = all_users
+                .iter()
+                .filter(|u| u.role == UserRole::Admin)
+                .count();
+            if admin_count <= 1 {
+                return Err(StatusCode::BAD_REQUEST);
+            }
+        }
+    }
+
     users
         .remove_user(&username)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

--- a/src/rust/lqosd/src/node_manager/ws.rs
+++ b/src/rust/lqosd/src/node_manager/ws.rs
@@ -1132,6 +1132,9 @@ async fn receive_channel_message(
                 Err(StatusCode::BAD_REQUEST) => (false, "Invalid user data".to_string()),
                 Err(_) => (false, "Error".to_string()),
             };
+            if ok {
+                crate::node_manager::auth::refresh_cached_users().await;
+            }
             let response = WsResponse::AddUserResult { ok, message };
             if send_ws_response(&tx, response).await {
                 return true;
@@ -1156,6 +1159,9 @@ async fn receive_channel_message(
                 Err(StatusCode::BAD_REQUEST) => (false, "Invalid user data".to_string()),
                 Err(_) => (false, "Error".to_string()),
             };
+            if ok {
+                crate::node_manager::auth::refresh_cached_users().await;
+            }
             let response = WsResponse::UpdateUserResult { ok, message };
             if send_ws_response(&tx, response).await {
                 return true;
@@ -1169,6 +1175,9 @@ async fn receive_channel_message(
                 Err(StatusCode::BAD_REQUEST) => (false, "Invalid user data".to_string()),
                 Err(_) => (false, "Error".to_string()),
             };
+            if ok {
+                crate::node_manager::auth::refresh_cached_users().await;
+            }
             let response = WsResponse::DeleteUserResult { ok, message };
             if send_ws_response(&tx, response).await {
                 return true;


### PR DESCRIPTION
This PR fixes two config-tool issues:

1. NICs were shown twice in interface selectors.
2. Visiting/managing Web Users could destabilize setup/auth state.

Root Cause

- NIC duplication: backend ListNics returned raw default_net::get_interfaces() output, which can include duplicate interface names on some systems; UI rendered that list as- is.
- Web Users/setup breakage:   - User CRUD mutated lqusers.toml but did not refresh in-memory auth cache     (WEB_USERS), causing runtime auth state drift.   - Backend allowed deleting/demoting the final admin account, which could leave the     system without a valid admin path.

What Changed

- Deduplicated NICs server-side by interface name in config.rs:25 (/opt/libreqos/src/ rust/lqosd/src/node_manager/local_api/config.rs:25)   - Uses BTreeMap<name, (type, mac)>   - Prefers non-empty MAC and non-Unknown interface type when duplicates differ
- Added guardrails in config.rs:157 (/opt/libreqos/src/rust/lqosd/src/node_manager/ local_api/config.rs:157)   - Block demoting the last admin (BAD_REQUEST)   - Block deleting the last admin (BAD_REQUEST)
- Added auth cache refresh helper in auth.rs:186 (/opt/libreqos/src/rust/lqosd/src/ node_manager/auth.rs:186)
- Refreshes auth cache after successful Add/Update/Delete user websocket operations in ws.rs:1135 (/opt/libreqos/src/rust/lqosd/src/node_manager/ws.rs:1135), ws.rs:1162 (/ opt/libreqos/src/rust/lqosd/src/node_manager/ws.rs:1162), ws.rs:1178 (/opt/libreqos/ src/rust/lqosd/src/node_manager/ws.rs:1178)

Behavioral Impact

- Config NIC dropdowns now show each interface once.
- Web user changes take effect immediately in runtime auth state.
- System cannot enter a no-admin state via Web Users actions.