### PR TITLE
Docs: reduce support burden with clearer integration choices, validation checklists, and EN/ES troubleshooting parity

### DIFF
--- a/docs-es/v2.0/configuration-advanced-es.md
+++ b/docs-es/v2.0/configuration-advanced-es.md
@@ -2,6 +2,16 @@
 
 Use esta página cuando necesite configuración por CLI, edición directa de archivos o contenido de referencia detallado.
 
+## Guardrails de patrones topológicos
+
+Antes de ajustes profundos:
+
+- Single-interface (on-a-stick): compatible, pero valide conteo de colas y mapeo por dirección tras cambios de interfaz/colas.
+- Diseños con VLAN: compatibles si roles de interfaz y mapeo de nodos padre están bien definidos.
+- En modo integración: no mantenga cambios permanentes en archivos que la integración regenera.
+
+Si el resultado no coincide con lo esperado, use [Solución de problemas](troubleshooting-es.md) antes de seguir cambiando parámetros.
+
 ## Configuración por línea de comando
 
 También puedes modificar ajustes usando la CLI.
@@ -46,6 +56,13 @@ do_not_track_subnets = ["192.168.0.0/16"]
 ### Integraciones con CRM/NMS
 
 Más información sobre [configuración de integraciones aquí.](integrations-es.md).
+
+### Límite de fuente de verdad para usuarios de integración
+
+Si el modo integración está habilitado, los ciclos de refresco suelen ser dueños de `ShapedDevices.csv` y, según configuración, también de `network.json`.
+
+- Use edición manual/WebUI para ajustes operativos temporales.
+- Mantenga cambios permanentes en el sistema de integración, overrides de integración o flujo externo declarado.
 
 ## Jerarquía de Red
 ### Network.json

--- a/docs-es/v2.0/integrations-splynx-es.md
+++ b/docs-es/v2.0/integrations-splynx-es.md
@@ -10,11 +10,38 @@ Use esta integración cuando Splynx sea su fuente de verdad CRM/NMS.
 2. Seleccione estrategia de topología (`flat`, `ap_only`, `ap_site`, `full`).
 3. Habilite sincronización automática y reinicie scheduler.
 
+## Inicio rápido para nuevos operadores
+
+Base recomendada:
+
+- `strategy = "ap_only"` (menos confusión inicial)
+- `enable_splynx = true`
+- `always_overwrite_network_json = false` salvo que quiera sobrescritura en cada ejecución
+
+Después, ejecute una sincronización manual y valide salidas antes de aumentar frecuencia de refresh.
+
 ## Notas operativas
 
 - `ShapedDevices.csv` se regenera en cada sincronización.
 - `network.json` depende de `always_overwrite_network_json`.
 - Use WebUI para ajustes operativos diarios.
+
+## Validación en 5 minutos después de cambios Splynx
+
+1. Ejecute prueba de integración:
+```bash
+python3 integrationSplynx.py
+```
+2. Confirme archivos actualizados:
+```bash
+ls -lh /opt/libreqos/src/network.json /opt/libreqos/src/ShapedDevices.csv
+```
+3. Confirme salud de servicios:
+```bash
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqos_scheduler --since "30 minutes ago"
+```
+4. Verifique en WebUI que Scheduler Status y profundidad de árbol coincidan con la estrategia elegida.
 
 ## Referencia completa
 

--- a/docs-es/v2.0/integrations-uisp-es.md
+++ b/docs-es/v2.0/integrations-uisp-es.md
@@ -10,11 +10,46 @@ Use esta integración cuando UISP sea su fuente de verdad CRM/NMS.
 2. Elija estrategia de topología y estrategia de suspensión.
 3. Habilite sincronización automática y reinicie scheduler.
 
+## Selector rápido para nuevos operadores
+
+Use esta guía para evitar confusión con opciones:
+
+1. Si está empezando, use `strategy = "ap_only"`.
+2. Cambie a `ap_site` cuando necesite agregación explícita por sitio.
+3. Use `full` cuando necesite jerarquía/backhaul completo y tenga margen de CPU.
+4. Use `flat` solo si la jerarquía no es necesaria y prioriza rendimiento máximo.
+
+## Expectativas en router mode
+
+- Router mode en UISP es compatible, pero depende de que la topología en UISP esté bien definida.
+- LibreQoS se centra en shaping/jerarquía de colas, no en enforcement completo del ciclo de vida del suscriptor.
+- La suspensión de cuentas normalmente se aplica en edge/BNG/autenticación; `suspended_strategy` define solo el comportamiento de shaping en LibreQoS.
+
 ## Notas operativas
 
 - `ShapedDevices.csv` se regenera en cada sincronización.
 - `network.json` depende de `always_overwrite_network_json`.
 - En modo integración, trate ediciones de archivos como temporales.
