### PR TITLE
Feat: Prefer scheduler integrations on efficiency cores

### DIFF
--- a/src/rust/lqos_python/src/lib.rs
+++ b/src/rust/lqos_python/src/lib.rs
@@ -599,6 +599,7 @@ fn liblqos_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(use_bin_packing_to_balance_cpu, m)?)?;
     m.add_function(wrap_pyfunction!(monitor_mode_only, m)?)?;
     m.add_function(wrap_pyfunction!(shaping_cpu_count, m)?)?;
+    m.add_function(wrap_pyfunction!(efficiency_core_ids, m)?)?;
     m.add_function(wrap_pyfunction!(run_shell_commands_as_sudo, m)?)?;
     m.add_function(wrap_pyfunction!(generated_pn_download_mbps, m)?)?;
     m.add_function(wrap_pyfunction!(generated_pn_upload_mbps, m)?)?;
@@ -1188,6 +1189,19 @@ fn shaping_cpu_count() -> PyResult<u32> {
     let config = lqos_config::load_config().unwrap();
     let det = lqos_config::detect_shaping_cpus(config.as_ref());
     Ok(det.shaping.len() as u32)
+}
+
+/// Returns detected efficiency-core CPU IDs for scheduler affinity decisions.
+#[pyfunction]
+fn efficiency_core_ids() -> PyResult<Vec<u32>> {
+    let config = lqos_config::load_config().unwrap();
+    let det = lqos_config::detect_shaping_cpus(config.as_ref());
+    let efficiency = match det.source {
+        lqos_config::ShapingCpuSource::CpuCoreSysfs
+        | lqos_config::ShapingCpuSource::PossibleMinusAtomSysfs => det.efficiency,
+        _ => Vec::new(),
+    };
+    Ok(efficiency)
 }
 
 #[pyfunction]

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -11,7 +11,7 @@ from io import StringIO
 from liblqos_python import automatic_import_uisp, automatic_import_splynx, queue_refresh_interval_mins, \
     automatic_import_powercode, automatic_import_sonar, influx_db_enabled, get_libreqos_directory, \
     blackboard_finish, blackboard_submit, automatic_import_wispgate, enable_insight_topology, insight_topology_role, \
-    automatic_import_netzur, automatic_import_visp, calculate_hash, scheduler_alive, scheduler_error, overrides_persistent_devices, overrides_circuit_adjustments, overrides_network_adjustments
+    automatic_import_netzur, automatic_import_visp, calculate_hash, efficiency_core_ids, scheduler_alive, scheduler_error, overrides_persistent_devices, overrides_circuit_adjustments, overrides_network_adjustments
 
 from apscheduler.schedulers.background import BlockingScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
@@ -20,6 +20,67 @@ import os
 
 ads = BlockingScheduler(executors={'default': ThreadPoolExecutor(1)})
 network_hash = 0
+
+
+def get_integration_affinity_cpus():
+    """Return efficiency-core CPU IDs to prefer for integration subprocesses."""
+    try:
+        cpus = efficiency_core_ids()
+    except Exception as e:
+        msg = f"Failed to determine efficiency cores for integrations: {e}"
+        print(msg)
+        scheduler_error(msg)
+        return []
+
+    normalized = []
+    for cpu in cpus or []:
+        try:
+            normalized.append(int(cpu))
+        except (TypeError, ValueError):
+            continue
+    return sorted(set(cpu for cpu in normalized if cpu >= 0))
+
+
+def _affinity_preexec(cpu_ids):
+    cpu_set = set(cpu_ids)
+
+    def apply_affinity():
+        os.sched_setaffinity(0, cpu_set)
+
+    return apply_affinity
+
+
+def run_integration_subprocess(cmd, *, capture_output=True, text=True, cwd=None, label="integration"):
+    """
+    Launch a scheduler-managed integration subprocess.
+    Prefer detected efficiency cores when available, but retry unpinned on failure.
+    """
+    kwargs = {
+        "capture_output": capture_output,
+        "text": text,
+    }
+    if cwd is not None:
+        kwargs["cwd"] = cwd
+
+    cpu_ids = get_integration_affinity_cpus()
+    used_affinity = False
+    if cpu_ids and hasattr(os, "sched_setaffinity"):
+        kwargs["preexec_fn"] = _affinity_preexec(cpu_ids)
+        used_affinity = True
+
+    try:
+        return subprocess.run(cmd, **kwargs)
+    except Exception as e:
+        if not used_affinity:
+            raise
+        msg = (
+            f"Failed to pin {label} to efficiency cores {cpu_ids}: {e}. "
+            "Retrying without affinity."
+        )
+        print(msg)
+        scheduler_error(msg)
+        kwargs.pop("preexec_fn", None)
+        return subprocess.run(cmd, **kwargs)
 
 
 def capture_output_and_run(func):
