### PR TITLE
Docs v2.0: clarify ISP operator workflows, standardize integration guidance, and add EN/ ES glossary

### DIFF
--- a/docs-es/index.rst
+++ b/docs-es/index.rst
@@ -19,6 +19,7 @@ Bienvenido a la documentación de LibreQoS
    :caption: Gestionando LibreQoS (v1.5 a v2.0):
    
    v2.0/configuration-es
+   v2.0/glossary-es
    v2.0/operating-modes-es
    v2.0/configuration-advanced-es
    v2.0/integrations-es

--- a/docs-es/v2.0/api-es.md
+++ b/docs-es/v2.0/api-es.md
@@ -2,175 +2,140 @@
 
 ## Requisitos
 
-La API del nodo LibreQoS requiere una suscripción activa a LibreQoS Insight.
+El servicio `lqos_api` (API del nodo) requiere una suscripción activa a LibreQoS Insight.
 
-## Instalación
+Esto es independiente de los límites base de shaping:
+- El shaping base de LibreQoS puede operar hasta 1000 suscriptores sin Insight.
+- Límites superiores dependen de una licencia Insight activa.
 
-### Si instaló vía `.deb` (recomendado)
+## Fuente de verdad y pruebas
 
-`lqos_api` se instala con LibreQoS en:
+Use Swagger en su nodo como referencia completa y superficie de prueba para la versión instalada:
 
-`/opt/libreqos/src/bin/lqos_api`
+- `http://<node-ip>:9122/api-docs`
 
-### Ejecución de prueba
+Use esta página como mapa de capacidades. Use Swagger para inventario completo de endpoints, esquemas request/response y pruebas en vivo.
 
-```bash
-/opt/libreqos/src/bin/lqos_api
-```
+¿Necesita definiciones de persistencia e impacto en runtime? Vea el [Glosario](glossary-es.md).
 
-### Servicio systemd
+## Instalar y habilitar
 
-El paquete incluye un archivo de servicio de ejemplo:
+Si instaló vía `.deb` (recomendado), `lqos_api` ya está en:
+
+- `/opt/libreqos/src/bin/lqos_api`
+
+Habilitar servicio:
 
 ```bash
 sudo cp /opt/libreqos/src/bin/lqos_api.service.example /etc/systemd/system/lqos_api.service
-```
-
-Luego ejecute:
-
-```bash
 sudo systemctl daemon-reload
 sudo systemctl enable lqos_api
 sudo systemctl start lqos_api
 ```
 
-### Actualizar solo el binario de la API
-
-Use el script de ayuda:
+Actualizar solo el binario de la API:
 
 ```bash
 cd /opt/libreqos/src
 ./update_api.sh
 ```
 