+
+## Validación en 5 minutos después de cambios UISP
+
+1. Ejecute integración una vez:
+```bash
+cd /opt/libreqos/src
+sudo /opt/libreqos/src/bin/uisp_integration
+```
+2. Confirme archivos generados/actualizados:
+```bash
+ls -lh /opt/libreqos/src/network.json /opt/libreqos/src/ShapedDevices.csv
+```
+3. Verifique salud de servicios:
+```bash
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqos_scheduler --since "30 minutes ago"
+```
+4. Valide en WebUI:
+- Scheduler Status saludable
+- Profundidad de árbol acorde a la estrategia elegida
 
 ## Referencia completa
 

--- a/docs-es/v2.0/operating-modes-es.md
+++ b/docs-es/v2.0/operating-modes-es.md
@@ -32,6 +32,17 @@ Comportamiento clave:
 4. Documente su flujo de cambios rápidos (WebUI, editor externo, o ambos).
 5. No mantenga ediciones en competencia en varios sistemas para los mismos objetos.
 
+## Expectativas de topología y modo
+
+- Diseños single-interface (on-a-stick) y con VLAN son válidos, pero requieren validación explícita de colas/interfaces después de cambios.
+- Modo integración es ideal cuando CRM/NMS debe controlar topología y datos de suscriptores.
+- Si necesita topología estrictamente personalizada no representada por integración, use modo fuente personalizada y mantenga propiedad clara.
+
+Vea también:
+- [Referencia avanzada de configuración](configuration-advanced-es.md)
+- [Integraciones CRM/NMS](integrations-es.md)
+- [Solución de problemas](troubleshooting-es.md)
+
 ## Páginas relacionadas
 
 - [Configurar LibreQoS](configuration-es.md)

--- a/docs-es/v2.0/performance-tuning-es.md
+++ b/docs-es/v2.0/performance-tuning-es.md
@@ -1,5 +1,13 @@
 # Ajuste de rendimiento
 
+## Triage por síntoma
+
+| Síntoma | Primeros checks | Siguiente acción probable |
+|---|---|---|
+| Throughput menor al esperado | distribución de colas/CPU, profundidad de estrategia, salud del scheduler | reducir profundidad o usar `promote_to_root` y volver a medir |
+| CPU alta en un solo núcleo | desbalance IRQ/colas, cuello en nodo raíz | rebalancear afinidad y/o promover sitios pesados a raíz |
+| Cambio de rendimiento tras cambios de integración | cambio no intencional de estrategia/profundidad | confirmar estrategia (`flat`/`ap_only`/`ap_site`/`full`) y validar árbol/flujo |
+
 ## Base de CPU e IRQ
 
 Configure el governor de CPU en modo rendimiento para bare metal/hipervisor:

--- a/docs-es/v2.0/quickstart-es.md
+++ b/docs-es/v2.0/quickstart-es.md
@@ -26,6 +26,25 @@ sudo apt install ./{deb_url_v1_5}
 
 5. Abra WebUI en `http://your_shaper_ip:9123`.
 
+## Después de instalar: estado esperado (10 minutos)
+
+Antes de cambios profundos, valide base operativa:
+
+1. Servicios activos:
+```bash
+sudo systemctl status lqosd lqos_scheduler
+```
+2. WebUI carga y actualiza (Dashboard + Scheduler Status).
+3. Sin errores críticos recientes:
+```bash
+journalctl -u lqosd -u lqos_scheduler --since "10 minutes ago"
+```
+4. Fuente de verdad definida:
+- modo integración: la integración controla refresco de archivos
+- modo custom/manual: sus archivos/scripts controlan persistencia
+
+Si falla algo, pase a [Solución de problemas](troubleshooting-es.md) antes del piloto.
+
 ## Testbed / Lab
 
 ### Cuándo elegir