@@ -57,14 +118,19 @@ def run_python_integration(module_name: str, func_name: str, label: str = ""):
     try:
         code = f"from {module_name} import {func_name} as f; f()"
         cmd = [sys.executable, "-c", code]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        friendly = label or f"{module_name}.{func_name}"
+        result = run_integration_subprocess(
+            cmd,
+            capture_output=True,
+            text=True,
+            label=friendly,
+        )
         output = (result.stdout or "") + (result.stderr or "")
         if output:
             print(output)
             scheduler_error(output)
         if result.returncode != 0:
             # Non-zero exit shouldn't stop scheduling; log and continue
-            friendly = label or f"{module_name}.{func_name}"
             msg = f"Integration {friendly} exited with code {result.returncode}. Continuing."
             print(msg)
             scheduler_error(msg)
@@ -79,7 +145,12 @@ def importFromCRM():
         try:
             # Execute UISP integration in a subprocess and keep going on failure
             path = get_libreqos_directory() + "/bin/uisp_integration"
-            result = subprocess.run([path], capture_output=True, text=True)
+            result = run_integration_subprocess(
+                [path],
+                capture_output=True,
+                text=True,
+                label="UISP integration",
+            )
             output = (result.stdout or "") + (result.stderr or "")
             if output:
                 print(output)