-Esto descarga el `lqos_api` más reciente e instala en `/opt/libreqos/src/bin/lqos_api`.
-
-Puede omitir el reinicio del servicio:
-
-```bash
-./update_api.sh --no-restart
-```
-
-O instalar en otra ruta:
-
-```bash
-./update_api.sh --bin-dir /alguna/ruta/bin --no-restart
-```
-
-### Archivo de servicio manual (si es necesario)
-
-Si crea el servicio manualmente, use:
-
-```
-[Unit]
-After=network.service lqosd.service
-Requires=lqosd.service
-
-[Service]
-WorkingDirectory=/opt/libreqos/src/bin
-ExecStart=/opt/libreqos/src/bin/lqos_api
-Restart=always
-
-[Install]
-WantedBy=default.target
-```
-
-Luego ejecute:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable lqos_api
-sudo systemctl start lqos_api
-```
-
-## Uso
-
-Vea `localhost:9122/api-docs` para la interfaz Swagger.
-
-`/api-docs` es la fuente de verdad para su versión instalada. La disponibilidad de endpoints puede cambiar entre versiones.
-
-## Guía de despliegue y hardening
-
-Postura recomendada para producción:
-
-1. Mantenga la API accesible solo desde redes de gestión confiables.
-2. No exponga la API directamente a Internet público.
-3. Si requiere acceso remoto, publíquela detrás de un reverse proxy con TLS y autenticación.
-4. Restrinja acceso entrante con allowlists de firewall (host/red).
-5. Monitoree logs de API/servicio para detectar accesos anómalos.
-
-Si la API no se necesita en un nodo, deshabilite el servicio:
-
-```bash
-sudo systemctl disable --now lqos_api
-```
-
-Si está habilitada, verifique el estado tras actualizaciones:
+Verificar estado del servicio:
 
 ```bash
 sudo systemctl status lqos_api
 ```
 
-## Endpoints de la API
+## Autenticación
 
-### Salud y sistema
-- `/health` - Verificación de salud del servicio
-- `/reload_libreqos` - Recarga configuración de LibreQoS
-- `/validate_shaped_devices` - Valida CSV de Shaped Devices
-- `/lqos_stats` - Estadísticas internas de lqosd
-- `/stormguard_stats` - Estadísticas de StormGuard
-- `/bakery_stats` - Conteo de circuitos activos de Bakery
+La mayoría de endpoints requieren:
 
-### Métricas de tráfico
-- `/current_throughput` - Throughput actual de red
-- `/top_n_downloaders/{start}/{end}` - Top descargadores por tráfico
-- `/worst_rtt/{start}/{end}` - Hosts con peor RTT
-- `/worst_retransmits/{start}/{end}` - Hosts con más retransmisiones TCP
-- `/best_rtt/{start}/{end}` - Hosts con mejor RTT
-- `/host_counter` - Contadores de tráfico por host
+- Header: `x-bearer`
+- Valor: su clave de licencia Insight
 
-### Topología de red
-- `/network_map/{parent}` - Mapa de red desde nodo padre
-- `/full_network_map` - Topología completa
-- `/top_map_queues/{n}` - Top N colas por tráfico
-- `/node_names` - Nombres de nodos por ID
-- `/funnel/{target}` - Análisis de embudo hacia circuito
+## Qué pueden hacer los ISPs con la API
 
-### Gestión de circuitos
-- `/all_circuits` - Lista de todos los circuitos
-- `/raw_queue_data/{circuit_id}` - Datos de cola en bruto por circuito
+### 1) Ciclo de vida de suscriptores/circuitos
 
-### Análisis de flujos
-- `/dump_active_flows` - Volcado de flujos activos (lento)
-- `/count_active_flows` - Conteo de flujos activos
-- `/top_flows/{flow_type}/{n}` - Top flujos por tipo de métrica
-- `/flows_by_ip/{ip}` - Flujos por IP específica
-- `/flow_duration` - Estadísticas de duración de flujos
+Aprovisionar, actualizar y eliminar registros de suscriptor/dispositivo.
 
-### Geo y protocolos
-- `/current_endpoints_by_country` - Endpoints de tráfico por país
-- `/current_endpoint_latlon` - Coordenadas geográficas de endpoints
-- `/ether_protocol_summary` - Resumen de protocolos Ethernet
-- `/ip_protocol_summary` - Resumen de protocolos IP
+- Alta o reemplazo:
+  - `POST /overrides/persistent_devices`
+  - `POST /shaped_devices/update`
+- Ajustes de velocidad:
+  - `POST /overrides/adjustments/circuit_speed`
+  - `POST /overrides/adjustments/device_speed`
+- Bajas:
+  - `DELETE /overrides/persistent_devices/by_circuit/{circuit_id}`
+  - `DELETE /overrides/persistent_devices/by_device/{device_id}`
+  - `POST /overrides/adjustments/remove_circuit`
+  - `POST /overrides/adjustments/remove_device`
 
-## Cobertura de API en versiones recientes
+### 2) Gestión de overrides y políticas
 
-Compilaciones recientes ampliaron cobertura en algunas áreas. Dependiendo de su versión, la API también puede incluir:
+Mantener políticas persistentes para circuitos, dispositivos, sitios y overrides específicos de UISP.
 
-- Resúmenes de alertas y warnings
-- Resúmenes de conteo de dispositivos y circuitos
-- Consulta de detalle para circuito individual
-- Helpers de búsqueda para flujos de UI
-- Endpoints de detalle de scheduler y estadísticas de colas
+- `GET/POST/DELETE /overrides/adjustments*`
+- `GET/POST/DELETE /overrides/network_adjustments*`
+- `GET/POST/DELETE /overrides/uisp/bandwidth*`
+- `GET/POST/DELETE /overrides/uisp/routes*`
 
-Use `localhost:9122/api-docs` para confirmar rutas y esquemas exactos en su nodo.
+### 3) Topología y archivos de entrada de shaping
 
-## Capturar inventario de endpoints por release
+Inspeccionar y actualizar archivos de topología/shaping usados por los flujos de runtime.
 
-Para notas de release o runbooks internos, capture un snapshot de rutas API desde el nodo:
+- `GET /network_json/json`
+- `GET /network_json/text`
+- `POST /network_json/update`
+- `POST /network_json/set_site_speed`
+- `POST /network_json/set_site_speed_batch`
+- `GET /shaped_devices`
+- `POST /shaped_devices/update`
 
-```bash
-curl -s http://localhost:9122/api-docs | jq -r '.paths | keys[]' | sort
-```
+### 4) Monitoreo y diagnóstico
 
-Guarde esta salida junto con artefactos del release para comparar diferencias entre versiones.
+Leer estado de salud, scheduler, throughput, flujos, colas y circuitos.
+
+Endpoints representativos:
+- `GET /health`
+- `GET /status_snapshot`
+- `GET /scheduler_status`
+- `GET /circuit/{circuit_id}`
+- `GET /search`
+- `GET /current_throughput`
+- `GET /queue_stats_total`
+- `GET /warnings`
+- `GET /urgent`, `GET /urgent/status`
+
+### 5) Operaciones de control y reload
+
+Disparar acciones de control operativo cuando sea necesario.
+
+- `POST /reload_libreqos`
+- `POST /clear_hot_cache`
+
+Trátelas como operaciones de mayor riesgo en producción.
+
+## Modelo de persistencia (importante)
+
+No todas las escrituras persisten del mismo modo:
+
+- `overrides/*`: estado de política persistente.
+- `network_json/set_site_speed*`: ediciones transitorias.
+- `network_json/update` y `shaped_devices/update`: reemplazo directo de archivos, generalmente sobrescribible por integración.
+
+Si hay integraciones habilitadas, sus ciclos de refresco pueden sobrescribir ediciones directas de archivos.
+
+## Flujo recomendado para producción
+
+1. Validar comportamiento del endpoint y esquema de payload en Swagger.
+2. Aplicar el cambio mínimo necesario.
+3. Verificar resultado con checks de solo lectura (`/health`, `/scheduler_status`, vistas de circuito/throughput).
+4. Mantener snapshots de rollback para operaciones que cambien config/datos.
+
+## Hardening de despliegue
+
+- Limite acceso de API a redes de gestión confiables.
+- No exponga la API directamente a Internet público.
+- Si necesita acceso remoto, use reverse proxy con TLS y autenticación.
+- Restrinja acceso entrante con allowlists de firewall.

--- a/docs-es/v2.0/components-es.md
+++ b/docs-es/v2.0/components-es.md
@@ -2,6 +2,19 @@
 
 ## Servicios systemd
 
+```{mermaid}
+flowchart LR
+    A[Integraciones CRM/NMS] --> B[lqos_scheduler]
+    C[network.json + ShapedDevices.csv] --> B
+    D[lqos_overrides.json] --> B
+    B --> E[Refresco del plan de colas/shaping]
+    E --> F[lqosd]
+    F --> G[Shaping runtime XDP/TC]
+    F --> H[WebUI :9123]
+    B --> I[Estado del scheduler / problemas urgentes]
+    F --> I
+```
+
 ### lqosd
 
 - Administra la lógica de shaping/XDP.

--- a/docs-es/v2.0/configuration-advanced-es.md
+++ b/docs-es/v2.0/configuration-advanced-es.md
@@ -12,6 +12,10 @@ Antes de ajustes profundos:
 
 Si el resultado no coincide con lo esperado, use [Solución de problemas](troubleshooting-es.md) antes de seguir cambiando parámetros.
 
+```{warning}
+Si el modo integración está habilitado, las ediciones directas a `network.json` y `ShapedDevices.csv` pueden ser sobrescritas por los ciclos de refresco de integración. Use configuración de integración y overrides para cambios durables.
+```
+
 ## Configuración por línea de comando
 
 También puedes modificar ajustes usando la CLI.
@@ -57,12 +61,26 @@ do_not_track_subnets = ["192.168.0.0/16"]
 
 Más información sobre [configuración de integraciones aquí.](integrations-es.md).
 
-### Límite de fuente de verdad para usuarios de integración
+### Límite de Fuente de Verdad para Usuarios de Integración
 
 Si el modo integración está habilitado, los ciclos de refresco suelen ser dueños de `ShapedDevices.csv` y, según configuración, también de `network.json`.
 
 - Use edición manual/WebUI para ajustes operativos temporales.
 - Mantenga cambios permanentes en el sistema de integración, overrides de integración o flujo externo declarado.
+
+### Overrides en runtime (`lqos_overrides.json`)
+
+LibreQoS también permite ajustes de runtime mediante `lqos_overrides.json` en el `lqos_directory`.
+
+```{mermaid}
+flowchart LR
+    A[CRM/NMS o archivos manuales] --> B[network.json + ShapedDevices.csv base]
+    C[API/CLI de overrides] --> D[lqos_overrides.json]
+    B --> E[Refresco de lqos_scheduler]
+    D --> E
+    E --> F[Plan de shaping combinado]
+    F --> G[Colas/clases activas en lqosd]
+```
 
 ## Jerarquía de Red
 ### Network.json
@@ -84,6 +102,15 @@ echo "{}" > network.json
 #### Nodos virtuales (solo lógicos)
 
 LibreQoS soporta **nodos virtuales** en `network.json` para agrupar y para monitoreo/agregación en la WebUI/Insight. Los nodos virtuales **no** se incluyen en el árbol físico de shaping HTB (no crean clases HTB y no aplican límites de ancho de banda).
+
+```{mermaid}
+flowchart TD
+    A[Árbol lógico incluye nodo virtual] --> B[Fase de armado del scheduler]
+    B --> C[Promover hijos virtuales al ancestro no virtual más cercano]
+    C --> D{¿Colisión de nombres entre hermanos tras promoción?}
+    D -->|No| E[Se genera el árbol físico de shaping]
+    D -->|Sí| F[Error de build: renombrar/reestructurar nodos]
+```
 
 Para marcar un nodo como virtual, configura `"virtual": true` en ese nodo.
 

--- a/docs-es/v2.0/configuration-es.md
+++ b/docs-es/v2.0/configuration-es.md
@@ -11,11 +11,6 @@ La herramienta de instalación configura puente, interfaces, ancho de banda, ran
 
 Notas:
 - La herramienta se controla con teclado (`Enter` para seleccionar, `Q` para salir sin guardar).
-- Si necesita volver a abrirla:
-  ```
-  sudo apt remove libreqos
-  sudo apt install ./{deb_url_v1_5}
-  ```
 
 ### Próximos pasos
 
@@ -42,22 +37,11 @@ La mayoría de cambios operativos diarios se realizan en la WebUI (`http://tu_ip
 Lea esto primero antes de cambios en producción:
 - [Modos de operación y fuente de verdad](operating-modes-es.md)
 
-## Referencia avanzada de configuración
+## ¿Necesita cambios por CLI o por archivos?
 
-La configuración por CLI, edición directa de archivos y referencia detallada se movió aquí:
+Para edición directa de archivos (`/etc/lqos.conf`, `network.json`, `ShapedDevices.csv`), overrides y material de referencia profundo sobre topología/circuitos, use:
+
 - [Referencia avanzada de configuración](configuration-advanced-es.md)
-
-## Configuración por línea de comando
-
-Esta sección se movió a [Referencia avanzada de configuración](configuration-advanced-es.md#configuración-por-línea-de-comando).
-
-## Jerarquía de red
-
-Esta sección se movió a [Referencia avanzada de configuración](configuration-advanced-es.md#jerarquía-de-red).
-
-## Circuitos
-
-Esta sección se movió a [Referencia avanzada de configuración](configuration-advanced-es.md#circuitos).
 
 ## Páginas relacionadas
 

--- a/docs-es/v2.0/design-es.md
+++ b/docs-es/v2.0/design-es.md
@@ -18,8 +18,17 @@ Si tu despliegue MPLS usa un patrón distinto, lo ideal es terminar el tráfico 
 - Ruta primaria (bajo costo) *a través* del servidor que ejecuta LibreQoS.
 - Ruta de respaldo (alto costo) *evitando* el servidor que ejecuta LibreQoS.
 
-#### Diagrama
-![Offical Configuration](https://github.com/user-attachments/assets/e5914a58-3ec6-4eb1-b016-8a57582dd082)
+```{mermaid}
+flowchart LR
+    A[Router de borde] -->|Ruta preferida OSPF/BGP| B[Ruta inline de LibreQoS]
+    B --> C[Router/Switch core]
+    A -->|Ruta de respaldo de mayor costo| C
+```
+
+Interpretación:
+1. En operación normal, el enrutamiento prefiere la ruta inline de bajo costo a través de LibreQoS.
+2. Si la ruta inline falla, el enrutamiento converge hacia la ruta bypass de mayor costo.
+3. Tras la recuperación, la preferencia de rutas devuelve el tráfico a la ruta inline.
 
 ### Opción 1: Enrutamiento dinámico (recomendado)
 

--- a/docs-es/v2.0/glossary-es.md
+++ b/docs-es/v2.0/glossary-es.md
@@ -1,0 +1,51 @@
+# Glosario
+
+Use esta página para definiciones consistentes usadas en la documentación operativa de LibreQoS.
+
+## Fuente de verdad
+
+El sistema que es dueño de los datos durables de shaping y debe tratarse como autoritativo.
+
+## Ciclo de refresco de integración
+
+Proceso periódico de sincronización que importa datos del CRM/NMS y regenera insumos de shaping.
+
+## Override
+
+Ajuste específico que se aplica por encima de los datos base importados/manuales.
+
+## Cambio persistente
+
+Cambio que permanece entre ciclos de refresco/reinicio, salvo eliminación explícita.
+
+## Cambio transitorio
+
+Cambio temporal que puede ser reemplazado por sincronizaciones o refrescos posteriores.
+
+## Sobrescribible por integración
+
+Datos que la salida de sincronización de integración puede reemplazar en operación normal.
+
+## ShapedDevices.csv
+
+Archivo de entrada de shaping de suscriptores/dispositivos usado por el scheduler.
+
+## network.json
+
+Archivo de entrada de topología y capacidad de nodos usado para jerarquía y estructura de shaping.
+
+## Circuito mapeado
+
+Circuito actualmente resuelto/mapeado dentro del estado activo de shaping.
+
+## Límite de circuitos mapeados
+
+Tope aplicado a circuitos mapeados según estado actual de licencia/política.
+
+## Estado del scheduler
+
+Estado operativo de `lqos_scheduler` expuesto por WebUI/API.
+
+## Impacto inmediato en runtime
+
+Acción de API/UI/CLI que puede afectar el shaping activo poco después de ejecutarse.

--- a/docs-es/v2.0/high-availability-es.md
+++ b/docs-es/v2.0/high-availability-es.md
@@ -13,6 +13,16 @@ Esta página describe un modelo práctico de activo/respaldo para LibreQoS.
 
 Una ruta está activa (preferida) y otra está en respaldo (espera). La política de enrutamiento controla la selección de ruta y la conmutación por falla.
 
+```{mermaid}
+stateDiagram-v2
+    [*] --> PrimariaActiva
+    PrimariaActiva: Ruta primaria preferida (costo 1)
+    PrimariaActiva --> ConvergenciaFailover: Falla primaria detectada
+    ConvergenciaFailover --> RespaldoActivo: Enrutamiento convergió al respaldo (costo 100)
+    RespaldoActivo --> ValidacionRecuperacion: Primaria reparada
+    ValidacionRecuperacion --> PrimariaActiva: Preferencia restaurada y estable
+```
+
 ## Ejemplo OSPF (Costo 1 Primario, Costo 100 Respaldo)
 
 Use el costo de interfaz OSPF para preferir la ruta activa.

--- a/docs-es/v2.0/insight-es.md
+++ b/docs-es/v2.0/insight-es.md
@@ -75,9 +75,12 @@ Permite identificar la topología general de la red desde la perspectiva de Insi
 
 <img width="1784" height="882" alt="07 libby" src="https://github.com/user-attachments/assets/591a3fd1-3946-44ed-a4fd-e1b1d84b9ef6" />
 
-Libby es el asistente IA de Insight. Puede ayudarte con dudas sobre LibreQoS o Insight basándose en la documentación oficial. Libby accede a datos en vivo y de largo plazo tanto de los shapers sincronizados como de Insight. Puede responder en la mayoría de los idiomas mediante traducción automática.
+Libby es una interfaz de chat asistiva para operaciones de Insight y consulta de documentación.
 
-Si encuentras nuevos casos de uso para Libby, comparte con nosotros cómo te ayuda en el flujo de trabajo.
+Guía operativa:
+- Trate la salida de Libby como guía asistiva, no como comando autoritativo de cambio.
+- Valide recomendaciones contra estado actual del nodo, logs y procedimientos documentados antes de aplicar cambios en producción.
+- Para acciones sensibles/de alto impacto, confirme con el flujo estándar del operador (estado de servicios, estado del scheduler y ruta de rollback).
 
 ### Site Heatmap
 

--- a/docs-es/v2.0/integrations-es.md
+++ b/docs-es/v2.0/integrations-es.md
@@ -4,14 +4,17 @@
 
 Use esta página para elegir y configurar integraciones CRM/NMS soportadas. Use las páginas por integración para detalles específicos.
 
-La mayoría de operadores usan las integraciones incluidas. Si usa scripts propios como fuente de verdad para `network.json` y `ShapedDevices.csv`, comience por [Modos de operación y fuente de verdad](operating-modes-es.md).
+¿Necesita definiciones de términos de sobrescritura/persistencia? Vea el [Glosario](glossary-es.md).
+
+La mayoría de operadores usan las integraciones incluidas.
+Si todavía no eligió ruta de despliegue, empiece por [Quickstart](quickstart-es.md).
 
 ## Elegir ruta de integración
 
 | Ruta | Mejor para | Fuente de verdad principal |
 |---|---|---|
 | Integración incluida | La mayoría de operadores con sistemas soportados | CRM/NMS por jobs de integración de LibreQoS |
-| Fuente-de-verdad personalizada | Operadores con sincronización propia de CRM/NMS | Archivos externos generados (`network.json`, `ShapedDevices.csv`) |
+| Fuente de verdad personalizada | Operadores con sincronización propia de CRM/NMS | Archivos externos generados (`network.json`, `ShapedDevices.csv`) |
 
 ## Dónde en la WebUI
 

--- a/docs-es/v2.0/integrations-netzur-es.md
+++ b/docs-es/v2.0/integrations-netzur-es.md
@@ -14,6 +14,7 @@ Use esta integración cuando Netzur sea su fuente de verdad CRM/NMS.
 
 - La integración regenera `ShapedDevices.csv`.
 - `network.json` depende de su configuración de sobrescritura.
+- Recomendado: mantener `always_overwrite_network_json = true` para alinear topología con los ciclos de Netzur.
 
 ## Referencia completa
 

--- a/docs-es/v2.0/integrations-reference-es.md
+++ b/docs-es/v2.0/integrations-reference-es.md
@@ -1,7 +1,7 @@
 # Integraciones CRM/NMS
 
-Esta página conserva la referencia detallada heredada de integraciones.
-Para el punto de entrada orientado a tareas, use [Integraciones CRM/NMS](integrations-es.md).
+Esta página conserva material heredado de referencia detallada.
+La guía canónica y orientada a tareas está en las páginas por integración enlazadas desde [Integraciones CRM/NMS](integrations-es.md).
 
   * [Integración con Splynx](#integración-con-splynx)
     + [Estrategias de Topología](#estrategias-de-topología)
@@ -22,7 +22,7 @@ Para el punto de entrada orientado a tareas, use [Integraciones CRM/NMS](integra
   * [Integración con Sonar](#integración-con-sonar)
 
 La mayoría de operadores usan este camino de integraciones incluidas.
-Si usa scripts propios como fuente de verdad para `network.json` y `ShapedDevices.csv`, comience por [Modos de operación y fuente de verdad](configuration-es.md#modos-de-operación-y-fuente-de-verdad).
+Si usa scripts propios como fuente de verdad para `network.json` y `ShapedDevices.csv`, comience por [Modos de operación y fuente de verdad](operating-modes-es.md).
 
 Comportamiento importante cuando hay integraciones habilitadas:
 - `ShapedDevices.csv` normalmente se regenera por los jobs de sincronización.
@@ -218,12 +218,12 @@ LibreQoS soporta múltiples estrategias de topología para la integración con U
 | `flat` | Solo regula suscriptores por velocidad del plan de servicio | Mínimo | Máximo rendimiento, regulación simple solo de suscriptores |
 | `ap_only` | Regula por plan de servicio y Punto de Acceso | Bajo | Buen equilibrio entre rendimiento y control a nivel de AP |
 | `ap_site` | Regula por plan de servicio, Punto de Acceso y Sitio | Medio | Agregación a nivel de sitio con complejidad moderada |
-| `full` | Regula toda la red incluyendo backhauls, Sitios, APs y clientes | Alto | **Recomendado para la mayoría de implementaciones**. Jerarquía completa de red con reconocimiento de backhaul |
+| `full` | Regula toda la red incluyendo backhauls, Sitios, APs y clientes | Alto | Mejor cuando topología/overrides ya están validados y estables |
 
 **Cómo Elegir la Estrategia Correcta:**
-- Use `full` para la mayoría de implementaciones para obtener reconocimiento completo de la topología de red incluyendo enlaces de backhaul
-- Use `ap_site` si necesita control a nivel de sitio pero no necesita regulación de backhaul
-- Use `ap_only` para mejor rendimiento cuando no se necesita agregación de sitios
+- Comience con `ap_only` en despliegues nuevos y validación inicial
+- Pase a `ap_site` cuando necesite control por sitio sin regulación de backhaul
+- Pase a `full` cuando la calidad de topología y overrides esté validada y exista margen de CPU
 - Use `flat` solo cuando el máximo rendimiento es crítico y no necesita ninguna jerarquía
 
 **Nota de Rendimiento:** Cuando use la estrategia `full` con redes grandes, considere usar la función **promote_to_root** (vea [Promover Nodos a Raíz](#promover-nodos-a-raíz-optimización-de-rendimiento) arriba) para distribuir la carga del CPU entre múltiples núcleos.
@@ -276,7 +276,7 @@ url = "https://uisp.su_dominio.com"
 site = "Nombre_Sitio_Raiz"  # Sitio raíz para perspectiva de topología
 
 # Estrategia de Topología (ver tabla arriba)
-strategy = "full"  # Recomendado para la mayoría de implementaciones
+strategy = "ap_only"  # Punto de inicio recomendado para nuevos despliegues UISP
 
 # Manejo de Suspensiones (ver tabla arriba)
 suspended_strategy = "none"
@@ -296,7 +296,7 @@ commit_bandwidth_multiplier = 0.98  # Establecer mínimo al 98% del máximo (CIR
 
 # Opciones Avanzadas
 ipv6_with_mikrotik = false  # Habilitar si usa DHCPv6 con MikroTik
-always_overwrite_network_json = false  # Establecer true para reconstruir topología en cada ejecución
+always_overwrite_network_json = true  # Recomendado para despliegues guiados por integración
 exception_cpes = []  # Excepciones de CPE en formato ["cpe:parent"]
 squash_sites = []  # Opcional: sitios a compactar
 enable_squashing = false  # Opcional: habilita lógica adicional de compactación
@@ -338,7 +338,7 @@ ShapedDevices.csv será sobrescrito cada vez que se ejecute la integración de U
 Para asegurarse de que network.json siempre sea sobrescrito con la versión más reciente obtenida por la integración, edite el archivo `/etc/lqos.conf` con el comando `sudo nano /etc/lqos.conf` y configure el valor  `always_overwrite_network_json` a `true`.
 Luego ejecute: `sudo systemctl restart lqosd`.
 
-Tiene la opción de ejecutar integrationUISP.py automáticamente al iniciar el equipo y cada X minutos (configurado con el parámetro `queue_refresh_interval_mins`), lo cual es altamente recomendado. Esto se habilita estableciendo ```enable_uisp = true``` en `/etc/lqos.conf`. Una vez configurado, ejecute `sudo systemctl restart lqos_scheduler`.
+Tiene la opción de ejecutar `uisp_integration` automáticamente al iniciar el equipo y cada X minutos (configurado con el parámetro `queue_refresh_interval_mins`), lo cual es altamente recomendado. Esto se habilita estableciendo ```enable_uisp = true``` en `/etc/lqos.conf`. Una vez configurado, ejecute `sudo systemctl restart lqos_scheduler`.
 
 ### Sobrescrituras de UISP
 

--- a/docs-es/v2.0/integrations-sonar-es.md
+++ b/docs-es/v2.0/integrations-sonar-es.md
@@ -14,6 +14,7 @@ Use esta integración cuando Sonar sea su fuente de verdad CRM/NMS.
 
 - `ShapedDevices.csv` se regenera en cada sincronización.
 - `network.json` depende de su configuración de sobrescritura.
+- Recomendado: mantener `always_overwrite_network_json = true` para alinear topología con Sonar en cada ciclo.
 
 ## Referencia completa
 

--- a/docs-es/v2.0/integrations-splynx-es.md
+++ b/docs-es/v2.0/integrations-splynx-es.md
@@ -16,7 +16,7 @@ Base recomendada:
 
 - `strategy = "ap_only"` (menos confusión inicial)
 - `enable_splynx = true`
-- `always_overwrite_network_json = false` salvo que quiera sobrescritura en cada ejecución
+- `always_overwrite_network_json = true` para despliegues guiados por integración
 
 Después, ejecute una sincronización manual y valide salidas antes de aumentar frecuencia de refresh.
 
@@ -24,6 +24,7 @@ Después, ejecute una sincronización manual y valide salidas antes de aumentar 
 
 - `ShapedDevices.csv` se regenera en cada sincronización.
 - `network.json` depende de `always_overwrite_network_json`.
+- Recomendado: mantener `always_overwrite_network_json = true` para alinear topología con Splynx en cada ciclo.
 - Use WebUI para ajustes operativos diarios.
 
 ## Validación en 5 minutos después de cambios Splynx

--- a/docs-es/v2.0/integrations-uisp-es.md
+++ b/docs-es/v2.0/integrations-uisp-es.md
@@ -16,7 +16,7 @@ Use esta guía para evitar confusión con opciones:
 
 1. Si está empezando, use `strategy = "ap_only"`.
 2. Cambie a `ap_site` cuando necesite agregación explícita por sitio.
-3. Use `full` cuando necesite jerarquía/backhaul completo y tenga margen de CPU.
+3. Use `full` cuando necesite jerarquía/backhaul completo, tenga margen de CPU y ya haya validado topología/overrides.
 4. Use `flat` solo si la jerarquía no es necesaria y prioriza rendimiento máximo.
 
 ## Expectativas en router mode
@@ -29,6 +29,7 @@ Use esta guía para evitar confusión con opciones:
 
 - `ShapedDevices.csv` se regenera en cada sincronización.
 - `network.json` depende de `always_overwrite_network_json`.
+- Para despliegues guiados por integración, use `always_overwrite_network_json = true` para mantener la topología alineada con UISP en cada ciclo.
 - En modo integración, trate ediciones de archivos como temporales.
 
 ## Validación en 5 minutos después de cambios UISP

--- a/docs-es/v2.0/integrations-visp-es.md
+++ b/docs-es/v2.0/integrations-visp-es.md
@@ -14,6 +14,7 @@ Use esta integración cuando VISP sea su fuente de verdad CRM/NMS.
 
 - `ShapedDevices.csv` se reescribe en cada ejecución.
 - `network.json` se sobrescribe solo cuando está habilitado.
+- Recomendado: mantener `always_overwrite_network_json = true` para despliegues guiados por integración VISP.
 
 ## Referencia completa
 

--- a/docs-es/v2.0/integrations-wispgate-es.md
+++ b/docs-es/v2.0/integrations-wispgate-es.md
@@ -14,6 +14,7 @@ Use esta integración cuando WISPGate sea su fuente de verdad CRM/NMS.
 
 - `ShapedDevices.csv` se regenera en cada sincronización.
 - `network.json` depende de su configuración de sobrescritura.
+- Recomendado: mantener `always_overwrite_network_json = true` para alinear topología con WISPGate en cada ciclo.
 
 ## Referencia completa
 

--- a/docs-es/v2.0/operating-modes-es.md
+++ b/docs-es/v2.0/operating-modes-es.md
@@ -4,6 +4,8 @@
 
 Use esta página para elegir y aplicar su política de fuente de verdad (integraciones incluidas vs fuente personalizada) antes de cambios en producción.
 
+¿Necesita definiciones de términos usados aquí? Vea el [Glosario](glossary-es.md).
+
 LibreQoS soporta dos modos de operación principales.
 
 ## Integraciones incluidas (recomendado para la mayoría de operadores)
@@ -15,7 +17,7 @@ Comportamiento clave:
 - El comportamiento de sobrescritura de `network.json` depende de la configuración de integración (por ejemplo `always_overwrite_network_json`).
 - Las ediciones manuales directas pueden sobrescribirse en el siguiente refresco del scheduler.
 
-## Fuente-de-verdad personalizada
+## Fuente de verdad personalizada
 
 En este modo, sus propios scripts/sistemas generan `network.json` y `ShapedDevices.csv`.
 
@@ -40,8 +42,9 @@ Comportamiento clave:
 
 Vea también:
 - [Referencia avanzada de configuración](configuration-advanced-es.md)
-- [Integraciones CRM/NMS](integrations-es.md)
 - [Solución de problemas](troubleshooting-es.md)
+
+Si está usando integraciones incluidas, continúe en [Integraciones CRM/NMS](integrations-es.md).
 
 ## Páginas relacionadas
 

--- a/docs-es/v2.0/quickstart-es.md
+++ b/docs-es/v2.0/quickstart-es.md
@@ -2,6 +2,8 @@
 
 Use esta página para elegir rápidamente la ruta correcta y ejecutar solo los pasos de esa ruta.
 
+¿Necesita definiciones de términos clave? Vea el [Glosario](glossary-es.md).
+
 ## Base de instalación común
 
 Complete esto una vez antes de cualquier paso específico de ruta.
@@ -45,6 +47,18 @@ journalctl -u lqosd -u lqos_scheduler --since "10 minutes ago"
 
 Si falla algo, pase a [Solución de problemas](troubleshooting-es.md) antes del piloto.
 
+## Decidir fuente de verdad (hágalo una vez)
+
+Antes de continuar, elija quién controla las actualizaciones persistentes de datos de shaping:
+
+| Si esto describe su caso | Elija este modo | Siguiente página |
+|---|---|---|
+| Usa una integración CRM/NMS soportada | Modo integración incluida | [Integraciones CRM/NMS](integrations-es.md) |
+| Genera `network.json` y `ShapedDevices.csv` con scripts propios | Modo fuente de verdad personalizada | [Modos de operación y fuente de verdad](operating-modes-es.md) |
+| Mantiene archivos manualmente (redes pequeñas/simples) | Modo archivos manuales | [Modos de operación y fuente de verdad](operating-modes-es.md) |
+
+Regla: mantenga un único dueño para los insumos persistentes de shaping para evitar conflictos de sobrescritura.
+
 ## Testbed / Lab
 
 ### Cuándo elegir
@@ -63,8 +77,6 @@ Quiere validar comportamiento en un entorno controlado antes de producción inli
 ### Luego vaya aquí
 
 - [Configurar LibreQoS](configuration-es.md)
-- [Modos de operación y fuente de verdad](operating-modes-es.md)
-- [Integraciones CRM/NMS](integrations-es.md)
 - [Solución de problemas](troubleshooting-es.md)
 
 ## Integración Soportada
@@ -88,7 +100,6 @@ Nota:
 ### Luego vaya aquí
 
 - [Integraciones CRM/NMS](integrations-es.md)
-- [Escalado y diseño de topología](scale-topology-es.md)
 - [Solución de problemas](troubleshooting-es.md)
 
 ## Errores comunes en primera puesta en marcha
@@ -114,12 +125,11 @@ Su CRM/NMS no está soportado y usted generará `network.json` + `ShapedDevices.
 Nota:
 - Las ediciones por WebUI son útiles para operación rápida.
 - El estado de largo plazo debe mantenerse en su flujo externo de fuente de verdad.
+- Referencia de formato de archivos: vea las secciones `network.json` y `ShapedDevices.csv` en la [Referencia avanzada de configuración](configuration-advanced-es.md).
 
 ### Luego vaya aquí
 
 - [Modos de operación y fuente de verdad](operating-modes-es.md)
-- [Referencia avanzada de configuración](configuration-advanced-es.md)
-- [Escalado y diseño de topología](scale-topology-es.md)
 - [Solución de problemas](troubleshooting-es.md)
 
 ## Archivos Manuales (<100 suscriptores)
@@ -141,6 +151,4 @@ Recomendado solo para redes menores a 100 suscriptores.
 ### Luego vaya aquí
 
 - [Referencia avanzada de configuración](configuration-advanced-es.md)
-- [Modos de operación y fuente de verdad](operating-modes-es.md)
-- [Escalado y diseño de topología](scale-topology-es.md)
 - [Solución de problemas](troubleshooting-es.md)

--- a/docs-es/v2.0/requirements-es.md
+++ b/docs-es/v2.0/requirements-es.md
@@ -2,6 +2,19 @@
 
 LibreQoS puede ejecutarse en un servidor físico dedicado (bare metal) o como una máquina virtual (VM). El sistema operativo soportado es Ubuntu Server 24.04.
 
+## Guía rápida de dimensionamiento (empiece aquí)
+
+Use esta guía rápida antes de entrar a las tablas completas de hardware:
+
+| Perfil objetivo | Ajuste típico | Punto de inicio |
+|---|---|---|
+| Pequeño | hasta ~1,000 suscriptores, hasta ~1 Gbps | 2+ núcleos fuertes, 8 GB RAM, NIC soportada clase 10G |
+| Mediano | ~1,000-5,000 suscriptores, ~1-10 Gbps | 6-16 núcleos fuertes, 32-64 GB RAM, NIC soportada 10/25G |
+| Grande | ~5,000-20,000 suscriptores, ~10-50 Gbps | 16-64 núcleos fuertes, 64-128 GB RAM, NIC soportada 25/50/100G |
+| Alto throughput | 50 Gbps+ o jerarquía profunda a escala | priorice alto rendimiento por hilo, balance cola/núcleo y soporte NIC/XDP validado |
+
+Luego use las tablas detalladas de esta página para escoger hardware específico.
+
 ## Servidor Físico (Bare Metal)
 
 ### CPU

--- a/docs-es/v2.0/scale-topology-es.md
+++ b/docs-es/v2.0/scale-topology-es.md
@@ -13,6 +13,19 @@ Esta guía se centra en diseñar `network.json` y elegir estrategias de integrac
 
 Use la estrategia más simple que cumpla el objetivo operativo:
 
+```{mermaid}
+flowchart TD
+    A[¿Necesita visibilidad/control jerárquico?] -->|No| B[flat]
+    A -->|Sí| C{¿Necesita agregación por sitio?}
+    C -->|No| D[ap_only]
+    C -->|Sí| E{¿Necesita shaping de ruta/backhaul completo?}
+    E -->|No| F[ap_site]
+    E -->|Sí| G[full]
+    G --> H{¿Saturación de un solo núcleo?}
+    H -->|Sí| I[Usar promote_to_root]
+    H -->|No| J[Mantener estrategia full]
+```
+
 | Estrategia | Ajuste típico de escala | Tradeoff |
 |---|---|---|
 | `flat` | Máximo rendimiento, mínima jerarquía | Menor visibilidad/agregación |

--- a/docs-es/v2.0/troubleshooting-es.md
+++ b/docs-es/v2.0/troubleshooting-es.md
@@ -4,6 +4,8 @@
 
 Use esta tabla para ir al primer check rápidamente.
 
+¿Necesita definiciones de términos de licencia/scheduler? Vea el [Glosario](glossary-es.md).
+
 | Síntoma | Primer check | Ubicación en WebUI | Siguiente sección |
 |---|---|---|---|
 | No se puede acceder a la WebUI | `systemctl status lqosd` | N/A (UI no disponible) | No hay WebUI en x.x.x.x:9123 |
@@ -59,10 +61,9 @@ La WebUI depende de `lqosd`. En builds actuales, la mayoría de fallas de acceso
 
 ```bash
 sudo systemctl status lqosd
-journalctl -u lqosd --since "10 minutes ago"
 ```
 
-`lqosd` suele mostrar causa específica (interfaz caída, falta de multi-queue, etc.).
+Luego siga el flujo completo en **El servicio lqosd no se ejecuta o falla al iniciar**.
 
 ### LibreQoS está en ejecución, pero no hace shaping
 
@@ -205,36 +206,6 @@ Patrón operativo:
 2. Recolecte logs correlacionados de `lqosd` y `lqos_scheduler`.
 3. Aplique mitigación inmediata.
 4. Reconozca/limpie el evento en UI cuando esté estable.
-
-### Segfault de systemd
-
-Si experimenta un segfault en systemd, es un problema conocido [1](https://github.com/systemd/systemd/issues/36031) [2](https://github.com/systemd/systemd/issues/33643).
-
-#### Instalar dependencias de compilación
-
-```bash
-sudo apt update
-sudo apt install build-essential git meson libcap-dev libmount-dev libseccomp-dev \
-libblkid-dev libacl1-dev libattr1-dev libcryptsetup-dev libaudit-dev \
-libpam0g-dev libselinux1-dev libzstd-dev libcurl4-openssl-dev
-```
-
-#### Clonar systemd desde GitHub
-
-```bash
-git clone https://github.com/systemd/systemd.git
-cd systemd
-git checkout v257.5
-meson setup build
-meson compile -C build
-sudo meson install -C build
-```
-
-Luego reinicie y valide con:
-
-```bash
-systemctl --version
-```
 
 ## Páginas relacionadas
 

--- a/docs/v2.0/api.md
+++ b/docs/v2.0/api.md
@@ -2,175 +2,140 @@
 
 ## Requirements
 
-The LibreQoS Node API requires an active LibreQoS Insight subscription.
+The `lqos_api` (Node API service) requires an active LibreQoS Insight subscription.
 
-## Installation
+This is separate from base shaping limits:
+- Core LibreQoS shaping can run up to 1000 subscribers without Insight.
+- Higher subscriber limits depend on active Insight licensing.
 
-### If installed via `.deb` (recommended)
+## Source of Truth and Testing
 
-`lqos_api` is installed with LibreQoS into:
+Use Swagger on your node as the complete reference and test surface for your installed build:
 
-`/opt/libreqos/src/bin/lqos_api`
+- `http://<node-ip>:9122/api-docs`
 
-### Test run
+Use this page as a capability map. Use Swagger for full endpoint inventory, request/response schemas, and live testing.
 
-```bash
-/opt/libreqos/src/bin/lqos_api
-```
+Need definitions for persistence and runtime-impact terms? See the [Glossary](glossary.md).
 
-### Systemd Service
+## Install and Enable
 
-The package includes a template service file:
+If installed via `.deb` (recommended), `lqos_api` is included at:
+
+- `/opt/libreqos/src/bin/lqos_api`
+
+Enable service:
 
 ```bash
 sudo cp /opt/libreqos/src/bin/lqos_api.service.example /etc/systemd/system/lqos_api.service
-```
-
-Then run:
-
-```bash
 sudo systemctl daemon-reload
 sudo systemctl enable lqos_api
 sudo systemctl start lqos_api
 ```
 
-### Update just the API binary
-
-Use the helper script:
+Update only the API binary:
 
 ```bash
 cd /opt/libreqos/src
 ./update_api.sh
 ```
 
-This downloads the latest `lqos_api` and installs it to `/opt/libreqos/src/bin/lqos_api`.
-
-You can optionally skip service restart:
-
-```bash
-./update_api.sh --no-restart
-```
-
-Or install to an alternate location:
-
-```bash
-./update_api.sh --bin-dir /some/path/bin --no-restart
-```
-
-### Manual service file (if needed)
-
-If you are creating the service manually, use:
-
-```
-[Unit]
-After=network.service lqosd.service
-Requires=lqosd.service
-
-[Service]
-WorkingDirectory=/opt/libreqos/src/bin
-ExecStart=/opt/libreqos/src/bin/lqos_api
-Restart=always
-
-[Install]
-WantedBy=default.target
-```
-
-Then run:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable lqos_api
-sudo systemctl start lqos_api
-```
-
-## Usage
-
-See `localhost:9122/api-docs` for the Swagger UI.
-
-`/api-docs` is the source of truth for your installed version. Endpoint availability can change between releases.
-
-## Deployment and Hardening Guidance
-
-Recommended production posture:
-
-1. Keep the Node API reachable only from trusted management networks.
-2. Do not expose the API directly to the public Internet.
-3. If remote access is required, place it behind a reverse proxy with TLS and authentication.
-4. Restrict inbound access with host/network firewall allowlists.
-5. Monitor API and service logs for abnormal access patterns.
-
-If the API is not needed on a node, disable the service:
-
-```bash
-sudo systemctl disable --now lqos_api
-```
-
-If enabled for operations, verify service state after upgrades:
+Verify service state:
 
 ```bash
 sudo systemctl status lqos_api
 ```
 
-## API Endpoints
+## Authentication
 
-### Health & System
-- `/health` - Service health check
-- `/reload_libreqos` - Reload LibreQoS configuration
-- `/validate_shaped_devices` - Validate shaped devices CSV
-- `/lqos_stats` - Get lqosd internal statistics
-- `/stormguard_stats` - Get Stormguard statistics
-- `/bakery_stats` - Get Bakery active circuits count
+Most endpoints require:
 
-### Traffic Metrics
-- `/current_throughput` - Current network throughput stats
-- `/top_n_downloaders/{start}/{end}` - Top downloaders by traffic
-- `/worst_rtt/{start}/{end}` - Hosts with worst round-trip time
-- `/worst_retransmits/{start}/{end}` - Hosts with worst TCP retransmits
-- `/best_rtt/{start}/{end}` - Hosts with best round-trip time
-- `/host_counter` - All host traffic counters
+- Header: `x-bearer`
+- Value: your Insight license key
 
-### Network Topology
-- `/network_map/{parent}` - Network map from parent node
-- `/full_network_map` - Complete network topology
-- `/top_map_queues/{n}` - Top N queues by traffic
-- `/node_names` - Get node names from IDs
-- `/funnel/{target}` - Analyze traffic funnel to circuit
+## What ISPs Can Do with the API
 
-### Circuit Management
-- `/all_circuits` - List all circuits
-- `/raw_queue_data/{circuit_id}` - Raw queue data for circuit
+### 1) Subscriber/Circuit Lifecycle
 
-### Flow Analysis
-- `/dump_active_flows` - Dump all active flows (slow)
-- `/count_active_flows` - Count of active flows
-- `/top_flows/{flow_type}/{n}` - Top flows by metric type
-- `/flows_by_ip/{ip}` - Flows for specific IP
-- `/flow_duration` - Flow duration statistics
+Provision, update, and remove subscriber/device records.
 
-### Geo & Protocol Stats
-- `/current_endpoints_by_country` - Traffic endpoints by country
-- `/current_endpoint_latlon` - Endpoint geographic coordinates
-- `/ether_protocol_summary` - Ethernet protocol statistics
-- `/ip_protocol_summary` - IP protocol statistics
+- Add or replace:
+  - `POST /overrides/persistent_devices`
+  - `POST /shaped_devices/update`
+- Adjust speeds:
+  - `POST /overrides/adjustments/circuit_speed`
+  - `POST /overrides/adjustments/device_speed`
+- Remove:
+  - `DELETE /overrides/persistent_devices/by_circuit/{circuit_id}`
+  - `DELETE /overrides/persistent_devices/by_device/{device_id}`
+  - `POST /overrides/adjustments/remove_circuit`
+  - `POST /overrides/adjustments/remove_device`
 
-## Newer API Coverage Areas
+### 2) Override and Policy Management
 
-Recent builds expanded API coverage in a few areas. Depending on your version, the API may also include:
+Maintain persistent override policies for circuits, devices, sites, and UISP-specific overrides.
 
-- Alerts and warnings summaries
-- Device and circuit count summaries
-- Single-circuit detail lookups
-- Search result helpers for UI workflows
-- Scheduler and queue-stat detail endpoints
+- `GET/POST/DELETE /overrides/adjustments*`
+- `GET/POST/DELETE /overrides/network_adjustments*`
+- `GET/POST/DELETE /overrides/uisp/bandwidth*`
+- `GET/POST/DELETE /overrides/uisp/routes*`
 
-Use `localhost:9122/api-docs` to confirm exact paths and schemas on your node.
+### 3) Topology and Shaping Input Files
 
-## Capturing an endpoint inventory for your release
+Inspect and update shaping/topology files used by runtime workflows.
 
-For release notes or internal runbooks, capture a snapshot of API paths from your node:
+- `GET /network_json/json`
+- `GET /network_json/text`
+- `POST /network_json/update`
+- `POST /network_json/set_site_speed`
+- `POST /network_json/set_site_speed_batch`
+- `GET /shaped_devices`
+- `POST /shaped_devices/update`
 
-```bash
-curl -s http://localhost:9122/api-docs | jq -r '.paths | keys[]' | sort
-```
+### 4) Monitoring and Diagnostics
 
-Save this output with your release artifacts so operators can compare endpoint differences between versions.
+Read health, scheduler, throughput, flow, queue, and circuit status.
+
+Representative endpoints:
+- `GET /health`
+- `GET /status_snapshot`
+- `GET /scheduler_status`
+- `GET /circuit/{circuit_id}`
+- `GET /search`
+- `GET /current_throughput`
+- `GET /queue_stats_total`
+- `GET /warnings`
+- `GET /urgent`, `GET /urgent/status`
+
+### 5) Control and Reload Operations
+
+Trigger operational control actions when needed.
+
+- `POST /reload_libreqos`
+- `POST /clear_hot_cache`
+
+Treat these as higher-risk actions in production.
+
+## Persistence Model (Important)
+
+Not all writes persist the same way:
+
+- `overrides/*`: persistent policy state.
+- `network_json/set_site_speed*`: transient edits.
+- `network_json/update` and `shaped_devices/update`: direct file replacement, often integration-overwritable.
+
+If integrations are enabled, integration refresh cycles may overwrite direct file edits.
+
+## Recommended Production Workflow
+
+1. Validate endpoint behavior and payload schema in Swagger.
+2. Apply the smallest change needed.
+3. Verify result with read-only checks (`/health`, `/scheduler_status`, circuit/throughput views).
+4. Keep rollback snapshots for config/data-changing operations.
+
+## Deployment Hardening
+
+- Keep API access limited to trusted management networks.
+- Do not expose the API directly to the public Internet.
+- If remote access is needed, use a reverse proxy with TLS and authentication.
+- Restrict inbound access with firewall allowlists.

--- a/docs/v2.0/bridge.md
+++ b/docs/v2.0/bridge.md
@@ -7,7 +7,7 @@ There are two options for the bridge to pass data through your two interfaces:
 - Option A: Regular Linux Bridge (Recommended)
 - Option B: Bifrost XDP-Accelerated Bridge
 
-The regular Linux bridge is recommended for most installations. The Linux Bridge continues to move data even if the lqosd service is in a failed state, making this a generally safer option in scenatios where a backup route is not in place. It works best with Nvidia/Mellanox NICs such as the ConnectX-5 series (which have superior bridge performance), and VM setups using virtualized NICs. The  Bifrost XDP Bridge is recommended for 40G-100G Intel NICs with XDP support.
+The regular Linux bridge is recommended for most installations. The Linux Bridge continues to move data even if the lqosd service is in a failed state, making this a generally safer option in scenarios where a backup route is not in place. It works best with Nvidia/Mellanox NICs such as the ConnectX-5 series (which have superior bridge performance), and VM setups using virtualized NICs. The Bifrost XDP Bridge is recommended for 40G-100G Intel NICs with XDP support.
 
 Below are the instructions to configure Netplan, whether using the Linux Bridge or Bifrost XDP bridge:
 

--- a/docs/v2.0/components.md
+++ b/docs/v2.0/components.md
@@ -1,6 +1,20 @@
 # LibreQoS Software Components
 
 ## Systemd Services
+
+```{mermaid}
+flowchart LR
+    A[CRM/NMS Integrations] --> B[lqos_scheduler]
+    C[network.json + ShapedDevices.csv] --> B
+    D[lqos_overrides.json] --> B
+    B --> E[Queue/shaping plan refresh]
+    E --> F[lqosd]
+    F --> G[XDP/TC shaping runtime]
+    F --> H[WebUI :9123]
+    B --> I[Scheduler Status / Urgent Issues]
+    F --> I
+```
+
 ### lqosd
 
 - Manages actual XDP code.
@@ -34,7 +48,7 @@ sudo journalctl -u lqosd -b
 ```
 Press the End key on the keyboard to take you to the bottom of the log to see the latest updates to that log.
 
-Lqosd will provide specific reasons it failed, such as an interface not being up, an interface lacking multi-queue, or other cocnerns.
+Lqosd will provide specific reasons it failed, such as an interface not being up, an interface lacking multi-queue, or other concerns.
 
 ### Debugging lqos_scheduler
 

--- a/docs/v2.0/configuration-advanced.md
+++ b/docs/v2.0/configuration-advanced.md
@@ -12,6 +12,10 @@ Use these guardrails before deeper tuning:
 
 If results diverge from expectations after edits, use [Troubleshooting](troubleshooting.md) before additional changes.
 
+```{warning}
+If integration mode is enabled, direct edits to `network.json` and `ShapedDevices.csv` can be overwritten by integration refresh cycles. Use integration settings and overrides for durable changes.
+```
+
 ## Configuration via Command Line
 
 You can also modify settings using the command line.
@@ -70,12 +74,12 @@ If shaping appears asymmetric in on-a-stick deployments, verify:
 
 See also [Troubleshooting](troubleshooting.md).
 
-#### Source-of-truth boundary for integration users
+#### Source of Truth Boundary for Integration Users
 
 If integration mode is enabled, integration refresh cycles typically own `ShapedDevices.csv` and may also own `network.json` depending on settings.
 
 - Use WebUI/manual edits for short operational adjustments only.
-- Put permanent changes in your integration system, integration overrides, or declared external source-of-truth workflow.
+- Put permanent changes in your integration system, integration overrides, or declared external source of truth workflow.
 
 #### CRM/NMS Integrations
 
@@ -84,6 +88,16 @@ Learn more about [configuring integrations here](integrations.md).
 ### Runtime overrides (`lqos_overrides.json`)
 
 LibreQoS supports runtime-friendly adjustments via `lqos_overrides.json` in your `lqos_directory`.
+
+```{mermaid}
+flowchart LR
+    A[CRM/NMS or manual files] --> B[Base network.json + ShapedDevices.csv]
+    C[lqos_overrides API/CLI] --> D[lqos_overrides.json]
+    B --> E[lqos_scheduler refresh]
+    D --> E
+    E --> F[Merged shaping plan]
+    F --> G[lqosd active queues/classes]
+```
 
 Use the `lqos_overrides` CLI:
 
@@ -132,6 +146,15 @@ echo "{}" > network.json
 ##### Virtual (logical-only) nodes
 
 LibreQoS supports **virtual nodes** in `network.json` for organizational grouping and monitoring/aggregation in the WebUI/Insight. Virtual nodes are **not** included in the physical HTB shaping tree (they won’t create HTB classes and won’t enforce bandwidth limits).
+
+```{mermaid}
+flowchart TD
+    A[Logical tree includes virtual node] --> B[Scheduler build phase]
+    B --> C[Promote virtual children to nearest non-virtual ancestor]
+    C --> D{Sibling name collision after promotion?}
+    D -->|No| E[Physical shaping tree generated]
+    D -->|Yes| F[Build error: rename/restructure nodes]
+```
 
 To mark a node as virtual, set `"virtual": true` on that node.
 

--- a/docs/v2.0/configuration.md
+++ b/docs/v2.0/configuration.md
@@ -11,11 +11,6 @@ The setup tool configures initial bridge, interface, bandwidth, IP range, and We
 
 Notes:
 - The setup tool is keyboard-driven (`Enter` to select, `Q` to quit without saving).
-- If you need to relaunch it after closing:
-  ```
-  sudo apt remove libreqos
-  sudo apt install ./{deb_url_v1_5}
-  ```
 
 ### Next Steps
 
@@ -67,22 +62,11 @@ qoo_profile_id = "web_browsing"
 - Changes to `qoo_profiles.json` are picked up automatically.
 - If you change `/etc/lqos.conf`, restart `lqosd`.
 
-## Advanced Configuration Reference
+## Need CLI or File-Level Changes?
 
-CLI-driven configuration, direct file editing, and deep reference content were moved here:
+For direct file editing (`/etc/lqos.conf`, `network.json`, `ShapedDevices.csv`), overrides, and deeper topology/circuit reference material, use:
+
 - [Advanced Configuration Reference](configuration-advanced.md)
-
-## Configuration via Command Line
-
-This section moved to [Advanced Configuration Reference](configuration-advanced.md#configuration-via-command-line).
-
-## Network Hierarchy
-
-This section moved to [Advanced Configuration Reference](configuration-advanced.md#network-hierarchy).
-
-## Circuits
-
-This section moved to [Advanced Configuration Reference](configuration-advanced.md#circuits).
 
 ## Related Pages
 

--- a/docs/v2.0/design.md
+++ b/docs/v2.0/design.md
@@ -18,8 +18,17 @@ If you use MPLS with a different tag pattern, you would ideally want to terminat
 - Primary path (low cost) *through* the server running LibreQoS
 - Backup path (high cost) *bypassing* the server running LibreQoS.
 
-#### Diagram
-![Offical Configuration](https://github.com/user-attachments/assets/e5914a58-3ec6-4eb1-b016-8a57582dd082)
+```{mermaid}
+flowchart LR
+    A[Edge Router] -->|OSPF/BGP preferred path| B[LibreQoS inline path]
+    B --> C[Core Router/Switch]
+    A -->|Higher-cost backup path| C
+```
+
+Interpretation:
+1. In normal operation, routing prefers the low-cost inline path through LibreQoS.
+2. If the inline path fails, routing converges to the higher-cost bypass path.
+3. After recovery, routing preference returns traffic to the inline path.
 
 ### Option 1: Using Dynamic Routing (Strongly Recommended)
 

--- a/docs/v2.0/glossary.md
+++ b/docs/v2.0/glossary.md
@@ -1,0 +1,51 @@
+# Glossary
+
+Use this page for consistent definitions used across LibreQoS operator docs.
+
+## Source of truth
+
+The system that owns durable shaping data and should be treated as authoritative.
+
+## Integration refresh cycle
+
+The recurring sync process that imports CRM/NMS data and regenerates shaping inputs.
+
+## Override
+
+A targeted adjustment layered on top of base imported/manual data.
+
+## Persistent change
+
+A change that remains across refresh/restart cycles unless explicitly removed.
+
+## Transient change
+
+A temporary change that may be replaced by later syncs or file refreshes.
+
+## Integration-overwritable
+
+Data that can be replaced by integration sync output in normal operation.
+
+## ShapedDevices.csv
+
+Subscriber/device shaping input file used by scheduler workflows.
+
+## network.json
+
+Topology and node-capacity input file used for hierarchy and shaping structure.
+
+## Mapped circuit
+
+A circuit currently resolved/mapped into active shaping state.
+
+## Mapped circuit limit
+
+The enforced cap on mapped circuits based on current licensing/policy state.
+
+## Scheduler status
+
+Operational state of `lqos_scheduler` as exposed in WebUI/API.
+
+## Immediate runtime impact
+
+An API/UI/CLI action that can affect active shaping behavior shortly after execution.

--- a/docs/v2.0/high-availability.md
+++ b/docs/v2.0/high-availability.md
@@ -13,6 +13,16 @@ This page describes a practical active/backup model for LibreQoS.
 
 One path is active (preferred), and one path is backup (standby). Routing policy controls path selection and failover.
 
+```{mermaid}
+stateDiagram-v2
+    [*] --> PrimaryActive
+    PrimaryActive: Primary path preferred (cost 1)
+    PrimaryActive --> FailoverConverging: Primary failure detected
+    FailoverConverging --> BackupActive: Routing converged to backup (cost 100)
+    BackupActive --> RecoveryValidation: Primary repaired
+    RecoveryValidation --> PrimaryActive: Preference restored and stable
+```
+
 ## OSPF Example (Primary Cost 1, Backup Cost 100)
 
 Use OSPF interface cost to prefer the active path.

--- a/docs/v2.0/insight.md
+++ b/docs/v2.0/insight.md
@@ -74,9 +74,12 @@ This view allows you to identify the general topology of the network from LibreQ
 ### Libby (AI Assistant)
 <img width="1784" height="882" alt="07 libby" src="https://github.com/user-attachments/assets/591a3fd1-3946-44ed-a4fd-e1b1d84b9ef6" />
 
-Libby is LibreQoS Insight's AI Chat Assistant. Libby can help with questions you may have about using LibreQoS or LibreQoS Insight. Libby leverages the official LibreQoS documentation to help you with any questions you may have. Libby can access both live and long-term data - both from synced LibreQoS shaper boxes and from Insight itself. Libby can reply to queries in most major languages with automatic translation.
+Libby is an assistive chat interface for Insight operations and documentation lookup.
 
-You may find new ways to use Libby that we had not originally considered. Please feel welcome to share with us ways you have found Libby to help your workflow.
+Operational guidance:
+- Treat Libby output as assistive guidance, not an authoritative change command.
+- Validate recommendations against current node status, logs, and documented procedures before making production changes.
+- For sensitive/impactful actions, confirm with standard operator workflows (service status, scheduler state, and rollback path).
 
 ### Site Heatmap
 <img width="3830" height="2160" alt="08 heatmap" src="https://github.com/user-attachments/assets/dfaea245-3221-4cea-874b-fd795ac8da33" />

--- a/docs/v2.0/integrations-netzur.md
+++ b/docs/v2.0/integrations-netzur.md
@@ -25,6 +25,9 @@ python3 integrationNetzur.py
 
 The integration regenerates `ShapedDevices.csv` and, unless `always_overwrite_network_json` is disabled, updates `network.json`. Adjust the Integration → Common settings if you need to preserve an existing network map between Netzur syncs.
 
+Overwrite policy:
+- Recommended: keep `always_overwrite_network_json = true` for integration-driven deployments so topology stays aligned with Netzur syncs.
+
 
 ## Related Pages
 

--- a/docs/v2.0/integrations-reference.md
+++ b/docs/v2.0/integrations-reference.md
@@ -1,7 +1,7 @@
 # CRM/NMS Integrations
 
-This page preserves the detailed legacy integration reference.
-For the task-oriented entrypoint, use [CRM/NMS Integrations](integrations.md).
+This page preserves detailed legacy integration reference material.
+Canonical, task-oriented guidance lives in the per-integration pages linked from [CRM/NMS Integrations](integrations.md).
 
   * [Splynx Integration](#splynx-integration)
     + [Topology Strategies](#topology-strategies)
@@ -22,7 +22,7 @@ For the task-oriented entrypoint, use [CRM/NMS Integrations](integrations.md).
   * [Sonar Integration](#sonar-integration)
 
 Most operators use this built-in integration path.
-If you use your own scripts as the source of truth for `network.json` and `ShapedDevices.csv`, start with [Operating Modes and Source of Truth](configuration.md#operating-modes-and-source-of-truth).
+If you use your own scripts as the source of truth for `network.json` and `ShapedDevices.csv`, start with [Operating Modes and Source of Truth](operating-modes.md).
 
 ## What these integrations do
 
@@ -221,12 +221,12 @@ LibreQoS supports multiple topology strategies for UISP integration to balance C
 | `flat` | Only shapes subscribers by service plan speed | Lowest | Maximum performance, simple subscriber-only shaping |
 | `ap_only` | Shapes by service plan and Access Point | Low | Good balance of performance and AP-level control |
 | `ap_site` | Shapes by service plan, Access Point, and Site | Medium | Site-level aggregation with moderate complexity |
-| `full` | Shapes entire network including backhauls, Sites, APs, and clients | Highest | **Recommended for most deployments**. Complete network hierarchy with backhaul awareness |
+| `full` | Shapes entire network including backhauls, Sites, APs, and clients | Highest | Best after topology/overrides are validated and stable |
 
 **Choosing the Right Strategy:**
-- Use `full` for most deployments to get complete network topology awareness including backhaul links
-- Use `ap_site` if you need site-level control but don't need backhaul shaping
-- Use `ap_only` for better performance when site aggregation isn't needed
+- Start with `ap_only` for new deployments and initial validation
+- Move to `ap_site` when you need site-level control but not backhaul shaping
+- Move to `full` after topology quality and overrides are validated, and CPU headroom is confirmed
 - Use `flat` only when maximum performance is critical and you don't need any hierarchy
 
 **Performance Note:** When using `full` strategy with large networks, consider using the **promote_to_root** feature (see [Promote to Root Nodes](#promote-to-root-nodes-performance-optimization) above) to distribute CPU load across multiple cores.
@@ -279,7 +279,7 @@ url = "https://uisp.your_domain.com"
 site = "Root_Site_Name"  # Root site for topology perspective
 
 # Topology Strategy (see table above)
-strategy = "full"  # Recommended for most deployments
+strategy = "ap_only"  # Recommended starting point for new UISP deployments
 
 # Suspension Handling (see table above)
 suspended_strategy = "none"
@@ -299,7 +299,7 @@ commit_bandwidth_multiplier = 0.98  # Set minimum to 98% of maximum (CIR)
 
 # Advanced Options
 ipv6_with_mikrotik = false  # Enable if using DHCPv6 with MikroTik
-always_overwrite_network_json = false  # Set true to rebuild topology each run
+always_overwrite_network_json = true  # Recommended for integration-driven deployments
 exception_cpes = []  # CPE exceptions in ["cpe:parent"] format
 squash_sites = []  # Optional: sites to squash
 enable_squashing = false  # Optional: enable AP/single-entry squashing logic
@@ -342,7 +342,7 @@ To ensure the network.json is always overwritten with the newest version pulled 
 Edit the file to set the value of `always_overwrite_network_json` to `true`.
 Then, run `sudo systemctl restart lqosd`.
 
-You have the option to run integrationUISP.py automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_uisp = true``` in `/etc/lqos.conf`. Once set, run `sudo systemctl restart lqos_scheduler`.
+You have the option to run `uisp_integration` automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_uisp = true``` in `/etc/lqos.conf`. Once set, run `sudo systemctl restart lqos_scheduler`.
 
 ### UISP Overrides
 

--- a/docs/v2.0/integrations-sonar.md
+++ b/docs/v2.0/integrations-sonar.md
@@ -12,6 +12,7 @@ On the first successful run, it will create a ShapedDevices.csv file.
 If a network.json file exists, it will not be overwritten, unless you set ```always_overwrite_network_json = true```.
 You can modify the network.json file to more accurately reflect bandwidth limits.
 ShapedDevices.csv will be overwritten every time the Sonar integration is run.
+Recommended: keep `always_overwrite_network_json = true` for integration-driven deployments so topology stays aligned with Sonar syncs.
 You have the option to run integrationSonar.py automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_sonar = true``` in `/etc/lqos.conf`.
 
 

--- a/docs/v2.0/integrations-splynx.md
+++ b/docs/v2.0/integrations-splynx.md
@@ -10,9 +10,12 @@ Start with this baseline unless you have a known reason to deviate:
 
 - `strategy = "ap_only"` (default, lowest confusion)
 - `enable_splynx = true`
-- `always_overwrite_network_json = false` unless you explicitly want integration to overwrite each run
+- `always_overwrite_network_json = true` for integration-driven deployments
 
 Then run one manual sync and validate outputs before enabling frequent scheduler refresh cycles.
+
+Overwrite policy:
+- Recommended: keep `always_overwrite_network_json = true` so topology stays aligned with Splynx on each refresh cycle.
 
 ### Topology Strategies
 
@@ -98,12 +101,8 @@ To test the Splynx Integration, use
 python3 integrationSplynx.py
 ```
 
-On the first successful run, it will create a ShapedDevices.csv file and network.json.
+On the first successful run, it creates `ShapedDevices.csv` and `network.json`.
 ShapedDevices.csv will be overwritten every time the Splynx integration is run.
-
-To ensure the network.json is always overwritten with the newest version pulled in by the integration, please edit `/etc/lqos.conf` with the command `sudo nano /etc/lqos.conf`.
-Edit the file to set the value of `always_overwrite_network_json` to `true`.
-Then, run `sudo systemctl restart lqosd`.
 
 You have the option to run integrationSplynx.py automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_splynx = true``` under the ```[splynx_integration]``` section in `/etc/lqos.conf`.
 Once set, run `sudo systemctl restart lqos_scheduler`.

--- a/docs/v2.0/integrations-uisp.md
+++ b/docs/v2.0/integrations-uisp.md
@@ -26,13 +26,7 @@ LibreQoS supports multiple topology strategies for UISP integration to balance C
 | `flat` | Only shapes subscribers by service plan speed | Lowest | Maximum performance, simple subscriber-only shaping |
 | `ap_only` | Shapes by service plan and Access Point | Low | Good balance of performance and AP-level control |
 | `ap_site` | Shapes by service plan, Access Point, and Site | Medium | Site-level aggregation with moderate complexity |
-| `full` | Shapes entire network including backhauls, Sites, APs, and clients | Highest | **Recommended for most deployments**. Complete network hierarchy with backhaul awareness |
-
-**Choosing the Right Strategy:**
-- Use `full` for most deployments to get complete network topology awareness including backhaul links
-- Use `ap_site` if you need site-level control but don't need backhaul shaping
-- Use `ap_only` for better performance when site aggregation isn't needed
-- Use `flat` only when maximum performance is critical and you don't need any hierarchy
+| `full` | Shapes entire network including backhauls, Sites, APs, and clients | Highest | Best after topology/overrides are validated and stable |
 
 **Performance Note:** When using `full` strategy with large networks, consider using `promote_to_root` to distribute CPU load across multiple cores.
 
@@ -127,7 +121,7 @@ url = "https://uisp.your_domain.com"
 site = "Root_Site_Name"  # Root site for topology perspective
 
 # Topology Strategy (see table above)
-strategy = "full"  # Recommended for most deployments
+strategy = "ap_only"  # Recommended starting point for new UISP deployments
 
 # Suspension Handling (see table above)
 suspended_strategy = "none"
@@ -147,7 +141,7 @@ commit_bandwidth_multiplier = 0.98  # Set minimum to 98% of maximum (CIR)
 
 # Advanced Options
 ipv6_with_mikrotik = false  # Enable if using DHCPv6 with MikroTik
-always_overwrite_network_json = false  # Set true to rebuild topology each run
+always_overwrite_network_json = true  # Recommended when using UISP integration in production
 exception_cpes = []  # CPE exceptions in ["cpe:parent"] format
 squash_sites = []  # Optional: sites to squash
 enable_squashing = false  # Optional: enable AP/single-entry squashing logic
@@ -174,27 +168,18 @@ Recommended use:
 2. Use `exclude_sites` and `do_not_squash_sites` first for safer topology changes.
 3. Apply `squash_sites`/`enable_squashing` incrementally and validate queue placement after each change.
 
-To test the UISP Integration, use
-
-```shell
-cd /opt/libreqos/src
-sudo /opt/libreqos/src/bin/uisp_integration
-```
-
-On the first successful run, it will create a network.json and ShapedDevices.csv file.
-If a network.json file exists, it will not be overwritten, unless you set ```always_overwrite_network_json = true```.
+On the first successful run, the integration creates `network.json` and `ShapedDevices.csv`.
+If a `network.json` file exists, it is only overwritten when `always_overwrite_network_json = true`.
 
 ShapedDevices.csv will be overwritten every time the UISP integration is run.
 
-To ensure the network.json is always overwritten with the newest version pulled in by the integration, please edit `/etc/lqos.conf` with the command `sudo nano /etc/lqos.conf`.
-Edit the file to set the value of `always_overwrite_network_json` to `true`.
-Then, run `sudo systemctl restart lqosd`.
+For integration-driven deployments, keep `always_overwrite_network_json = true` so topology stays aligned with UISP on each refresh cycle.
 
-You have the option to run integrationUISP.py automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_uisp = true``` in `/etc/lqos.conf`. Once set, run `sudo systemctl restart lqos_scheduler`.
+You have the option to run `uisp_integration` automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_uisp = true``` in `/etc/lqos.conf`. Once set, run `sudo systemctl restart lqos_scheduler`.
 
 ### UISP Overrides
 
-You can also modify the the following files to more accurately reflect your network:
+You can also modify the following files to more accurately reflect your network:
 - integrationUISPbandwidths.csv
 - integrationUISProutes.csv
 

--- a/docs/v2.0/integrations-visp.md
+++ b/docs/v2.0/integrations-visp.md
@@ -20,6 +20,7 @@ Notes:
 - VISP import is GraphQL-based and currently defaults to a flat topology strategy.
 - The integration writes `ShapedDevices.csv` every run.
 - `network.json` is only overwritten when `always_overwrite_network_json = true` (under `[integration_common]`).
+- Recommended: keep `always_overwrite_network_json = true` for integration-driven deployments so topology stays aligned with VISP syncs.
 - VISP auth tokens are cached in `<lqos_directory>/.visp_token_cache_*.json`.
 
 Run a manual import with:

--- a/docs/v2.0/integrations-wispgate.md
+++ b/docs/v2.0/integrations-wispgate.md
@@ -21,10 +21,7 @@ python3 integrationWISPGate.py
 
 On the first successful run, it will create a ShapedDevices.csv file and network.json.
 ShapedDevices.csv will be overwritten every time the WISPGate integration is run.
-
-To ensure the network.json is always overwritten with the newest version pulled in by the integration, please edit `/etc/lqos.conf` with the command `sudo nano /etc/lqos.conf`.
-Edit the file to set the value of `always_overwrite_network_json` to `true`.
-Then, run `sudo systemctl restart lqosd`.
+Recommended: keep `always_overwrite_network_json = true` for integration-driven deployments so topology stays aligned with WISPGate syncs.
 
 You have the option to run integrationWISPGate.py automatically on boot and every X minutes (set by the parameter `queue_refresh_interval_mins`), which is highly recommended. This can be enabled by setting ```enable_wispgate = true``` in `/etc/lqos.conf`.
 Once set, run `sudo systemctl restart lqos_scheduler`.

--- a/docs/v2.0/integrations.md
+++ b/docs/v2.0/integrations.md
@@ -4,7 +4,10 @@
 
 Use this page to choose and configure supported CRM/NMS integrations. Use per-integration pages for specific setup details.
 
-Most operators use built-in integrations. If you use your own scripts as the source of truth for `network.json` and `ShapedDevices.csv`, start with [Operating Modes and Source of Truth](operating-modes.md).
+Need definitions for overwrite/persistence terms? See the [Glossary](glossary.md).
+
+Most operators use built-in integrations.
+If you have not selected a deployment path yet, start with [Quickstart](quickstart.md).
 
 ```{mermaid}
 flowchart LR
@@ -22,7 +25,7 @@ flowchart LR
 | Path | Best fit | Primary source of truth |
 |---|---|---|
 | Built-in integration | Most operators using supported systems | CRM/NMS via LibreQoS integration jobs |
-| Custom source-of-truth | Operators with in-house CRM/NMS sync logic | External generated files (`network.json`, `ShapedDevices.csv`) |
+| Custom source of truth | Operators with in-house CRM/NMS sync logic | External generated files (`network.json`, `ShapedDevices.csv`) |
 
 ## Where in WebUI
 

--- a/docs/v2.0/operating-modes.md
+++ b/docs/v2.0/operating-modes.md
@@ -2,14 +2,16 @@
 
 ## Page Purpose
 
-Use this page to choose and enforce your source-of-truth policy (built-in integrations vs custom source-of-truth) before production changes.
+Use this page to choose and enforce your source of truth policy (built-in integrations vs custom source of truth) before production changes.
+
+Need definitions for terms on this page? See the [Glossary](glossary.md).
 
 ```{mermaid}
 flowchart TD
     A[Choose Source of Truth] --> B{Using built-in CRM/NMS integration?}
     B -->|Yes| C[Built-in Integrations Mode]
     B -->|No| D{Generating files from your own scripts/systems?}
-    D -->|Yes| E[Custom Source-of-Truth Mode]
+    D -->|Yes| E[Custom Source of Truth Mode]
     D -->|No| F[Manual Files Mode]
     C --> G[Integration sync jobs own file refresh]
     E --> H[External script pipeline owns persistence]
@@ -27,14 +29,14 @@ Key behavior:
 - `network.json` overwrite behavior depends on integration settings (for example `always_overwrite_network_json`).
 - Direct manual edits may be overwritten on the next scheduler refresh.
 
-## Custom Source-of-Truth
+## Custom Source of Truth
 
 In this mode, your own scripts/systems generate `network.json` and `ShapedDevices.csv`.
 
 Key behavior:
 - Your external workflow owns persistence.
 - WebUI edits are valid for quick operational changes.
-- Permanent changes should be made in your external source-of-truth workflow.
+- Permanent changes should be made in your external source of truth workflow.
 
 ## Mode Declaration Checklist (Before Go-Live)
 
@@ -48,12 +50,13 @@ Key behavior:
 
 - Single-interface (on-a-stick) and VLAN-heavy designs are valid, but require explicit queue/interface planning and careful validation after changes.
 - Integration mode is best when you want CRM/NMS-driven topology and subscriber lifecycle data to own shaping inputs.
-- If you need strict custom topology behavior not represented by integration output, use custom source-of-truth mode and keep ownership explicit.
+- If you need strict custom topology behavior not represented by integration output, use custom source of truth mode and keep ownership explicit.
 
 See:
 - [Advanced Configuration Reference](configuration-advanced.md)
-- [CRM/NMS Integrations](integrations.md)
 - [Troubleshooting](troubleshooting.md)
+
+If you are running built-in integrations, continue to [CRM/NMS Integrations](integrations.md).
 
 ## Related Pages
 

--- a/docs/v2.0/quickstart.md
+++ b/docs/v2.0/quickstart.md
@@ -2,6 +2,8 @@
 
 Use this page to choose the correct deployment path quickly, then execute only the steps for that path.
 
+Need definitions for key terms? See the [Glossary](glossary.md).
+
 ```{mermaid}
 flowchart TD
     A[Start Here: Quickstart] --> B{Choose Path}
@@ -19,14 +21,6 @@ flowchart TD
 ## Common Install Foundation
 
 Complete this once before any path-specific steps.
-
-```{mermaid}
-flowchart LR
-    A[Review Design + Requirements] --> B[Host Prerequisites + Ubuntu]
-    B --> C[Configure Bridge]
-    C --> D[Install LibreQoS .deb]
-    D --> E[Open WebUI]
-```
 
 1. Review deployment assumptions and capacity:
    - [Deployment Scenarios](design.md)
@@ -61,11 +55,23 @@ sudo systemctl status lqosd lqos_scheduler
 ```bash
 journalctl -u lqosd -u lqos_scheduler --since "10 minutes ago"
 ```
-4. Your chosen source-of-truth is clear:
+4. Your chosen source of truth is clear:
 - integration mode: integration owns refresh of shaping inputs
 - custom/manual mode: your files/scripts own persistence
 
 If these checks fail, continue in [Troubleshooting](troubleshooting.md) before pilot rollout.
+
+## Decide Source of Truth (Do This Once)
+
+Before continuing, choose who owns ongoing shaping data updates:
+
+| If this describes you | Choose this mode | Next page |
+|---|---|---|
+| You use a supported CRM/NMS integration | Built-in integration mode | [CRM/NMS Integrations](integrations.md) |
+| You generate `network.json` and `ShapedDevices.csv` from your own scripts | Custom source of truth mode | [Operating Modes and Source of Truth](operating-modes.md) |
+| You maintain files directly (small/simple networks) | Manual files mode | [Operating Modes and Source of Truth](operating-modes.md) |
+
+Rule: keep one owner for persistent shaping inputs to avoid overwrite conflicts.
 
 ## Testbed / Lab
 
@@ -85,8 +91,6 @@ You want to validate behavior in a controlled environment before inline producti
 ### Then go here
 
 - [Configure LibreQoS](configuration.md)
-- [Operating Modes and Source of Truth](operating-modes.md)
-- [CRM/NMS Integrations](integrations.md)
 - [Troubleshooting](troubleshooting.md)
 
 ## Supported Integration
@@ -110,7 +114,6 @@ Note:
 ### Then go here
 
 - [CRM/NMS Integrations](integrations.md)
-- [Scale Planning and Topology Design](scale-topology.md)
 - [Troubleshooting](troubleshooting.md)
 
 ## Custom Script Integration
@@ -122,20 +125,19 @@ Your CRM/NMS is unsupported and you will generate `network.json` + `ShapedDevice
 ### Do this now
 
 1. Implement script/process to generate and refresh shaping files.
-2. Declare your script outputs as source-of-truth.
+2. Declare your script outputs as source of truth.
 3. Place LibreQoS inline for pilot traffic.
 4. Use WebUI for operational checks and quick adjustments.
 5. Move permanent changes back into your script workflow.
 
 Note:
 - WebUI edits are useful for quick operations.
-- Long-term state should be maintained by your external source-of-truth workflow.
+- Long-term state should be maintained by your external source of truth workflow.
+- File format reference: see `network.json` and `ShapedDevices.csv` sections in [Advanced Configuration Reference](configuration-advanced.md).
 
 ### Then go here
 
 - [Operating Modes and Source of Truth](operating-modes.md)
-- [Advanced Configuration Reference](configuration-advanced.md)
-- [Scale Planning and Topology Design](scale-topology.md)
 - [Troubleshooting](troubleshooting.md)
 
 ## Manual Files (<100 subscribers)
@@ -157,13 +159,11 @@ Recommended only for networks under 100 subscribers.
 ### Then go here
 
 - [Advanced Configuration Reference](configuration-advanced.md)
-- [Operating Modes and Source of Truth](operating-modes.md)
-- [Scale Planning and Topology Design](scale-topology.md)
 - [Troubleshooting](troubleshooting.md)
 
 ## Common First-Run Mistakes
 
-- Unclear source-of-truth ownership between integration and manual edits.
+- Unclear source of truth ownership between integration and manual edits.
 - Choosing deeper topology strategy before confirming baseline health.
 - Skipping post-install service/log checks before pilot traffic.
 

--- a/docs/v2.0/requirements.md
+++ b/docs/v2.0/requirements.md
@@ -2,6 +2,19 @@
 
 LibreQoS can be run either on a dedicated physical server (bare metal) or as a VM. Ubuntu Server 24.04 is the supported operating system.
 
+## Fast Sizing Guide (Start Here)
+
+Use this quick guide before reading full hardware tables:
+
+| Target profile | Typical fit | Starting point |
+|---|---|---|
+| Small | up to ~1,000 subscribers, up to ~1 Gbps | 2+ strong cores, 8 GB RAM, supported 10G-class NIC |
+| Medium | ~1,000-5,000 subscribers, ~1-10 Gbps | 6-16 strong cores, 32-64 GB RAM, supported 10/25G NIC |
+| Large | ~5,000-20,000 subscribers, ~10-50 Gbps | 16-64 strong cores, 64-128 GB RAM, supported 25/50/100G NIC |
+| High-throughput | 50 Gbps+ or deep hierarchy at scale | prioritize high single-thread score, queue/core balance, and validated NIC/XDP support |
+
+Then use the detailed tables below to choose specific hardware.
+
 ## Physical Server (Bare Metal)
 
 ### CPU
@@ -68,7 +81,7 @@ Please [disable Hyper-Threading](prereq.md) (Simultaneous Multi-Threading) in th
 
 ##### MS-01 Notes:
 
-As with any machine running LibreQoS, please be sure to [disable hyperthreading](prereq.md). Specific to the MS-01, please consider [replacing the thermal paste](https://www.youtube.com/watch?v=G70QtUAxomU) to lower CPU temps by about 20 degrees celcius (Note: this may void the warranty).
+As with any machine running LibreQoS, please be sure to [disable hyperthreading](prereq.md). Specific to the MS-01, please consider [replacing the thermal paste](https://www.youtube.com/watch?v=G70QtUAxomU) to lower CPU temps by about 20 degrees Celsius (Note: this may void the warranty).
 
 #### Rackmount Servers (10G to 100G)
 
@@ -113,7 +126,7 @@ Officially supported Network Interface Cards for the two shaping interfaces are 
 
 (*) Intel often vendor-locks SFP+ module compatibility. Check module compatibility before buying. Mellanox does not have this problem.
 
-**We will ONLY provide support for systems using a NIC listed above**. Some other NICs *may* work, but will not be officially supported by LibreQoS. If you want to *test* the compatability of another card, please be aware of these fundamental NIC requirements:
+**We will ONLY provide support for systems using a NIC listed above**. Some other NICs *may* work, but will not be officially supported by LibreQoS. If you want to *test* the compatibility of another card, please be aware of these fundamental NIC requirements:
   * NIC must have multiple TX/RX transmit queues, greater than or equal to the number of CPU cores. [Here's how to check from the command line](https://serverfault.com/questions/772380/how-to-tell-if-nic-has-multiqueue-enabled).
   * NIC must have [XDP driver support](https://github.com/xdp-project/xdp-project/blob/master/areas/drivers/README.org) for high-throughput (10 Gbps+).
 

--- a/docs/v2.0/scale-topology.md
+++ b/docs/v2.0/scale-topology.md
@@ -13,6 +13,19 @@ This guide focuses on designing `network.json` and integration strategy choices 
 
 Use the simplest integration strategy that still meets operational needs:
 
+```{mermaid}
+flowchart TD
+    A[Need hierarchy visibility/control?] -->|No| B[flat]
+    A -->|Yes| C{Need site-level aggregation?}
+    C -->|No| D[ap_only]
+    C -->|Yes| E{Need full backhaul/path shaping?}
+    E -->|No| F[ap_site]
+    E -->|Yes| G[full]
+    G --> H{Single-core saturation?}
+    H -->|Yes| I[Use promote_to_root]
+    H -->|No| J[Keep full strategy]
+```
+
 | Strategy | Typical Scale Fit | Tradeoff |
 |---|---|---|
 | `flat` | Maximum performance, minimal hierarchy | Lowest topology visibility/aggregation |

--- a/docs/v2.0/troubleshooting.md
+++ b/docs/v2.0/troubleshooting.md
@@ -4,6 +4,8 @@
 
 Use this table to jump to the first checks quickly.
 
+Need definitions for licensing/scheduler terms? See the [Glossary](glossary.md).
+
 | Symptom | First check | WebUI location | Next section |
 |---|---|---|---|
 | Cannot access WebUI | `systemctl status lqosd` | N/A (UI unavailable) | No WebUI at x.x.x.x:9123 |
@@ -56,19 +58,14 @@ This will allow you to set up the user again from scratch using the WebUI.
 
 ### No WebUI at x.x.x.x:9123
 
-The WebUI is controlled by the lqosd service. In current builds, most WebUI access failures are caused by `lqosd` not being healthy.
-Check to see if the lqosd service is running:
+The WebUI is controlled by the `lqosd` service. In current builds, most WebUI access failures are caused by `lqosd` not being healthy.
+
+Start by checking:
 ```
 sudo systemctl status lqosd
 ```
 
-If the status is 'failed', examine why using journalctl, which shows the full status of the service:
-```
-journalctl -u lqosd --since "10 minutes ago"
-```
-Press the End key on the keyboard to take you to the bottom of the log to see the latest updates to that log.
-
-Lqosd will provide specific reasons it failed, such as an interface not being up, an interface lacking multi-queue, or other cocnerns.
+Then follow the full workflow in **Service lqosd is not running or failed to start** below.
 
 ### LibreQoS Is Running, But Traffic Not Shaping
 
@@ -114,7 +111,7 @@ journalctl -u lqosd --since "10 minutes ago"
 ```
 Press the End key on the keyboard to take you to the bottom of the log to see the latest updates to that log.
 
-Lqosd will provide specific reasons it failed, such as an interface not being up, an interface lacking multi-queue, or other cocnerns.
+Lqosd will provide specific reasons it failed, such as an interface not being up, an interface lacking multi-queue, or other concerns.
 
 ### Advanced lqosd debug
 
@@ -230,38 +227,6 @@ Operational pattern:
 2. Pull matching logs from `lqosd` and `lqos_scheduler`.
 3. Apply the immediate mitigation.
 4. Acknowledge/clear the issue in UI once stable.
-
-### Systemd segfault
-
-If you experience a segfault in systemd, this is a known issue in systemd [1](https://github.com/systemd/systemd/issues/36031) [2](https://github.com/systemd/systemd/issues/33643).
-To work around it, you can compile systemd from scratch:
-
-### Install build dependencies
-
-```
-sudo apt update
-sudo apt install build-essential git meson libcap-dev libmount-dev libseccomp-dev \
-libblkid-dev libacl1-dev libattr1-dev libcryptsetup-dev libaudit-dev \
-libpam0g-dev libselinux1-dev libzstd-dev libcurl4-openssl-dev
-```
-
-#### Clone systemd repository from github
-
-```
-git clone https://github.com/systemd/systemd.git
-cd systemd
-git checkout v257.5
-meson setup build
-meson compile -C build
-sudo meson install -C build
-```
-
-Then, reboot, and confirm the systemd version with `systemctl --version`
-
-```
-libreqos@libreqos:~$ systemctl --version
-systemd 257 (257.5)
-```
 
 ## Related Pages
 

--- a/index.rst
+++ b/index.rst
@@ -22,6 +22,7 @@ Welcome to the LibreQoS documentation
    :caption: Managing LibreQoS (v1.5 to v2.0):
 
    docs/v2.0/configuration
+   docs/v2.0/glossary
    docs/v2.0/operating-modes
    docs/v2.0/configuration-advanced
    docs/v2.0/integrations


### PR DESCRIPTION
This PR is a broad documentation quality pass across docs/v2.0 and docs-es/v2.0 to
improve clarity for ISP evaluators/operators and keep EN/ES parity.

## What changed

- Simplified and clarified Node API docs (EN/ES) as capability map + Swagger-first
  reference.
- Added new glossary pages:
    - docs/v2.0/glossary.md
    - docs-es/v2.0/glossary-es.md
- Added glossary links from key operator pages:
    - Quickstart, Operating Modes, Integrations, API, Troubleshooting (EN/ES).
- Added glossary pages to both Sphinx indexes:
    - index.rst
    - docs-es/index.rst
- Improved custom source-of-truth path guidance:
    - Added explicit note in Quickstart (EN/ES) pointing operators to network.json and
      ShapedDevices.csv format sections in Advanced Configuration.
- Reduced quickstart navigation overload:
    - Trimmed “Then go here” blocks to primary next-page + troubleshooting for clearer
      flow (EN/ES).
- Standardized “source of truth” terminology (removed mixed hyphenation in primary
  workflow pages).
- Standardized integration overwrite guidance:
    - Clarified always_overwrite_network_json expectations for integration-driven
      deployments across integration pages (EN/ES).
- Cleaned stale/legacy integration-reference inconsistencies:
    - Updated outdated links/defaults and command wording.
- Removed obsolete “compile systemd from source” troubleshooting section (EN/ES).
- Minor wording/typo cleanup (including residual typo in components.md).

## Why

- Make onboarding/evaluation flow easier for ISPs.
- Reduce contradictory or legacy guidance in integration docs.
- Improve operator comprehension of persistence/overwrite behavior.
- Keep Spanish docs aligned with current English guidance.