@@ -71,6 +90,12 @@ Nota:
 - [Integraciones CRM/NMS](integrations-es.md)
 - [Escalado y diseño de topología](scale-topology-es.md)
 - [Solución de problemas](troubleshooting-es.md)
+
+## Errores comunes en primera puesta en marcha
+
+- Fuente de verdad no definida entre integración y edición manual.
+- Elegir estrategia topológica profunda sin validar salud base.
+- Omitir checks de servicios/logs antes de tráfico piloto.
 
 ## Integración con Script Personalizado
 

--- a/docs-es/v2.0/troubleshooting-es.md
+++ b/docs-es/v2.0/troubleshooting-es.md
@@ -23,6 +23,25 @@ Use esta tabla para ir al primer check rápidamente.
 - Visualización de topología/tráfico: `WebUI -> Network Tree Overview` y `Flow Map`
 - Revisión de datos de shaping: `WebUI -> Shaped Devices Editor`
 
+### Antes de pedir ayuda en chat: recolecte esta evidencia
+
+```bash
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqosd --since "30 minutes ago"
+journalctl -u lqos_scheduler --since "30 minutes ago"
+```
+
+Si el problema es de integración, agregue:
+
+```bash
+ls -lh /opt/libreqos/src/network.json /opt/libreqos/src/ShapedDevices.csv
+```
+
+Incluya también:
+- versión/build actual
+- tipo de integración y estrategia
+- síntoma exacto y hora de inicio
+
 ### La contraseña de usuario no funciona
 
 Elimine el archivo de usuarios:
@@ -36,7 +55,7 @@ Luego abra: `IP_CAJA:9123/index.html`.
 
 ### No hay WebUI en x.x.x.x:9123
 
-La WebUI depende de `lqosd`. Cuando no carga, normalmente `lqosd` está fallando.
+La WebUI depende de `lqosd`. En builds actuales, la mayoría de fallas de acceso WebUI se explican por `lqosd` no saludable.
 
 ```bash
 sudo systemctl status lqosd

--- a/docs-es/v2.0/update-es.md
+++ b/docs-es/v2.0/update-es.md
@@ -23,6 +23,22 @@ sudo reboot
 
 Esto limpiará los mapas eBPF antiguos y cargará la última versión de LibreQoS.
 
+### Validación obligatoria post-actualización
+
+Después de actualizar/reiniciar, ejecute:
+
+```bash
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqosd -u lqos_scheduler --since "20 minutes ago"
+```
+
+Luego valide:
+1. Dashboard y Scheduler Status saludables en WebUI.
+2. En modo integración: sincronización reciente con resultados esperados en `ShapedDevices.csv`/`network.json`.
+3. Profundidad topológica consistente con la estrategia seleccionada.
+
+Si algo falla, vaya a [Solución de problemas](troubleshooting-es.md) antes de otros cambios.
+
 ## Si instalaste desde Git
 
 1. Cambia a tu directorio `LibreQoS` (por ejemplo `cd /opt/LibreQoS`)
@@ -36,3 +52,11 @@ Ejecuta los siguientes comandos para recargar los servicios de LibreQoS:
 ```shell
 sudo systemctl restart lqosd lqos_scheduler
 ```
+
+## Síntomas para pausar y hacer triage
+
+Detenga el rollout y haga triage si aparece:
+
+- `lqosd` o `lqos_scheduler` no saludable tras reinicio
+- cambio inesperado de jerarquía tras sync de integración
+- scheduler persistentemente no saludable en WebUI

--- a/docs/v2.0/configuration-advanced.md
+++ b/docs/v2.0/configuration-advanced.md
@@ -2,6 +2,16 @@
 
 Use this page when you need CLI-driven configuration, direct file editing, or deep reference details.
 
+## Topology Pattern Guardrails
+
+Use these guardrails before deeper tuning:
+
+- Single-interface (on-a-stick): supported, but queue count and directional mapping must be validated after any interface/queue change.
+- VLAN-heavy designs: supported when interface roles and topology parent mapping are clear; avoid mixing ambiguous parent definitions across multiple systems.
+- Integration users: do not manually maintain long-term conflicting edits in files that integration refresh cycles regenerate.
+
+If results diverge from expectations after edits, use [Troubleshooting](troubleshooting.md) before additional changes.
+
 ## Configuration via Command Line
 
 You can also modify settings using the command line.
@@ -59,6 +69,13 @@ If shaping appears asymmetric in on-a-stick deployments, verify:
 - you have restarted after config changes
 
 See also [Troubleshooting](troubleshooting.md).
+
+#### Source-of-truth boundary for integration users
+
+If integration mode is enabled, integration refresh cycles typically own `ShapedDevices.csv` and may also own `network.json` depending on settings.
+
+- Use WebUI/manual edits for short operational adjustments only.
+- Put permanent changes in your integration system, integration overrides, or declared external source-of-truth workflow.
 
 #### CRM/NMS Integrations
 

--- a/docs/v2.0/integrations-splynx.md
+++ b/docs/v2.0/integrations-splynx.md
@@ -4,6 +4,16 @@
 
 First, set the relevant parameters for Splynx (splynx_api_key, splynx_api_secret, etc.) in `/etc/lqos.conf`.
 
+## New Operator Quick Start
+
+Start with this baseline unless you have a known reason to deviate:
+
+- `strategy = "ap_only"` (default, lowest confusion)
+- `enable_splynx = true`
+- `always_overwrite_network_json = false` unless you explicitly want integration to overwrite each run
+
+Then run one manual sync and validate outputs before enabling frequent scheduler refresh cycles.
+
 ### Topology Strategies
 
 LibreQoS supports multiple topology strategies for Splynx integration to balance CPU performance with network hierarchy needs:
@@ -97,6 +107,25 @@ Then, run `sudo systemctl restart lqosd`.
 
 You have the option to run integrationSplynx.py automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_splynx = true``` under the ```[splynx_integration]``` section in `/etc/lqos.conf`.
 Once set, run `sudo systemctl restart lqos_scheduler`.