--- a/src/test_scheduler.py
+++ b/src/test_scheduler.py
@@ -1,0 +1,154 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+def install_scheduler_stubs():
+    libre = types.ModuleType("LibreQoS")
+    libre.refreshShapers = Mock()
+    libre.refreshShapersUpdateOnly = Mock()
+    sys.modules["LibreQoS"] = libre
+
+    lqlib = types.ModuleType("liblqos_python")
+    lqlib.automatic_import_uisp = lambda: False
+    lqlib.automatic_import_splynx = lambda: False
+    lqlib.queue_refresh_interval_mins = lambda: 30
+    lqlib.automatic_import_powercode = lambda: False
+    lqlib.automatic_import_sonar = lambda: False
+    lqlib.influx_db_enabled = lambda: False
+    lqlib.get_libreqos_directory = lambda: "/tmp/libreqos"
+    lqlib.blackboard_finish = Mock()
+    lqlib.blackboard_submit = Mock()
+    lqlib.automatic_import_wispgate = lambda: False
+    lqlib.enable_insight_topology = lambda: False
+    lqlib.insight_topology_role = lambda: "primary"
+    lqlib.automatic_import_netzur = lambda: False
+    lqlib.automatic_import_visp = lambda: False
+    lqlib.calculate_hash = lambda: 0
+    lqlib.efficiency_core_ids = lambda: []
+    lqlib.scheduler_alive = Mock()
+    lqlib.scheduler_error = Mock()
+    lqlib.overrides_persistent_devices = lambda: []
+    lqlib.overrides_circuit_adjustments = lambda: []
+    lqlib.overrides_network_adjustments = lambda: []
+    sys.modules["liblqos_python"] = lqlib
+
+    apscheduler_pkg = types.ModuleType("apscheduler")
+    sys.modules["apscheduler"] = apscheduler_pkg
+    apscheduler_schedulers = types.ModuleType("apscheduler.schedulers")
+    sys.modules["apscheduler.schedulers"] = apscheduler_schedulers
+    apscheduler_background = types.ModuleType("apscheduler.schedulers.background")
+    sys.modules["apscheduler.schedulers.background"] = apscheduler_background
+    apscheduler_executors = types.ModuleType("apscheduler.executors")
+    sys.modules["apscheduler.executors"] = apscheduler_executors
+    apscheduler_pool = types.ModuleType("apscheduler.executors.pool")
+    sys.modules["apscheduler.executors.pool"] = apscheduler_pool
+
+    class FakeBlockingScheduler:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def add_job(self, *args, **kwargs):
+            return None
+
+        def start(self):
+            return None
+
+    class FakeThreadPoolExecutor:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    apscheduler_background.BlockingScheduler = FakeBlockingScheduler
+    apscheduler_pool.ThreadPoolExecutor = FakeThreadPoolExecutor
+
+
+install_scheduler_stubs()
+scheduler = importlib.import_module("scheduler")
+
+
+class TestSchedulerAffinity(unittest.TestCase):
+    def test_run_integration_subprocess_uses_efficiency_core_affinity(self):
+        result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        def fake_run(cmd, **kwargs):
+            self.assertEqual(cmd, ["fake-binary"])
+            self.assertIn("preexec_fn", kwargs)
+            kwargs["preexec_fn"]()
+            return result
+
+        with patch.object(scheduler, "efficiency_core_ids", return_value=[11, 10, 10]):
+            with patch.object(scheduler.os, "sched_setaffinity") as mock_affinity:
+                with patch.object(scheduler.subprocess, "run", side_effect=fake_run):
+                    observed = scheduler.run_integration_subprocess(
+                        ["fake-binary"],
+                        label="fake integration",
+                    )
+
+        self.assertIs(observed, result)
+        mock_affinity.assert_called_once_with(0, {10, 11})
+
+    def test_run_integration_subprocess_retries_without_affinity_on_failure(self):
+        result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(kwargs.copy())
+            if "preexec_fn" in kwargs:
+                raise RuntimeError("preexec failed")
+            return result
+
+        with patch.object(scheduler, "efficiency_core_ids", return_value=[10]):
+            with patch.object(scheduler.subprocess, "run", side_effect=fake_run):
+                with patch.object(scheduler, "scheduler_error") as mock_scheduler_error:
+                    with patch("builtins.print"):
+                        observed = scheduler.run_integration_subprocess(
+                            ["fake-binary"],
+                            label="fake integration",
+                        )
+
+        self.assertIs(observed, result)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("preexec_fn", calls[0])
+        self.assertNotIn("preexec_fn", calls[1])
+        mock_scheduler_error.assert_called_once()
+
+    def test_run_integration_subprocess_skips_affinity_without_efficiency_cores(self):
+        result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        def fake_run(cmd, **kwargs):
+            self.assertNotIn("preexec_fn", kwargs)
+            return result
+
+        with patch.object(scheduler, "efficiency_core_ids", return_value=[]):
+            with patch.object(scheduler.subprocess, "run", side_effect=fake_run):
+                observed = scheduler.run_integration_subprocess(
+                    ["fake-binary"],
+                    label="fake integration",
+                )
+
+        self.assertIs(observed, result)
+
+    def test_post_integration_hook_remains_unpinned(self):
+        result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch.object(scheduler, "automatic_import_uisp", return_value=True):
+            with patch.object(scheduler, "get_libreqos_directory", return_value="/tmp/libreqos"):
+                with patch.object(scheduler, "run_integration_subprocess", return_value=result) as mock_run:
+                    with patch.object(scheduler, "apply_lqos_overrides"):
+                        with patch.object(scheduler.os.path, "isfile", return_value=True):
+                            with patch.object(scheduler.subprocess, "Popen") as mock_popen:
+                                scheduler.importFromCRM()
+
+        mock_run.assert_called_once()
+        mock_popen.assert_called_once_with(
+            "/tmp/libreqos/bin/post_integration_hook.sh",
+            cwd="/tmp/libreqos/bin",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose detected efficiency-core IDs to Python and use them to pin scheduler-launched CRM integrations, including UISP, onto efficiency cores when hybrid CPU detection succeeds. Retry unpinned if affinity setup fails so systems without usable e-cores keep the existing behavior.

Add focused scheduler tests covering efficiency-core affinity, fallback retry, no-e-core behavior, and leaving post_integration_hook.sh unchanged.

FIXES #954