### PR TITLE
Fix: route lqosd log spam through tracing

### DIFF
--- a/src/rust/lqosd/src/node_manager/local_api/lts/shaper_status.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/lts/shaper_status.rs
@@ -1,7 +1,7 @@
 use axum::http::StatusCode;
 use lqos_config::load_config;
 use serde::{Deserialize, Serialize};
-use tracing::error;
+use tracing::{debug, error};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ShaperStatus {
@@ -20,7 +20,7 @@ pub async fn shaper_status_data() -> Result<Vec<ShaperStatus>, StatusCode> {
             .lts_url
             .unwrap_or("insight.libreqos.com".to_string())
     );
-    println!("URL: {}", url);
+    debug!("Fetching shaper status from {url}");
 
     let client = reqwest::Client::builder()
         .danger_accept_invalid_certs(true)

--- a/src/rust/lqosd/src/throughput_tracker/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/mod.rs
@@ -1226,6 +1226,7 @@ pub fn current_endpoints_by_country() -> BusResponse {
 /// Current endpoint lat/lon
 pub fn current_lat_lon() -> BusResponse {
     let summary = flow_data::RECENT_FLOWS.lat_lon_endpoints();
+    debug!("CurrentLatLon payload: {:?}", summary);
     BusResponse::CurrentLatLon(summary)
 }
 


### PR DESCRIPTION
Reduces log spam and properly uses the tracing::debug! macro for it.