+
+## 5-Minute Validation After Splynx Changes
+
+1. Run one integration test:
+```shell
+python3 integrationSplynx.py
+```
+2. Confirm files exist and were updated:
+```shell
+ls -lh /opt/libreqos/src/network.json /opt/libreqos/src/ShapedDevices.csv
+```
+3. Confirm services are healthy:
+```shell
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqos_scheduler --since "30 minutes ago"
+```
+4. Check WebUI Scheduler Status and tree depth for expected strategy behavior.
+
+If sync looks successful but data is incomplete, recheck API permissions and strategy assumptions before changing unrelated settings.
 
 ### Splynx Overrides
 

--- a/docs/v2.0/integrations-uisp.md
+++ b/docs/v2.0/integrations-uisp.md
@@ -2,6 +2,21 @@
 
 First, set the relevant parameters for UISP in `/etc/lqos.conf`.
 
+## New Operator Quick Chooser
+
+Use this section first to avoid common strategy confusion.
+
+1. If you are new to UISP integration, start with `strategy = "ap_only"`.
+2. Move to `ap_site` when you need explicit site-level aggregation.
+3. Use `full` when you need full hierarchy/backhaul representation and have CPU headroom.
+4. Use `flat` only when hierarchy is not needed and maximum performance is the priority.
+
+## Router-Mode Expectations
+
+- UISP router mode is supported, but parent/route discovery quality depends on your UISP topology data quality.
+- LibreQoS focuses on shaping/queue hierarchy, not subscriber lifecycle enforcement.
+- Account suspension enforcement is usually handled by your edge/BNG/auth platform. Use `suspended_strategy` only for LibreQoS-side shaping behavior.
+
 ### Topology Strategies
 
 LibreQoS supports multiple topology strategies for UISP integration to balance CPU performance with network hierarchy needs:
@@ -20,6 +35,28 @@ LibreQoS supports multiple topology strategies for UISP integration to balance C
 - Use `flat` only when maximum performance is critical and you don't need any hierarchy
 
 **Performance Note:** When using `full` strategy with large networks, consider using `promote_to_root` to distribute CPU load across multiple cores.
+
+## 5-Minute Validation After UISP Config Changes
+
+1. Run the integration once:
+```shell
+cd /opt/libreqos/src
+sudo /opt/libreqos/src/bin/uisp_integration
+```
+2. Confirm outputs were generated/refreshed as expected:
+```shell
+ls -lh /opt/libreqos/src/network.json /opt/libreqos/src/ShapedDevices.csv
+```
+3. Confirm scheduler and shaper health:
+```shell
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqos_scheduler --since "30 minutes ago"
+```
+4. Validate result in WebUI:
+- Scheduler Status is healthy
+- Tree/Flow views reflect expected hierarchy depth for selected strategy
+
+If hierarchy depth or parent mapping is not what you expect, revisit `strategy`, `use_ptmp_as_parent`, `exclude_sites`, and `exception_cpes` before changing other settings.
 
 ### Promote to Root Nodes (Performance Optimization)
 

