### PR TITLE
Add NLNet milestone docs: case studies, deployment recipes, and future development inputs (EN/ES)

### DIFF
--- a/docs-es/index.rst
+++ b/docs-es/index.rst
@@ -28,6 +28,9 @@ Bienvenido a la documentación de LibreQoS
    v2.0/stormguard-es
    v2.0/high-availability-es
    v2.0/scale-topology-es
+   v2.0/recipes-es
+   v2.0/case-studies-es
+   v2.0/future-development-inputs-es
    v2.0/update-es
    v2.0/troubleshooting-es
 

--- a/docs-es/v2.0/case-studies-es.md
+++ b/docs-es/v2.0/case-studies-es.md
@@ -1,0 +1,82 @@
+# Casos de Estudio (Anonimizados)
+
+Esta pagina recopila historias cualitativas y anonimizadas de operadores para apoyar adopcion.
+
+Politica de anonimización usada aqui:
+
+- Geografia solo a nivel region/continente.
+- Cantidades de suscriptores en bandas.
+- Se pueden mencionar nombres de integraciones/productos.
+- No se incluyen detalles unicos que identifiquen una red especifica.
+
+## Historia 1: WISP Regional Estandariza en Integracion UISP
+
+- Region: Norteamerica
+- Banda de escala: 1,000-5,000 suscriptores
+- Patron de despliegue: [Receta WISP/FISP](recipes-wisp-fisp-integration-es.md)
+
+Situacion:
+
+- Cambios frecuentes de planes generaban desviacion entre intencion y shaping activo.
+
+Enfoque:
+
+- UISP como fuente de verdad durable.
+- `ShapedDevices.csv` controlado por integracion con politica de overwrite explicita.
+- Estrategia topologica moderada antes de profundizar.
+
+Resultado:
+
+- Menos correcciones manuales tras cambios de planes.
+- Onboarding operativo mas rapido.
+- Comportamiento de colas mas predecible tras syncs recurrentes.
+
+## Historia 2: Operador Maritimo Mejora Calidad con WAN Variable
+
+- Region: rutas globales en multiples zonas oceanicas
+- Banda de escala: 500-1,000 endpoints activos
+- Patron de despliegue: [Receta Maritima StormGuard](recipes-maritime-stormguard-es.md)
+
+Situacion:
+
+- Variabilidad de capacidad WAN causaba oscilaciones de calidad en picos.
+
+Enfoque:
+
+- Modelo con un nodo top-level `Ship`.
+- StormGuard en dry-run y luego activacion de ajustes acotados.
+- Monitoreo de vistas debug/status en ventanas de carga.
+
+Resultado:
+
+- Mayor resiliencia de calidad durante congestion.
+- Mejor visibilidad operacional de decisiones de limites.
+- Proceso de cambios mas seguro por rollout escalonado.
+
+## Historia 3: Red de Hospitalidad Migra a Equidad por Dispositivo
+
+- Region: Europa
+- Banda de escala: 500-1,000 habitaciones / 1,000-5,000 endpoints
+- Patron de despliegue: [Receta Hospitalidad](recipes-hospitality-es.md)
+
+Situacion:
+
+- Shaping por habitacion no lograba equidad en alta ocupacion.
+
+Enfoque:
+
+- Mapeo por dispositivo en pools administrados.
+- Jerarquia shallow y nombres parent estables.
+- Seguimiento de memoria y presion queue/class antes de ampliar.
+
+Resultado:
+
+- Mejor percepcion de equidad entre dispositivos concurrentes.
+- Mejor granularidad para troubleshooting de soporte.
+- Mejor señal para planificacion de capacidad en picos.
+
+## Paginas Relacionadas
+
+- [Recetas de Despliegue](recipes-es.md)
+- [Requisitos del Sistema](requirements-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)