--- a/docs/v2.0/operating-modes.md
+++ b/docs/v2.0/operating-modes.md
@@ -44,6 +44,17 @@ Key behavior:
 4. Document your hotfix workflow (WebUI, external editor, or both).
 5. Do not maintain competing edits in multiple systems for the same objects.
 
+## Topology and Mode Expectations
+
+- Single-interface (on-a-stick) and VLAN-heavy designs are valid, but require explicit queue/interface planning and careful validation after changes.
+- Integration mode is best when you want CRM/NMS-driven topology and subscriber lifecycle data to own shaping inputs.
+- If you need strict custom topology behavior not represented by integration output, use custom source-of-truth mode and keep ownership explicit.
+
+See:
+- [Advanced Configuration Reference](configuration-advanced.md)
+- [CRM/NMS Integrations](integrations.md)
+- [Troubleshooting](troubleshooting.md)
+
 ## Related Pages
 
 - [Configure LibreQoS](configuration.md)

--- a/docs/v2.0/performance-tuning.md
+++ b/docs/v2.0/performance-tuning.md
@@ -1,5 +1,13 @@
 # Performance Tuning
 
+## Symptom-First Triage
+
+| Symptom | First checks | Likely next action |
+|---|---|---|
+| Throughput lower than expected | queue/CPU distribution, integration strategy depth, scheduler health | reduce hierarchy depth or use `promote_to_root`, then retest |
+| High CPU on one core | IRQ/queue imbalance, root-node bottlenecks | rebalance queue/IRQ affinity and/or promote heavy remote sites to root |
+| Performance changed after integration edits | strategy and topology depth changed unintentionally | confirm strategy (`flat`/`ap_only`/`ap_site`/`full`) and validate tree/flow shape |
+
 ## CPU and IRQ Baseline
 
 Set CPU frequency governor to performance on bare metal/hypervisor hosts:

--- a/docs/v2.0/quickstart.md
+++ b/docs/v2.0/quickstart.md
@@ -48,6 +48,25 @@ sudo apt install ./{deb_url_v1_5}
 
 5. Open WebUI at `http://your_shaper_ip:9123`.
 
+## After Install: What Good Looks Like (10-Minute Check)
+
+Before deeper configuration, verify baseline health:
+
+1. Services are active:
+```bash
+sudo systemctl status lqosd lqos_scheduler
+```
+2. WebUI loads and updates (Dashboard + Scheduler Status).
+3. No urgent/fatal errors in recent logs:
+```bash
+journalctl -u lqosd -u lqos_scheduler --since "10 minutes ago"
+```
+4. Your chosen source-of-truth is clear:
+- integration mode: integration owns refresh of shaping inputs
+- custom/manual mode: your files/scripts own persistence
+
+If these checks fail, continue in [Troubleshooting](troubleshooting.md) before pilot rollout.
+
 ## Testbed / Lab
 
 ### When to choose
@@ -140,4 +159,14 @@ Recommended only for networks under 100 subscribers.
 - [Advanced Configuration Reference](configuration-advanced.md)
 - [Operating Modes and Source of Truth](operating-modes.md)
 - [Scale Planning and Topology Design](scale-topology.md)
+- [Troubleshooting](troubleshooting.md)
+
+## Common First-Run Mistakes
+
+- Unclear source-of-truth ownership between integration and manual edits.
+- Choosing deeper topology strategy before confirming baseline health.
+- Skipping post-install service/log checks before pilot traffic.
+
+Use:
+- [Operating Modes and Source of Truth](operating-modes.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/troubleshooting.md
+++ b/docs/v2.0/troubleshooting.md
@@ -23,6 +23,27 @@ Use this table to jump to the first checks quickly.
 - Topology/traffic visualization: `WebUI -> Network Tree Overview` and `Flow Map`
 - Shaped records review: `WebUI -> Shaped Devices Editor`
 
+### Before asking in chat: collect this evidence
+
+Collect these first to reduce back-and-forth:
+
+```bash
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqosd --since "30 minutes ago"
+journalctl -u lqos_scheduler --since "30 minutes ago"
+```
+
+If integration-related, also include:
+
+```bash
+ls -lh /opt/libreqos/src/network.json /opt/libreqos/src/ShapedDevices.csv
+```
+
+And include:
+- current version/build
+- integration type and strategy (if used)
+- exact symptom and when it started
+
 ### User password not working
 
 Delete the lqusers file:
@@ -35,7 +56,7 @@ This will allow you to set up the user again from scratch using the WebUI.
 
 ### No WebUI at x.x.x.x:9123
 
-The WebUI is controlled by the lqosd service. Usually, when the WebUI doesn't start, it is related to lqosd being in a failed state.
+The WebUI is controlled by the lqosd service. In current builds, most WebUI access failures are caused by `lqosd` not being healthy.
 Check to see if the lqosd service is running:
 ```
 sudo systemctl status lqosd

--- a/docs/v2.0/update.md
+++ b/docs/v2.0/update.md
@@ -21,6 +21,22 @@ sudo reboot
 ```
 This will flush the old eBPF maps and load the latest LibreQoS version.
 
+### Post-Upgrade Validation (Required)
+
+Run these checks after upgrade/reboot:
+
+```bash
+sudo systemctl status lqosd lqos_scheduler
+journalctl -u lqosd -u lqos_scheduler --since "20 minutes ago"
+```
+
+Then verify:
+1. WebUI Dashboard and Scheduler Status are healthy.
+2. Integration users: a fresh sync produces expected `ShapedDevices.csv`/`network.json` behavior.
+3. Topology depth matches your chosen integration strategy.
+
+If checks fail, go directly to [Troubleshooting](troubleshooting.md) before further config changes.
+
 ## If you installed with Git
 
 1. Change to your LibreQoS directory (e.g. `cd /opt/libreqos`)
@@ -46,3 +62,15 @@ If you use Git installs, keep this order:
 2. stop/restart services as needed
 3. run `sudo rust/remove_pinned_maps.sh`
 4. restart `lqosd` and `lqos_scheduler`
+
+## Stop-and-Triage Symptoms
+
+Pause rollout and triage immediately if you see:
+
+- `lqosd` or `lqos_scheduler` not healthy after restart
+- unexpected hierarchy collapse/expansion after integration sync
+- persistent scheduler unhealthy state in WebUI
+
+Primary references:
+- [Troubleshooting](troubleshooting.md)
+- [CRM/NMS Integrations](integrations.md)


### PR DESCRIPTION
## Summary

This PR improves existing LibreQoS docs to reduce top recurring support questions from Zulip,
without introducing major docs restructuring or new standalone guides.

## Why

Based on multi-year Zulip support patterns, the highest recurring confusion areas were:

- Integration option selection (especially UISP/Splynx)
- Source-of-truth ownership (integration vs manual edits)
- Performance triage starting points
- First-run/post-upgrade validation expectations
- Support intake quality (missing diagnostics in initial ask)

This PR addresses those areas in-place within existing docs pages.

## What Changed

### EN docs (docs/v2.0)

- integrations-uisp.md
    - Added quick option chooser for new operators
    - Added router-mode expectations
    - Added 5-minute post-change validation checklist
- integrations-splynx.md
    - Added quick-start defaults for new operators
    - Added 5-minute post-change validation checklist
- operating-modes.md
    - Added topology/mode expectations to clarify ownership and fit
- configuration-advanced.md
    - Added topology guardrails
    - Added explicit source-of-truth boundary guidance for integration users
- performance-tuning.md
    - Added symptom-first triage table (throughput, CPU hotspot, post-change regressions)
- quickstart.md
    - Added “what good looks like” post-install checks
    - Added common first-run mistakes section
- update.md
    - Added required post-upgrade validation checks
    - Added stop-and-triage symptom list
- troubleshooting.md
    - Added “collect this before asking in chat” evidence block
    - Updated WebUI failure framing for current builds (lqosd health first)

### ES docs (docs-es/v2.0)

Mirrored the same improvements for:

- integrations-uisp-es.md
- integrations-splynx-es.md
- operating-modes-es.md
- configuration-advanced-es.md
- performance-tuning-es.md
- quickstart-es.md
- update-es.md
- troubleshooting-es.md