--- a/docs-es/v2.0/future-development-inputs-es.md
+++ b/docs-es/v2.0/future-development-inputs-es.md
@@ -1,0 +1,118 @@
+# Insumos para Desarrollo Futuro
+
+Esta pagina resume insumos recurrentes de feedback operativo revisados para LibreQoS, en el contexto de entregables soportados por NLNet.
+
+## Alcance y Metodo
+
+Ventana de revision:
+
+- 1 de marzo de 2024 a 1 de marzo de 2026 (UTC)
+
+Fuentes de entrada:
+
+- Issues de GitHub del repositorio LibreQoS
+- Canales comunitarios de soporte
+
+Volumen revisado:
+
+- 139 issues de GitHub
+- 10,275 mensajes de canales comunitarios
+
+## Temas Recurrentes
+
+Estos temas ayudan a priorizar trabajo futuro. No son compromisos de release.
+
+## 1) Claridad de UI y confianza operativa
+
+Sintomas ejemplo:
+
+- Vistas en blanco o parcialmente vacias
+- Falta de contexto para diagnostico
+- Senales de estado inconsistentes entre pantallas
+
+Issues representativos:
+
+- [#922 - Flowmap doesn't render](https://github.com/LibreQoE/LibreQoS/issues/922)
+- [#921 - ASN Explorer dropdowns are empty](https://github.com/LibreQoE/LibreQoS/issues/921)
+- [#920 - Tree Overview shows blank on low-traffic boxes](https://github.com/LibreQoE/LibreQoS/issues/920)
+- [#831 - Dashboard goes blank when used by same user in multiple locations](https://github.com/LibreQoE/LibreQoS/issues/831)
+
+## 2) Comportamiento de integraciones y seguridad de fuente de verdad
+
+Sintomas ejemplo:
+
+- Confusion sobre ownership de overwrite de archivos de shaping
+- Casos borde de matching en integraciones
+- Defaults poco claros durante onboarding
+
+Issues representativos:
+
+- [#860 - always_overwrite_network_json default behavior confusion](https://github.com/LibreQoE/LibreQoS/issues/860)
+- [#899 - UISP: always_overwrite_network_json=false and missing ShapedDevices.csv](https://github.com/LibreQoE/LibreQoS/issues/899)
+- [#845 - UISP: multi-services with same site name](https://github.com/LibreQoE/LibreQoS/issues/845)
+- [#699 - UISP: trailing spaces break matching](https://github.com/LibreQoE/LibreQoS/issues/699)
+
+## 3) Friccion en onboarding y despliegue temprano
+
+Sintomas ejemplo:
+
+- Quiebres de primer arranque
+- Confusion en flujo de startup/configuracion
+- Mismatch entre defaults de instalador y expectativas
+
+Issues representativos:
+
+- [#859 - Broken default ShapedDevices.csv from setup tool](https://github.com/LibreQoE/LibreQoS/issues/859)
+- [#858 - Config tool webusers flow break](https://github.com/LibreQoE/LibreQoS/issues/858)
+- [#728 - Default installation bridge-mode mismatch](https://github.com/LibreQoE/LibreQoS/issues/728)
+- [#667 - Add YAML creation to setup installer](https://github.com/LibreQoE/LibreQoS/issues/667)
+
+## 4) Guardrails de escala/topologia y advertencias proactivas
+
+Sintomas ejemplo:
+
+- Presion de profundidad de colas en jerarquias complejas
+- Necesidad de mejor visibilidad de riesgo de overflow
+- Higiene de parent nodes y claridad topologica
+
+Issues representativos:
+
+- [#913 - Tree verbosity and HTB depth pressure](https://github.com/LibreQoE/LibreQoS/issues/913)
+- [#801 - Visible warning for TC ID overflow](https://github.com/LibreQoE/LibreQoS/issues/801)
+- [#856 - Improve no-parent circuit warnings](https://github.com/LibreQoE/LibreQoS/issues/856)
+- [#560 - htb too many events under load](https://github.com/LibreQoE/LibreQoS/issues/560)
+
+## 5) Ajuste de rendimiento y encaje de hardware
+
+Sintomas ejemplo:
+
+- Comportamiento de utilizacion de cores en CPUs heterogeneas
+- Preocupaciones de crecimiento de memoria
+- Ajuste de throughput/headroom por clase de hardware
+
+Issues representativos:
+
+- [#928 - Detect e-cores and avoid shaping load there](https://github.com/LibreQoE/LibreQoS/issues/928)
+- [#651 - Memory growth even when gather_stats is false](https://github.com/LibreQoE/LibreQoS/issues/651)
+- [#578 - Resource footprint for 100 Gbit fiber links](https://github.com/LibreQoE/LibreQoS/issues/578)
+- [#526 - Performance improvements during reloading](https://github.com/LibreQoE/LibreQoS/issues/526)
+
+## Direcciones Candidatas Bajo Evaluacion
+
+1. Mejorar diagnostico guiado y claridad de empty states en WebUI.
+2. Hacer mas explicito ownership de fuente de verdad y overwrite.
+3. Expandir validaciones pre-flight y manejo de edge cases en integraciones.
+4. Reforzar guardrails de escala y ergonomia de advertencias tempranas.
+5. Expandir runbooks para arquitecturas comunes.
+6. Mejorar guia de encaje rendimiento/topologia/hardware.
+
+## Fuera de Alcance
+
+- Esta pagina es un resumen de insumos de planificacion, no un roadmap comprometido.
+- Incluir un issue aqui no garantiza objetivo de release ni fecha de implementacion.
+
+## Paginas Relacionadas
+
+- [Recetas de Despliegue](recipes-es.md)
+- [Casos de Estudio (Anonimizados)](case-studies-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-es.md
+++ b/docs-es/v2.0/recipes-es.md
@@ -1,0 +1,41 @@
+# Recetas de Despliegue
+
+Esta pagina agrupa recetas repetibles y orientadas a escenarios.
+
+Use estas recetas despues de completar instalacion base y validacion de salud en [Quickstart](quickstart-es.md).
+
+## Alcance
+
+- Estas recetas cubren patrones de despliegue soportados.
+- Cada receta se enfoca en implementacion practica, validacion y rollback.
+- Los ejemplos de enrutamiento usan MikroTik RouterOS v7 cuando aplica.
+
+## Indice de Recetas
+
+1. [WISP/FISP con integracion CRM/NMS incorporada](recipes-wisp-fisp-integration-es.md)
+2. [Maritimo con WAN variable y StormGuard](recipes-maritime-stormguard-es.md)
+3. [Event WiFi con shaping por grupos de subred](recipes-event-wifi-es.md)
+4. [Hoteleria y hospitalidad con shaping por dispositivo](recipes-hospitality-es.md)
+5. [Fabric switch-centric con bypass de mantenimiento (incluye variante SD-WAN)](recipes-switch-fabric-sdwan-es.md)
+6. [Despliegue Proxmox VM con 3 NICs](recipes-proxmox-vm-es.md)
+
+```{toctree}
+:hidden:
+
+recipes-wisp-fisp-integration-es
+recipes-maritime-stormguard-es
+recipes-event-wifi-es
+recipes-hospitality-es
+recipes-switch-fabric-sdwan-es
+recipes-proxmox-vm-es
+```
+
+## Paginas Relacionadas
+
+- [Quickstart](quickstart-es.md)
+- [Modos de Operacion y Fuente de Verdad](operating-modes-es.md)
+- [Integraciones CRM/NMS](integrations-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)
+- [StormGuard](stormguard-es.md)
+- [Alta Disponibilidad y Dominios de Falla](high-availability-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-event-wifi-es.md
+++ b/docs-es/v2.0/recipes-event-wifi-es.md
@@ -1,0 +1,49 @@
+# Receta: Event WiFi con Shaping por Grupos de Subred
+
+Use este patron para redes de eventos de alta densidad y corta duracion, donde agrupar clientes por subred es mas operativo que administrar ciclo de vida por dispositivo.
+
+## Ajuste
+
+- Mejor para: eventos temporales y alta rotacion de clientes.
+- Evitar cuando: necesita enforcement estricto por dispositivo a largo plazo.
+
+## Patron
+
+- Defina un circuito por grupo de subred (por ejemplo por `/24`).
+- Mantenga topologia simple (`flat` o jerarquia poco profunda).
+- Use `Parent Node` explicito en `ShapedDevices.csv`.
+
+Ejemplo de fila:
+
+```text
+Circuit ID,Circuit Name,Device ID,Device Name,Parent Node,MAC,IPv4,IPv6,Download Min Mbps,Upload Min Mbps,Download Max Mbps,Upload Max Mbps,Comment
+EVT-24-101,Event Hall A Subnet,EVT-24-101,HallA-Clients,Event_Core,,100.64.101.0/24,,10,10,300,300,Temporary event subnet group
+```
+
+Si el modo de integracion controla sus archivos de shaping, estas ediciones directas pueden sobrescribirse en el siguiente sync.
+
+## Implementacion
+
+1. Confirme un solo owner para datos de shaping.
+2. Prepare circuitos por subred para segmentos esperados.
+3. Mantenga jerarquia shallow para reducir churn de colas.
+4. Valide en WebUI antes de abrir trafico de registro.
+
+## Checklist de Validacion
+
+1. El trafico aparece bajo los circuitos esperados.
+2. Scheduler se mantiene saludable bajo churn de clientes.
+3. Presion de queue/class estable (incluyendo overflow warnings).
+4. Vistas Flow/Tree coherentes en picos.
+
+## Rollback
+
+1. Restaure `ShapedDevices.csv` y `network.json` pre-evento.
+2. Reinicie scheduler.
+3. Valide comportamiento base.
+
+## Paginas Relacionadas
+
+- [Referencia de Configuracion Avanzada](configuration-advanced-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-hospitality-es.md
+++ b/docs-es/v2.0/recipes-hospitality-es.md
@@ -1,0 +1,50 @@
+# Receta: Hoteleria y Hospitalidad con Shaping por Dispositivo
+
+Use este patron cuando cada dispositivo cliente debe recibir comportamiento de circuito propio.
+
+## Ajuste
+
+- Mejor para: entornos de hospitalidad con pools de direcciones previsibles y objetivos de equidad por dispositivo.
+- Evitar cuando: el conteo proyectado de circuitos por dispositivo supera limites practicos de RAM/colas.
+
+## Guardrails de Capacidad
+
+El shaping por dispositivo eleva rapidamente la cantidad de circuitos. Valide:
+
+1. RAM segun volumen esperado ([Requisitos del Sistema](requirements-es.md)).
+2. Presion de queue/class y estado de urgencias bajo carga realista.
+3. Impacto de CAKE qdisc (memoria y overhead operativo).
+4. Si pruebas pico muestran presion persistente o crecimiento de memoria inseguro, migre a agrupacion por habitacion o subred.
+
+## Patron
+
+- Construya una lista enumerada de IPv4 posibles por dispositivo.
+- Asigne un circuito por IP de dispositivo.
+- Use grupos de parent estables (piso/edificio/ala).
+
+## Ejemplo
+
+```text
+Circuit ID,Circuit Name,Device ID,Device Name,Parent Node,MAC,IPv4,IPv6,Download Min Mbps,Upload Min Mbps,Download Max Mbps,Upload Max Mbps,Comment,sqm
+HTL-ROOM-1204,Room1204-Device,HTL-ROOM-1204,Room1204-DeviceA,Floor12,,100.70.12.44,,2,2,50,20,Hospitality per-device plan,cake
+```
+
+## Checklist de Validacion
+
+1. Mapeo dispositivo-circuito correcto y estable.
+2. Sin urgencias persistentes de limites queue/class.
+3. Memoria dentro de envelope esperado en ocupacion pico.
+4. RTT/retransmisiones aceptables en horas de mayor contencion.
+
+## Rollback
+
+1. Pase de per-device a per-room o per-subnet.
+2. Reduzca conteo de circuitos y recargue.
+3. Revalide salud de scheduler y presion de colas.
+
+## Paginas Relacionadas
+
+- [Requisitos del Sistema](requirements-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)
+- [CAKE](cake-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-maritime-stormguard-es.md
+++ b/docs-es/v2.0/recipes-maritime-stormguard-es.md
@@ -1,0 +1,95 @@
+# Receta: Maritimo con WAN Variable y StormGuard
+
+Use este patron cuando la capacidad WAN cambia de forma material en el tiempo (por ejemplo, enlaces satelitales) y necesita ajustes acotados de limites de colas.
+
+## Ajuste
+
+- Mejor para: un barco o dominio WAN de alta variacion representado por un nodo top-level.
+- Evitar cuando: pretende administrar decenas o cientos de targets con StormGuard.
+
+## Prerrequisitos
+
+1. Complete [Quickstart](quickstart-es.md).
+2. Revise alcance y limites en [StormGuard](stormguard-es.md).
+3. Confirme comportamiento de fuente de verdad en [Modos de Operacion](operating-modes-es.md).
+
+## Patron de Topologia
+
+Use un nodo top-level llamado `Ship`, con subnodos debajo.
+
+```json
+{
+  "Ship": {
+    "downloadBandwidthMbps": 1000,
+    "uploadBandwidthMbps": 200,
+    "children": {
+      "Deck_A": {
+        "downloadBandwidthMbps": 500,
+        "uploadBandwidthMbps": 100
+      },
+      "Deck_B": {
+        "downloadBandwidthMbps": 500,
+        "uploadBandwidthMbps": 100
+      }
+    }
+  }
+}
+```
+
+## Configuracion de StormGuard
+
+```toml
+[stormguard]
+enabled = true
+dry_run = true
+targets = ["Ship"]
+minimum_download_percentage = 0.5
+minimum_upload_percentage = 0.5
+log_file = "/var/log/stormguard.csv"
+```
+
+## Ilustracion de Loop de Control
+
+```{mermaid}
+flowchart LR
+    METRICS[Metricas del nodo Ship\nthroughput, RTT, contexto de perdida]
+    SG[Evaluador StormGuard]
+    LIMITS[Ajustes acotados de limites]
+    QOE[Calidad observada del enlace]
+
+    METRICS --> SG
+    SG --> LIMITS
+    LIMITS --> QOE
+    QOE --> METRICS
+```
+
+## Secuencia de Rollout
+
+1. Inicie con `dry_run = true`.
+2. Observe multiples periodos de carga.
+3. Confirme que ajustes son razonables y acotados.
+4. Cambie a `dry_run = false`.
+
+## Checklist de Validacion
+
+1. Las vistas de StormGuard muestran `Ship` como target activo.
+2. Los limites efectivos se ajustan bajo congestion y respetan pisos.
+3. Mejora RTT/retransmisiones en periodos estresados.
+4. No hay drift de nombres entre target y jerarquia actual.
+
+## Rollback
+
+1. Ponga `[stormguard] enabled = false` (o vuelva a `dry_run = true`).
+2. Reinicie servicios:
+
+```bash
+sudo systemctl restart lqosd lqos_scheduler
+```
+
+3. Verifique estabilidad sin ajustes adaptativos.
+
+## Paginas Relacionadas
+
+- [StormGuard](stormguard-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-proxmox-vm-es.md
+++ b/docs-es/v2.0/recipes-proxmox-vm-es.md
@@ -1,0 +1,158 @@
+# Receta: Despliegue Proxmox VM con 3 NICs
+
+Use este patron para despliegues VM donde LibreQoS corre en Ubuntu Server 24.04 con interfaces dedicadas de gestion y shaping.
+
+## Ajuste
+
+- Mejor para: operadores estandarizados en Proxmox.
+- Evitar cuando: objetivos de throughput/latencia requieren mayor headroom de bare metal.
+
+## Seleccion de Patron
+
+- Patron A (recomendado): bridges dedicados para shaping (`vmbr1`, `vmbr2`)
+- Patron B (alternativo): bridge unico (`vmbr0`) con virtio NICs etiquetadas por VLAN
+
+## Roles de Interfaces
+
+- `ens18`: gestion (IP asignada)
+- `ens19`: shaping puerto 1
+- `ens20`: shaping puerto 2
+
+`ens19` y `ens20` son interfaces de shaping para LibreQoS (`to_internet`/`to_network`).
+`ens18`/`ens19`/`ens20` son nombres de ejemplo; verifique nombres reales en su VM.
+
+## Patron A (Recomendado): Bridges de Shaping Dedicados
+
+Intencion del host:
+
+- `vmbr1` respaldado por ruta de shaping A en el host.
+- `vmbr2` respaldado por ruta de shaping B en el host.
+- Gestion normalmente sin tag en `vmbr0`.
+
+Referencia de mapeo host->guest:
+
+| Puerto/ruta host Proxmox | Bridge | vNIC VM | NIC guest | Rol LibreQoS |
+|---|---|---|---|---|
+| Uplink gestion (ejemplo `eno1`) | `vmbr0` | `net0` | `ens18` | Gestion |
+| Ruta shaping A (ejemplo `eno2`) | `vmbr1` | `net1` | `ens19` | `to_internet` o `to_network` |
+| Ruta shaping B (ejemplo `eno3`) | `vmbr2` | `net2` | `ens20` | opuesto de `ens19` |
+
+Ejemplo en Proxmox UI:
+
+- `net0`: `virtio`, `bridge=vmbr0` (gestion)
+- `net1`: `virtio`, `bridge=vmbr1`, `multiqueue=<cantidad vCPU>` (shaping A)
+- `net2`: `virtio`, `bridge=vmbr2`, `multiqueue=<cantidad vCPU>` (shaping B)
+
+```{mermaid}
+flowchart LR
+    subgraph HOST[Host Proxmox]
+        H0[vmbr0 (gestion untagged)]
+        H1[vmbr1 (ruta shaping A)]
+        H2[vmbr2 (ruta shaping B)]
+    end
+
+    subgraph VM[LibreQoS VM]
+        N0[net0 virtio]
+        N1[net1 virtio]
+        N2[net2 virtio]
+        E18[ens18 gestion]
+        E19[ens19 shaping A]
+        E20[ens20 shaping B]
+    end
+
+    H0 --> N0 --> E18
+    H1 --> N1 --> E19
+    H2 --> N2 --> E20
+```
+
+## Patron B (Alternativo): Bridge Unico con NICs Taggeadas
+
+Intencion del host:
+
+- `vmbr0` lleva trunk de VLANs de gestion y shaping.
+- Gestion normalmente taggeada en este patron.
+
+Ejemplo en Proxmox UI:
+
+- `net0`: `virtio`, `bridge=vmbr0`, `tag=99` (gestion ejemplo)
+- `net1`: `virtio`, `bridge=vmbr0`, `tag=110`, `multiqueue=<cantidad vCPU>` (shaping A)
+- `net2`: `virtio`, `bridge=vmbr0`, `tag=120`, `multiqueue=<cantidad vCPU>` (shaping B)
+
+Notas:
+
+- Los VLAN IDs son ejemplos; use los de su diseno.
+- Con tag en Proxmox NIC, normalmente el trafico llega sin tag dentro del guest NIC.
+
+```{mermaid}
+flowchart LR
+    subgraph HOST[Host Proxmox]
+        T0[vmbr0 trunk VLAN]
+    end
+
+    subgraph VM[LibreQoS VM]
+        PN0[net0 virtio tag 99]
+        PN1[net1 virtio tag 110]
+        PN2[net2 virtio tag 120]
+        PE18[ens18 gestion]
+        PE19[ens19 shaping A]
+        PE20[ens20 shaping B]
+    end
+
+    T0 --> PN0 --> PE18
+    T0 --> PN1 --> PE19
+    T0 --> PN2 --> PE20
+```
+
+## Prerrequisitos
+
+1. Revise [Prerequisites](prereq-es.md) y [System Requirements](requirements-es.md).
+2. Habilite multiqueue en vNICs de shaping y ajuste al numero de vCPUs.
+3. Para >10 Gbps, use passthrough cuando corresponda.
+
+## Patron Netplan
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    ens18:
+      addresses:
+        - 100.99.0.10/24
+      routes:
+        - to: default
+          via: 100.99.0.1
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+    ens19:
+      dhcp4: no
+      dhcp6: no
+    ens20:
+      dhcp4: no
+      dhcp6: no
+```
+
+Luego configure el comportamiento bridge segun [Configure Shaping Bridge](bridge-es.md).
+
+## Checklist de Validacion
+
+1. Confirme que la VM usa Patron A o B.
+2. Patron A: confirme `net1->vmbr1` y `net2->vmbr2`.
+3. Patron B: confirme `net1->vmbr0 tag 110` y `net2->vmbr0 tag 120` (o sus tags).
+4. Confirme `to_internet` / `to_network` en `ens19`/`ens20`.
+5. Confirme que `ens19` y `ens20` no tienen IP en Netplan guest.
+6. Confirme salud de scheduler y daemon.
+7. Confirme throughput/latencia esperados para envelope VM.
+8. Confirme ausencia de shaping asimetrico.
+
+## Rollback
+
+1. Mueva trafico a ruta previa o bypass.
+2. Revierta configuracion de interfaces/colas de VM.
+3. Reinicie servicios y revalide.
+
+## Paginas Relacionadas
+
+- [Prerequisites](prereq-es.md)
+- [System Requirements](requirements-es.md)
+- [Configure Shaping Bridge](bridge-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-switch-fabric-sdwan-es.md
+++ b/docs-es/v2.0/recipes-switch-fabric-sdwan-es.md
@@ -1,0 +1,125 @@
+# Receta: Fabric Switch-Centric con Bypass de Mantenimiento (incluye SD-WAN)
+
+Use este patron cuando el core de red es switch-centric y basado en VLANs, y necesita rutas primarias con shaping mas rutas bypass para mantenimiento sin downtime.
+
+## Ajuste
+
+- Mejor para: fabrics con ingenieria L2/L3 explicita.
+- Evitar cuando: no hay ownership claro de rutas y parent mapping.
+
+## Patron Topologico
+
+VLANs primarias (con shaping via LibreQoS):
+
+1. `EdgeA <-> CoreA`
+2. `EdgeA <-> CoreB`
+3. `EdgeB <-> CoreA`
+4. `EdgeB <-> CoreB`
+
+Deben existir VLANs bypass, con politica de routing que prefiera la ruta con shaping en estado normal.
+
+## Ilustraciones Topologicas
+
+### Conjunto de VLANs con Shaping
+
+```{mermaid}
+flowchart LR
+    EA[Router EdgeA]
+    EB[Router EdgeB]
+    SW[Par de Switches SW1/SW2]
+    LQ[LibreQoS Bridge]
+    CA[Router CoreA]
+    CB[Router CoreB]
+
+    EA --> SW
+    EB --> SW
+    SW -->|VLANs Shaped 110,120,210,220| LQ
+    LQ --> SW
+    SW --> CA
+    SW --> CB
+```
+
+Mapeo shaped:
+
+- VLAN 110: `EdgeA <-> CoreA` (via LibreQoS)
+- VLAN 120: `EdgeA <-> CoreB` (via LibreQoS)
+- VLAN 210: `EdgeB <-> CoreA` (via LibreQoS)
+- VLAN 220: `EdgeB <-> CoreB` (via LibreQoS)
+
+### Conjunto de VLANs Bypass
+
+```{mermaid}
+flowchart LR
+    EA[Router EdgeA]
+    EB[Router EdgeB]
+    SW[Par de Switches SW1/SW2]
+    CA[Router CoreA]
+    CB[Router CoreB]
+
+    EA -.-> SW
+    EB -.-> SW
+    SW -. VLANs Bypass 310,320,410,420 .-> CA
+    SW -. VLANs Bypass 310,320,410,420 .-> CB
+```
+
+Mapeo bypass:
+
+- VLAN 310: `EdgeA <-> CoreA`
+- VLAN 320: `EdgeA <-> CoreB`
+- VLAN 410: `EdgeB <-> CoreA`
+- VLAN 420: `EdgeB <-> CoreB`
+
+## Ejemplo MikroTik RouterOS v7 (OSPF conceptual)
+
+```text
+/routing ospf instance
+add name=default-v2 router-id=10.255.255.1
+
+/routing ospf area
+add name=backbone-v2 area-id=0.0.0.0 instance=default-v2
+
+/routing ospf interface-template
+add interfaces=vlan-edgea-corea-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgea-coreb-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgeb-corea-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgeb-coreb-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgea-corea-bypass area=backbone-v2 cost=200
+add interfaces=vlan-edgea-coreb-bypass area=backbone-v2 cost=200
+add interfaces=vlan-edgeb-corea-bypass area=backbone-v2 cost=200
+add interfaces=vlan-edgeb-coreb-bypass area=backbone-v2 cost=200
+```
+
+## Implementacion
+
+1. Construya y verifique VLANs primarias y bypass.
+2. Mantenga preferencia de ruta deterministica (OSPF/BGP).
+3. Coloque LibreQoS inline en rutas primarias.
+4. Valide failover/failback en ventana de mantenimiento.
+
+## Checklist de Validacion
+
+1. Estado normal: trafico en ruta primaria con shaping.
+2. Falla o mantenimiento: convergencia hacia bypass.
+3. Recuperacion: retorno estable a ruta primaria.
+4. Salud de WebUI estable durante transiciones.
+
+## Variante SD-WAN
+
+Para SD-WAN use el mismo modelo:
+
+- Underlay primario pasando por ruta LibreQoS.
+- Underlay secundario como bypass de mantenimiento/falla.
+- Nombres de nodos y relaciones parent estables.
+
+## Rollback
+
+1. Fuerce preferencia temporal a bypass.
+2. Restaure politica previa de ruta LibreQoS.
+3. Rehabilite preferencia de ruta primary tras verificar.
+
+## Paginas Relacionadas
+
+- [Alta Disponibilidad y Dominios de Falla](high-availability-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)
+- [Configurar Bridge de Shaping](bridge-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs-es/v2.0/recipes-wisp-fisp-integration-es.md
+++ b/docs-es/v2.0/recipes-wisp-fisp-integration-es.md
@@ -1,0 +1,88 @@
+# Receta: WISP/FISP con Integracion CRM/NMS Incorporada
+
+Use este patron cuando su operacion este centrada en un CRM/NMS soportado (UISP, Splynx, Netzur, VISP, WISPGate, Powercode o Sonar).
+
+## Ajuste
+
+- Mejor para: cambios recurrentes de abonados, planes gestionados en CRM y automatizacion de ciclo de vida.
+- Evitar cuando: su fuente de verdad durable es un pipeline externo propio.
+
+## Prerrequisitos
+
+1. Complete [Quickstart](quickstart-es.md) y pase el health gate.
+2. Confirme la integracion en [Integraciones CRM/NMS](integrations-es.md).
+3. Confirme propiedad de fuente de verdad en [Modos de Operacion](operating-modes-es.md).
+
+## Implementacion
+
+1. Configure credenciales y parametros en WebUI (`Configuration -> Integrations`).
+2. Para despliegues guiados por integracion, mantenga `always_overwrite_network_json = true`.
+3. Elija la estrategia de topologia mas liviana que cumpla su necesidad.
+
+| Necesidad | Estrategia sugerida |
+|---|---|
+| Maximo rendimiento, minima jerarquia | `flat` |
+| Jerarquia/control moderado | `ap_only` o `ap_site` |
+| Requiere shaping completo de rutas/backhaul | `full` |
+
+4. Habilite refresco recurrente en `/etc/lqos.conf` (por ejemplo `enable_uisp = true`, `enable_splynx = true`, `enable_netzur = true`; use la bandera que corresponda a su integracion).
+5. Reinicie scheduler y verifique sincronizacion:
+
+```bash
+sudo systemctl restart lqos_scheduler
+sudo systemctl status lqos_scheduler
+journalctl -u lqos_scheduler --since "15 minutes ago"
+```
+
+## Ilustracion de Flujo de Datos
+
+```{mermaid}
+flowchart LR
+    CRM[CRM/NMS]
+    INT[Proceso de Integracion]
+    SD[ShapedDevices.csv]
+    NJ[network.json]
+    SCH[lqos_scheduler]
+    LQD[lqosd]
+    UI[Estado en WebUI]
+    MAN[Ediciones manuales sobre archivos generados]
+
+    CRM --> INT
+    INT --> SD
+    INT --> NJ
+    SD --> SCH
+    NJ --> SCH
+    SCH --> LQD
+    SCH --> UI
+    MAN -. Puede sobrescribirse en el siguiente sync .-> SD
+    MAN -. Puede sobrescribirse en el siguiente sync .-> NJ
+```
+
+## Checklist de Validacion
+
+1. `ShapedDevices.csv` se regenera como se espera tras cada sync.
+2. El comportamiento de `network.json` coincide con la politica de overwrite.
+3. La salud de vistas en WebUI es correcta.
+4. Revise `Scheduler Status` y `Urgent Issues`.
+5. Revise `Network Tree Overview` y `Flow Map`.
+6. La colocacion de padres y distribucion de colas se ve estable.
+
+## Fallas Comunes
+
+- Conflicto entre ediciones manuales e integracion.
+- Profundidad topologica excesiva y presion de CPU.
+- Advertencias no detectadas de circuitos sin parent.
+
+## Rollback
+
+1. Vuelva a la estrategia previa estable.
+2. Restaure backups de shaping si aplica.
+3. Reinicie `lqos_scheduler` y `lqosd`.
+4. Confirme que urgencias se limpian y vistas repueblan.
+
+## Paginas Relacionadas
+
+- [Integraciones CRM/NMS](integrations-es.md)
+- [Planeacion de Escala y Topologia](scale-topology-es.md)
+- [Referencia de Configuracion Avanzada](configuration-advanced-es.md)
+- [Troubleshooting](troubleshooting-es.md)

--- a/docs/v2.0/case-studies.md
+++ b/docs/v2.0/case-studies.md
@@ -1,0 +1,73 @@
+# Case Studies (Anonymized)
+
+This page collects qualitative, anonymized operator stories for adoption guidance.
+
+Anonymization policy used here:
+
+- Geography is kept at region/continent level only.
+- Subscriber counts are shown as bands.
+- Product/integration names may be included.
+- No uniquely identifying network details are included.
+
+## Story 1: Regional WISP Standardized on UISP Integration
+
+- Region: North America
+- Scale band: 1,000-5,000 subscribers
+- Deployment pattern: [WISP/FISP integration recipe](recipes-wisp-fisp-integration.md)
+
+Situation:
+- Frequent subscriber plan changes were creating drift between intended and active shaping behavior.
+
+Approach:
+- Adopted built-in UISP integration as durable source of truth.
+- Standardized on integration-owned `ShapedDevices.csv` with explicit overwrite policy.
+- Started with moderate hierarchy depth before considering deeper topology.
+
+Outcome:
+- Fewer manual corrections after plan changes.
+- Faster onboarding for operations staff.
+- More predictable queue behavior after recurring sync cycles.
+
+## Story 2: Maritime Operator Stabilized Quality on Variable WAN
+
+- Region: global routes across multiple ocean regions
+- Scale band: 500-1,000 active client endpoints
+- Deployment pattern: [Maritime StormGuard recipe](recipes-maritime-stormguard.md)
+
+Situation:
+- WAN capacity variability caused recurring quality swings during peak periods.
+
+Approach:
+- Modeled vessel traffic under a single top-level `Ship` node.
+- Enabled StormGuard in dry-run, then moved to live bounded adjustments.
+- Monitored debug/status views during busy windows.
+
+Outcome:
+- Better quality resilience during congestion events.
+- Clearer operational visibility into adaptive limit decisions.
+- Safer change process through staged dry-run rollout.
+
+## Story 3: Hospitality Network Shifted to Per-Device Fairness
+
+- Region: Europe
+- Scale band: 500-1,000 rooms / 1,000-5,000 device endpoints
+- Deployment pattern: [Hospitality per-device recipe](recipes-hospitality.md)
+
+Situation:
+- Shared room-level shaping led to fairness complaints in high-occupancy periods.
+
+Approach:
+- Moved to per-device circuit mapping for managed address pools.
+- Kept hierarchy shallow and parent naming stable.
+- Tracked memory and queue/class pressure before broader rollout.
+
+Outcome:
+- Improved perceived fairness across concurrently active guest devices.
+- Better troubleshooting granularity at support desk level.
+- Clearer capacity planning signals for peak occupancy periods.
+
+## Related Pages
+
+- [Deployment Recipes](recipes.md)
+- [System Requirements](requirements.md)
+- [Scale Planning and Topology Design](scale-topology.md)

--- a/docs/v2.0/future-development-inputs.md
+++ b/docs/v2.0/future-development-inputs.md
@@ -1,0 +1,118 @@
+# Future Development Inputs
+
+This page summarizes recurring operator feedback inputs reviewed for LibreQoS, supported by NLNet deliverable work.
+
+## Scope and Method
+
+Review window:
+
+- March 1, 2024 through March 1, 2026 (UTC)
+
+Input sources:
+
+- GitHub issues from the LibreQoS repository
+- Community support channels
+
+Reviewed volume:
+
+- 139 GitHub issues
+- 10,275 community-channel messages
+
+## Recurring Themes
+
+These themes are intended to help prioritize future work. They are not release commitments.
+
+## 1) UI clarity and operator confidence
+
+Example symptoms:
+
+- Blank or partially empty data views
+- Missing context when diagnosing state
+- Inconsistent status cues across screens
+
+Representative issues:
+
+- [#922 - Flowmap doesn't render](https://github.com/LibreQoE/LibreQoS/issues/922)
+- [#921 - ASN Explorer dropdowns are empty](https://github.com/LibreQoE/LibreQoS/issues/921)
+- [#920 - Tree Overview shows blank on low-traffic boxes](https://github.com/LibreQoE/LibreQoS/issues/920)
+- [#831 - Dashboard goes blank when used by same user in multiple locations](https://github.com/LibreQoE/LibreQoS/issues/831)
+
+## 2) Integration behavior and source-of-truth safety
+
+Example symptoms:
+
+- Confusion around overwrite ownership of shaping files
+- Integration matching edge cases
+- Unclear defaults during integration onboarding
+
+Representative issues:
+
+- [#860 - always_overwrite_network_json default behavior confusion](https://github.com/LibreQoE/LibreQoS/issues/860)
+- [#899 - UISP: always_overwrite_network_json=false and missing ShapedDevices.csv](https://github.com/LibreQoE/LibreQoS/issues/899)
+- [#845 - UISP: multi-services with same site name](https://github.com/LibreQoE/LibreQoS/issues/845)
+- [#699 - UISP: trailing spaces break matching](https://github.com/LibreQoE/LibreQoS/issues/699)
+
+## 3) Onboarding and early deployment friction
+
+Example symptoms:
+
+- First-run setup breakpoints
+- Startup/configuration workflow confusion
+- Installer/default behavior mismatches
+
+Representative issues:
+
+- [#859 - Broken default ShapedDevices.csv from setup tool](https://github.com/LibreQoE/LibreQoS/issues/859)
+- [#858 - Config tool webusers flow break](https://github.com/LibreQoE/LibreQoS/issues/858)
+- [#728 - Default installation bridge-mode mismatch](https://github.com/LibreQoE/LibreQoS/issues/728)
+- [#667 - Add YAML creation to setup installer](https://github.com/LibreQoE/LibreQoS/issues/667)
+
+## 4) Scale/topology guardrails and proactive warnings
+
+Example symptoms:
+
+- Queue depth pressure in complex hierarchies
+- Overflow-risk visibility needs
+- Parent-node hygiene and topology clarity concerns
+
+Representative issues:
+
+- [#913 - Tree verbosity and HTB depth pressure](https://github.com/LibreQoE/LibreQoS/issues/913)
+- [#801 - Visible warning for TC ID overflow](https://github.com/LibreQoE/LibreQoS/issues/801)
+- [#856 - Improve no-parent circuit warnings](https://github.com/LibreQoE/LibreQoS/issues/856)
+- [#560 - htb too many events under load](https://github.com/LibreQoE/LibreQoS/issues/560)
+
+## 5) Performance and hardware-fit tuning
+
+Example symptoms:
+
+- Core utilization behavior on heterogeneous CPU platforms
+- Memory growth concerns
+- Throughput/headroom fit on different hardware classes
+
+Representative issues:
+
+- [#928 - Detect e-cores and avoid shaping load there](https://github.com/LibreQoE/LibreQoS/issues/928)
+- [#651 - Memory growth even when gather_stats is false](https://github.com/LibreQoE/LibreQoS/issues/651)
+- [#578 - Resource footprint for 100 Gbit fiber links](https://github.com/LibreQoE/LibreQoS/issues/578)
+- [#526 - Performance improvements during reloading](https://github.com/LibreQoE/LibreQoS/issues/526)
+
+## Candidate Directions Under Evaluation
+
+1. Improve guided diagnostics and empty-state clarity in WebUI.
+2. Make source-of-truth ownership and overwrite behavior more explicit.
+3. Expand integration pre-flight validation and edge-case handling.
+4. Strengthen scale guardrails and early warning ergonomics.
+5. Expand deployment runbooks for common architecture patterns.
+6. Improve performance-fit guidance by hardware and topology profile.
+
+## Out of Scope
+
+- This page is a planning input summary, not a roadmap commitment.
+- Inclusion of an issue does not guarantee a release target or implementation date.
+
+## Related Pages
+
+- [Deployment Recipes](recipes.md)
+- [Case Studies (Anonymized)](case-studies.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes-event-wifi.md
+++ b/docs/v2.0/recipes-event-wifi.md
@@ -1,0 +1,49 @@
+# Recipe: Event WiFi with Subnet-Group Shaping
+
+Use this pattern for short-lived, high-density event networks where grouping client devices by subnet is operationally simpler than per-device lifecycle tracking.
+
+## Fit
+
+- Best for: temporary events, rapidly changing attendees/devices, low-friction operations.
+- Avoid when: you need strict long-term subscriber-level lifecycle shaping.
+
+## Pattern
+
+- Define one circuit per subnet group (for example per `/24`).
+- Keep topology intentionally simple (often `flat` or shallow parent grouping).
+- Use explicit `Parent Node` names in `ShapedDevices.csv` for grouping clarity.
+
+Example row (one subnet as one shaped circuit):
+
+```text
+Circuit ID,Circuit Name,Device ID,Device Name,Parent Node,MAC,IPv4,IPv6,Download Min Mbps,Upload Min Mbps,Download Max Mbps,Upload Max Mbps,Comment
+EVT-24-101,Event Hall A Subnet,EVT-24-101,HallA-Clients,Event_Core,,100.64.101.0/24,,10,10,300,300,Temporary event subnet group
+```
+
+If integration mode owns your shaping files, direct edits like this may be overwritten on the next integration sync.
+
+## Implementation
+
+1. Confirm one owner of shaping data (manual files, custom source of truth, or integration mode).
+2. Pre-create subnet-based circuits for expected attendee segments.
+3. Keep parent hierarchy shallow to reduce queue churn during rapid changes.
+4. Validate in WebUI before opening registration traffic.
+
+## Validation Checklist
+
+1. Active traffic appears under expected subnet-group circuits.
+2. Scheduler remains healthy under rapid client churn.
+3. Queue/class pressure remains stable (watch urgent issues, including overflow warnings).
+4. Flow/Tree views remain coherent during peak arrivals.
+
+## Rollback
+
+1. Restore pre-event `ShapedDevices.csv` / `network.json`.
+2. Restart scheduler.
+3. Validate baseline traffic behavior.
+
+## Related Pages
+
+- [Advanced Configuration Reference](configuration-advanced.md)
+- [Scale Planning and Topology Design](scale-topology.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes-hospitality.md
+++ b/docs/v2.0/recipes-hospitality.md
@@ -1,0 +1,50 @@
+# Recipe: Hotel and Hospitality Per-Device Shaping
+
+Use this pattern when each client device should receive its own circuit behavior (for example room-device fairness and isolation goals).
+
+## Fit
+
+- Best for: hospitality environments with predictable address pools and per-device fairness targets.
+- Avoid when: the projected per-device circuit count exceeds practical RAM/queue limits for your hardware.
+
+## Capacity Guardrails
+
+Per-device shaping can raise circuit count quickly. Validate:
+
+1. RAM sizing against expected device volume ([System Requirements](requirements.md)).
+2. Queue/class pressure and urgent issue health in production-like load.
+3. CAKE qdisc scale impact (memory and operational overhead).
+4. If peak tests show persistent queue/class pressure or unsafe memory growth, pivot to per-room or per-subnet grouping.
+
+## Pattern
+
+- Build an enumerated list of IPv4 addresses corresponding to possible client devices.
+- Assign one shaped circuit per device IP.
+- Use stable parent groups (floor/building/wing) to preserve operational visibility.
+
+## Example Entry
+
+```text
+Circuit ID,Circuit Name,Device ID,Device Name,Parent Node,MAC,IPv4,IPv6,Download Min Mbps,Upload Min Mbps,Download Max Mbps,Upload Max Mbps,Comment,sqm
+HTL-ROOM-1204,Room1204-Device,HTL-ROOM-1204,Room1204-DeviceA,Floor12,,100.70.12.44,,2,2,50,20,Hospitality per-device plan,cake
+```
+
+## Validation Checklist
+
+1. Device-to-circuit mapping is stable and correct.
+2. No persistent urgent issue signals for queue/class limits.
+3. Memory remains within expected envelope at peak occupancy.
+4. RTT/retransmit quality remains acceptable under busy-hour contention.
+
+## Rollback
+
+1. Move from per-device to per-room or per-subnet grouping.
+2. Reduce circuit count and reload.
+3. Re-check scheduler health and queue pressure.
+
+## Related Pages
+
+- [System Requirements](requirements.md)
+- [Scale Planning and Topology Design](scale-topology.md)
+- [CAKE](cake.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes-maritime-stormguard.md
+++ b/docs/v2.0/recipes-maritime-stormguard.md
@@ -1,0 +1,102 @@
+# Recipe: Maritime Variable WAN with StormGuard
+
+Use this pattern when WAN capacity changes materially over time (for example satellite backhaul under weather/load effects) and you need bounded adaptive queue tuning.
+
+## Fit
+
+- Best for: one vessel or one high-variance WAN domain represented as one top-level node.
+- Avoid when: you plan to manage dozens/hundreds of targets with StormGuard.
+
+## Prerequisites
+
+1. Complete [Quickstart](quickstart.md).
+2. Review [StormGuard](stormguard.md) scope and limits.
+3. Confirm source-of-truth behavior ([Operating Modes](operating-modes.md)).
+
+## Topology Pattern
+
+Use a single top-level node named `Ship`, with all subnodes beneath it.
+
+Example `network.json` skeleton:
+
+```json
+{
+  "Ship": {
+    "downloadBandwidthMbps": 1000,
+    "uploadBandwidthMbps": 200,
+    "children": {
+      "Deck_A": {
+        "downloadBandwidthMbps": 500,
+        "uploadBandwidthMbps": 100
+      },
+      "Deck_B": {
+        "downloadBandwidthMbps": 500,
+        "uploadBandwidthMbps": 100
+      }
+    }
+  }
+}
+```
+
+## StormGuard Configuration
+
+```toml
+[stormguard]
+enabled = true
+dry_run = true
+targets = ["Ship"]
+minimum_download_percentage = 0.5
+minimum_upload_percentage = 0.5
+log_file = "/var/log/stormguard.csv"
+```
+
+## Control Loop Illustration
+
+```{mermaid}
+flowchart LR
+    METRICS[Ship Node Metrics\nthroughput, RTT, loss context]
+    SG[StormGuard Evaluator]
+    LIMITS[Bounded Queue Limit Adjustments]
+    QOE[Observed Link Quality]
+
+    METRICS --> SG
+    SG --> LIMITS
+    LIMITS --> QOE
+    QOE --> METRICS
+```
+
+What this shows:
+
+- StormGuard continuously evaluates current `Ship` conditions and applies bounded adjustments.
+- Observed quality and saturation behavior feed the next evaluation cycle.
+
+Rollout sequence:
+
+1. Start with `dry_run = true`.
+2. Observe multiple busy periods.
+3. Confirm adjustments are bounded and sensible.
+4. Set `dry_run = false`.
+
+## Validation Checklist
+
+1. StormGuard debug/status pages show `Ship` as active target.
+2. Effective limits adjust during congestion but respect floor percentages.
+3. RTT/retransmit behavior improves under stress periods.
+4. No naming drift between target names and current hierarchy.
+
+## Rollback
+
+1. Set `[stormguard] enabled = false` (or back to `dry_run = true`).
+2. Restart services:
+
+```bash
+sudo systemctl restart lqosd lqos_scheduler
+```
+
+3. Verify stable behavior without adaptive changes.
+
+## Related Pages
+
+- [StormGuard](stormguard.md)
+- [Scale Planning and Topology Design](scale-topology.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes-proxmox-vm.md
+++ b/docs/v2.0/recipes-proxmox-vm.md
@@ -1,0 +1,172 @@
+# Recipe: Proxmox VM Deployment with 3 NICs
+
+Use this pattern for VM-based deployments where LibreQoS runs on Ubuntu Server 24.04 with dedicated management and shaping interfaces.
+
+## Fit
+
+- Best for: operators standardizing on Proxmox where VM operations are already mature.
+- Avoid when: target throughput and latency goals require bare-metal headroom.
+
+## Pattern Selection
+
+Pattern A is the default and recommended layout for clarity.
+
+- Pattern A (recommended): dedicated Proxmox bridges for shaping (`vmbr1`, `vmbr2`)
+- Pattern B (alternative): single Proxmox bridge (`vmbr0`) with VLAN-tagged virtio NICs
+
+## Interface Roles
+
+- `ens18`: management interface (IP assigned)
+- `ens19`: shaping port 1
+- `ens20`: shaping port 2
+
+`ens19` and `ens20` are the two shaping interfaces used by LibreQoS (`to_internet`/`to_network`).
+`ens18`/`ens19`/`ens20` are example names; verify actual guest interface names before setting `to_internet` and `to_network`.
+
+## Pattern A (Recommended): Dedicated Shaping Bridges
+
+Use this when you want the cleanest operational model.
+
+Host-side intent:
+
+- `vmbr1` is backed by shaping interface A path on the Proxmox host.
+- `vmbr2` is backed by shaping interface B path on the Proxmox host.
+- Management is usually untagged on `vmbr0`.
+
+Host-to-guest mapping reference:
+
+| Proxmox host port/path | Bridge | VM vNIC | Guest NIC | LibreQoS role |
+|---|---|---|---|---|
+| Management uplink (example `eno1`) | `vmbr0` | `net0` | `ens18` | Management |
+| Shaping path A (example `eno2`) | `vmbr1` | `net1` | `ens19` | `to_internet` or `to_network` |
+| Shaping path B (example `eno3`) | `vmbr2` | `net2` | `ens20` | opposite of `ens19` |
+
+VM Hardware (Proxmox UI) example:
+
+- `net0`: `virtio`, `bridge=vmbr0` (management)
+- `net1`: `virtio`, `bridge=vmbr1`, `multiqueue=<vCPU count>` (shaping A)
+- `net2`: `virtio`, `bridge=vmbr2`, `multiqueue=<vCPU count>` (shaping B)
+
+In-guest mapping:
+
+- `ens18 -> net0 -> vmbr0` (management)
+- `ens19 -> net1 -> vmbr1` (shaping A)
+- `ens20 -> net2 -> vmbr2` (shaping B)
+
+```{mermaid}
+flowchart LR
+    subgraph HOST[Proxmox Host]
+        H0[vmbr0 (mgmt untagged)]
+        H1[vmbr1 (shaping A path)]
+        H2[vmbr2 (shaping B path)]
+    end
+
+    subgraph VM[LibreQoS VM]
+        N0[net0 virtio]
+        N1[net1 virtio]
+        N2[net2 virtio]
+        E18[ens18 mgmt]
+        E19[ens19 shaping A]
+        E20[ens20 shaping B]
+    end
+
+    H0 --> N0 --> E18
+    H1 --> N1 --> E19
+    H2 --> N2 --> E20
+```
+
+## Pattern B (Alternative): Single Bridge with VLAN-Tagged NICs
+
+Use this when your Proxmox design standardizes on one VLAN-aware bridge.
+
+Host-side intent:
+
+- `vmbr0` carries management and shaping VLANs as a trunk.
+- Management is often tagged in this pattern.
+
+VM Hardware (Proxmox UI) example:
+
+- `net0`: `virtio`, `bridge=vmbr0`, `tag=99` (management example VLAN)
+- `net1`: `virtio`, `bridge=vmbr0`, `tag=110`, `multiqueue=<vCPU count>` (shaping A example VLAN)
+- `net2`: `virtio`, `bridge=vmbr0`, `tag=120`, `multiqueue=<vCPU count>` (shaping B example VLAN)
+
+Notes:
+
+- VLAN IDs above are examples. Use IDs matching your network design.
+- With Proxmox NIC tag assignment, traffic is typically presented untagged inside the guest NIC (no guest VLAN subinterface required for this model).
+
+```{mermaid}
+flowchart LR
+    subgraph HOST[Proxmox Host]
+        T0[vmbr0 VLAN trunk]
+    end
+
+    subgraph VM[LibreQoS VM]
+        PN0[net0 virtio tag 99]
+        PN1[net1 virtio tag 110]
+        PN2[net2 virtio tag 120]
+        PE18[ens18 mgmt]
+        PE19[ens19 shaping A]
+        PE20[ens20 shaping B]
+    end
+
+    T0 --> PN0 --> PE18
+    T0 --> PN1 --> PE19
+    T0 --> PN2 --> PE20
+```
+
+## Prerequisites
+
+1. Review [Prerequisites](prereq.md) and [System Requirements](requirements.md).
+2. Enable multiqueue on shaping vNICs; set queue count equal to VM vCPU count.
+3. For throughput above 10 Gbps, use NIC passthrough where required.
+
+## Netplan Pattern
+
+Example baseline:
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    ens18:
+      addresses:
+        - 100.99.0.10/24
+      routes:
+        - to: default
+          via: 100.99.0.1
+      nameservers:
+        addresses: [1.1.1.1, 8.8.8.8]
+    ens19:
+      dhcp4: no
+      dhcp6: no
+    ens20:
+      dhcp4: no
+      dhcp6: no
+```
+
+Then configure bridge behavior per [Configure Shaping Bridge](bridge.md).
+
+## Validation Checklist
+
+1. Confirm which pattern is deployed on this VM (A or B).
+2. For Pattern A, confirm `net1->vmbr1` and `net2->vmbr2`.
+3. For Pattern B, confirm `net1->vmbr0 tag 110` and `net2->vmbr0 tag 120` (or your chosen tags).
+4. Confirm `to_internet` / `to_network` map correctly to `ens19`/`ens20`.
+5. Confirm `ens19` and `ens20` have no IP assignment in guest Netplan.
+6. Confirm scheduler and daemon are healthy.
+7. Confirm throughput and latency match expected VM envelope.
+8. Confirm no asymmetric shaping behavior (especially in on-a-stick variants).
+
+## Rollback
+
+1. Move path back to previous shaper or bypass route.
+2. Revert VM interface or queue settings.
+3. Restart services and re-validate.
+
+## Related Pages
+
+- [Prerequisites](prereq.md)
+- [System Requirements](requirements.md)
+- [Configure Shaping Bridge](bridge.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes-switch-fabric-sdwan.md
+++ b/docs/v2.0/recipes-switch-fabric-sdwan.md
@@ -1,0 +1,136 @@
+# Recipe: Switch-Centric Fabric with Maintenance Bypass (SD-WAN Variant Included)
+
+Use this pattern when the network core is switch-centric, VLAN-driven, and you want shaped primary paths plus backup bypass paths for no-downtime LibreQoS maintenance.
+
+## Fit
+
+- Best for: fabrics where explicit L2/L3 path engineering is already in place.
+- Avoid when: path ownership and parent mapping are unclear across systems.
+
+## Topology Pattern
+
+Primary (shaped) VLAN paths traversing LibreQoS:
+
+1. `EdgeA <-> CoreA`
+2. `EdgeA <-> CoreB`
+3. `EdgeB <-> CoreA`
+4. `EdgeB <-> CoreB`
+
+Backup (bypass) VLAN paths should also exist, with dynamic routing policy preferring shaped paths during normal operation.
+
+## Example Topology Illustrations
+
+### Shaped VLAN Set
+
+```{mermaid}
+flowchart LR
+    EA[EdgeA Router]
+    EB[EdgeB Router]
+    SW[SW1/SW2 Switch Pair]
+    LQ[LibreQoS Bridge]
+    CA[CoreA Router]
+    CB[CoreB Router]
+
+    EA --> SW
+    EB --> SW
+    SW -->|Shaped VLANs 110,120,210,220| LQ
+    LQ --> SW
+    SW --> CA
+    SW --> CB
+```
+
+Shaped VLAN mapping:
+
+- VLAN 110: `EdgeA <-> CoreA` (through LibreQoS)
+- VLAN 120: `EdgeA <-> CoreB` (through LibreQoS)
+- VLAN 210: `EdgeB <-> CoreA` (through LibreQoS)
+- VLAN 220: `EdgeB <-> CoreB` (through LibreQoS)
+
+### Bypass VLAN Set
+
+```{mermaid}
+flowchart LR
+    EA[EdgeA Router]
+    EB[EdgeB Router]
+    SW[SW1/SW2 Switch Pair]
+    CA[CoreA Router]
+    CB[CoreB Router]
+
+    EA -.-> SW
+    EB -.-> SW
+    SW -. Bypass VLANs 310,320,410,420 .-> CA
+    SW -. Bypass VLANs 310,320,410,420 .-> CB
+```
+
+Bypass VLAN mapping:
+
+- VLAN 310: `EdgeA <-> CoreA` (bypass)
+- VLAN 320: `EdgeA <-> CoreB` (bypass)
+- VLAN 410: `EdgeB <-> CoreA` (bypass)
+- VLAN 420: `EdgeB <-> CoreB` (bypass)
+
+What this shows:
+
+- Shaped VLANs traverse the switch pair and the LibreQoS bridge path.
+- Bypass VLANs traverse the switch pair without traversing LibreQoS.
+- `SW1/SW2` are shown as a single logical switch-pair node for readability.
+- This is a logical VLAN-path illustration, not a full physical cabling diagram.
+
+## MikroTik RouterOS v7 Example (Conceptual OSPF Preference)
+
+Set lower OSPF cost on shaped interfaces, higher cost on bypass interfaces.
+
+```text
+/routing ospf instance
+add name=default-v2 router-id=10.255.255.1
+
+/routing ospf area
+add name=backbone-v2 area-id=0.0.0.0 instance=default-v2
+
+/routing ospf interface-template
+add interfaces=vlan-edgea-corea-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgea-coreb-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgeb-corea-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgeb-coreb-lq area=backbone-v2 cost=10
+add interfaces=vlan-edgea-corea-bypass area=backbone-v2 cost=200
+add interfaces=vlan-edgea-coreb-bypass area=backbone-v2 cost=200
+add interfaces=vlan-edgeb-corea-bypass area=backbone-v2 cost=200
+add interfaces=vlan-edgeb-coreb-bypass area=backbone-v2 cost=200
+```
+
+Adjust interface names/costs to match your design policy.
+
+## Implementation
+
+1. Build and verify all primary and bypass VLAN interfaces.
+2. Keep path preference deterministic (OSPF/BGP policy).
+3. Place LibreQoS inline on the primary VLAN paths.
+4. Validate failover and failback behavior during a maintenance window.
+
+## Validation Checklist
+
+1. Normal state: traffic follows shaped primary path.
+2. Failure or maintenance state: routing converges to bypass path.
+3. Recovery state: traffic returns to shaped path without instability.
+4. WebUI health remains stable across transitions.
+
+## SD-WAN Variant
+
+For SD-WAN, use the same primary/bypass control model:
+
+- Primary underlay paths pass through LibreQoS shaper path.
+- Secondary underlay paths bypass as maintenance/failure fallback.
+- Keep node naming and parent relationships stable so hierarchy does not churn after path events.
+
+## Rollback
+
+1. Temporarily force routing preference to bypass paths.
+2. Restore previous LibreQoS path policy.
+3. Re-enable shaped path preference after verification.
+
+## Related Pages
+
+- [High Availability and Failure Domains](high-availability.md)
+- [Scale Planning and Topology Design](scale-topology.md)
+- [Configure Shaping Bridge](bridge.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes-wisp-fisp-integration.md
+++ b/docs/v2.0/recipes-wisp-fisp-integration.md
@@ -1,0 +1,95 @@
+# Recipe: WISP/FISP with Built-In CRM/NMS Integration
+
+Use this pattern when your operator workflow is already centered on a supported CRM/NMS (UISP, Splynx, Netzur, VISP, WISPGate, Powercode, or Sonar).
+
+## Fit
+
+- Best for: recurring subscriber changes, CRM-owned service plans, and ongoing subscriber lifecycle automation.
+- Avoid when: your durable source of truth is a custom external pipeline (use custom source of truth mode instead).
+
+## Prerequisites
+
+1. Complete [Quickstart](quickstart.md) and pass the health gate.
+2. Confirm integration choice in [CRM/NMS Integrations](integrations.md).
+3. Confirm source-of-truth ownership in [Operating Modes and Source of Truth](operating-modes.md).
+
+## Implementation
+
+1. Configure integration credentials/settings in WebUI (`Configuration -> Integrations`).
+2. For integration-driven deployments, keep `always_overwrite_network_json = true`.
+3. Choose the lightest topology strategy that meets requirements.
+
+| Requirement | Suggested strategy |
+|---|---|
+| Maximum performance, minimal hierarchy | `flat` |
+| Moderate hierarchy visibility/control | `ap_only` or `ap_site` |
+| Full path/backhaul shaping required | `full` |
+
+4. Enable scheduler-driven recurring refresh in `/etc/lqos.conf` (for example `enable_uisp = true`, `enable_splynx = true`, `enable_netzur = true`; use the matching flag for your selected integration).
+5. Restart scheduler and verify sync behavior:
+
+```bash
+sudo systemctl restart lqos_scheduler
+sudo systemctl status lqos_scheduler
+journalctl -u lqos_scheduler --since "15 minutes ago"
+```
+
+## Data Flow Illustration
+
+```{mermaid}
+flowchart LR
+    CRM[CRM/NMS]
+    INT[Integration Job]
+    SD[ShapedDevices.csv]
+    NJ[network.json]
+    SCH[lqos_scheduler]
+    LQD[lqosd]
+    UI[WebUI Status]
+    MAN[Manual edits to generated files]
+
+    CRM --> INT
+    INT --> SD
+    INT --> NJ
+    SD --> SCH
+    NJ --> SCH
+    SCH --> LQD
+    SCH --> UI
+    MAN -. May be overwritten by next sync .-> SD
+    MAN -. May be overwritten by next sync .-> NJ
+```
+
+What this shows:
+
+- Integration jobs regenerate shaping inputs consumed by the scheduler.
+- In integration mode, direct manual edits to generated files are typically non-durable.
+
+## Validation Checklist
+
+1. `ShapedDevices.csv` is regenerated as expected after sync.
+2. `network.json` behavior matches overwrite policy.
+3. WebUI views are healthy.
+4. Check `Scheduler Status` and `Urgent Issues`.
+5. Check `Network Tree Overview` and `Flow Map`.
+6. Parent placement and queue distribution look sane (no unexpected hierarchy collapse).
+
+## Common Failure Modes
+
+- Integration and manual edits fighting each other.
+- Unexpected topology depth causing avoidable CPU pressure.
+- Missing warnings for unparented circuits in day-1 validation.
+
+Use [Scale Planning and Topology Design](scale-topology.md) and [Troubleshooting](troubleshooting.md) before deeper changes.
+
+## Rollback
+
+1. Revert integration strategy to previous known-good mode.
+2. Restore backed up shaping files if needed.
+3. Restart `lqos_scheduler` and `lqosd`.
+4. Confirm urgent issues clear and views repopulate.
+
+## Related Pages
+
+- [CRM/NMS Integrations](integrations.md)
+- [Scale Planning and Topology Design](scale-topology.md)
+- [Advanced Configuration Reference](configuration-advanced.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/recipes.md
+++ b/docs/v2.0/recipes.md
@@ -1,0 +1,41 @@
+# Deployment Recipes
+
+This page collects repeatable, scenario-based deployment recipes.
+
+Use recipes after you have completed base install and health validation in [Quickstart](quickstart.md).
+
+## Scope
+
+- Recipes here are for supported deployment patterns.
+- Each recipe focuses on practical implementation, validation, and rollback.
+- Router examples use MikroTik RouterOS v7 where routing policy examples are useful.
+
+## Recipe Index
+
+1. [WISP/FISP with built-in CRM/NMS integration](recipes-wisp-fisp-integration.md)
+2. [Maritime variable WAN with StormGuard](recipes-maritime-stormguard.md)
+3. [Event WiFi with subnet-group shaping](recipes-event-wifi.md)
+4. [Hotel and hospitality per-device shaping](recipes-hospitality.md)
+5. [Switch-centric fabric with maintenance bypass (plus SD-WAN variant)](recipes-switch-fabric-sdwan.md)
+6. [Proxmox VM deployment with 3 NICs](recipes-proxmox-vm.md)
+
+```{toctree}
+:hidden:
+
+recipes-wisp-fisp-integration
+recipes-maritime-stormguard
+recipes-event-wifi
+recipes-hospitality
+recipes-switch-fabric-sdwan
+recipes-proxmox-vm
+```
+
+## Related Pages
+
+- [Quickstart](quickstart.md)
+- [Operating Modes and Source of Truth](operating-modes.md)
+- [CRM/NMS Integrations](integrations.md)
+- [Scale Planning and Topology Design](scale-topology.md)
+- [StormGuard](stormguard.md)
+- [High Availability and Failure Domains](high-availability.md)
+- [Troubleshooting](troubleshooting.md)

--- a/index.rst
+++ b/index.rst
@@ -31,6 +31,9 @@ Welcome to the LibreQoS documentation
    docs/v2.0/scale-topology
    docs/v2.0/stormguard
    docs/v2.0/high-availability
+   docs/v2.0/recipes
+   docs/v2.0/case-studies
+   docs/v2.0/future-development-inputs
    docs/v2.0/update
    docs/v2.0/troubleshooting
 


### PR DESCRIPTION
This PR delivers documentation for NLNet milestone 11 across English and Spanish docs.

### What’s included

1. Milestone 11a: User stories (case studies)

- Added anonymized adoption-oriented stories in:
    - case-studies.md
    - case-studies-es.md

2. Milestone 11b: Complex deployment recipes

- Added recipe hub and scenario pages in English:
    - recipes.md
    - recipes-wisp-fisp-integration.md
    - recipes-maritime-stormguard.md
    - recipes-event-wifi.md
    - recipes-hospitality.md
    - recipes-switch-fabric-sdwan.md
    - recipes-proxmox-vm.md
- Added Spanish parity pages:
    - recipes-es.md
    - recipes-wisp-fisp-integration-es.md
    - recipes-maritime-stormguard-es.md
    - recipes-event-wifi-es.md
    - recipes-hospitality-es.md
    - recipes-switch-fabric-sdwan-es.md
    - recipes-proxmox-vm-es.md

3. Milestone 11c: Feedback/issues for future development

- Added public summary pages:
    - future-development-inputs.md
    - future-development-inputs-es.md
- Includes:
    - review window
    - input volumes
    - recurring themes
    - representative GitHub issue references
    - candidate directions under evaluation
    - non-commitment scope language

### Clarity and structure improvements included

- Added Mermaid diagrams where useful (integration flow, StormGuard loop, switch-centric topology, Proxmox patterns).
- Improved switch-centric readability by splitting shaped vs bypass VLAN diagrams.
- Expanded Proxmox pattern clarity (Pattern A/Pattern B, host-to-guest mapping, flattened validation checklist).
- Improved issue readability in 11c by replacing raw URLs with labeled #issue - title links.

### Navigation updates

- English nav updated in index.rst to include:
    - recipes
    - case studies
    - future development inputs
- Spanish nav updated in docs-es/index.rst for parity.