### PR TITLE
Fix BigInt handling in live throughput dashboard charts

### DIFF
--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/shaped_unshaped_dash.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/shaped_unshaped_dash.js
@@ -1,6 +1,7 @@
 import {ShapedUnshapedPie} from "../graphs/shaped_unshaped_pie";
 import {ShapedUnshapedTimescale} from "../graphs/shaped_unshaped_timescale";
 import {DashletBaseInsight} from "./insight_dashlet_base";
+import {sumDownUpOrder} from "../lq_js_common/helpers/scaling";
 
 export class ShapedUnshapedDash extends DashletBaseInsight {
     title() {
@@ -43,8 +44,8 @@ export class ShapedUnshapedDash extends DashletBaseInsight {
 
     onMessage(msg) {
         if (msg.event === "Throughput" && window.timePeriods.activePeriod === "Live") {
-            let shaped = msg.data.shaped_bps.down + msg.data.shaped_bps.up;
-            let unshaped = msg.data.bps.down + msg.data.bps.up;
+            let shaped = sumDownUpOrder(msg.data.shaped_bps, 0);
+            let unshaped = sumDownUpOrder(msg.data.bps, 0);
             this.graph.update(shaped, unshaped);
             if (this.zoomGraph) {
                 this.zoomGraph.update(shaped, unshaped);

--- a/src/rust/lqosd/src/node_manager/js_build/src/graphs/packets_bar.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/graphs/packets_bar.js
@@ -1,6 +1,9 @@
 import {DashboardGraph} from "./dashboard_graph";
 import {GraphOptionsBuilder} from "../lq_js_common/e_charts/chart_builder";
-import {scaleNumber} from "../lq_js_common/helpers/scaling";
+import {
+    normalizeDownUpOrder,
+    scaleNumber,
+} from "../lq_js_common/helpers/scaling";
 
 export class PacketsPerSecondBar extends DashboardGraph {
     constructor(id) {
@@ -136,29 +139,32 @@ export class PacketsPerSecondBar extends DashboardGraph {
 
     update(down, up, tcp, udp, icmp) {
         this.chart.hideLoading();
+        const tcpPair = normalizeDownUpOrder(tcp, 0);
+        const udpPair = normalizeDownUpOrder(udp, 0);
+        const icmpPair = normalizeDownUpOrder(icmp, 0);
 
         const now = Date.now();
-        this.option.series[0].data.push({ value: tcp.down, timestamp: now });
+        this.option.series[0].data.push({ value: tcpPair.down, timestamp: now });
         if (this.option.series[0].data.length > 300) {
             this.option.series[0].data.shift();
         }
-        this.option.series[1].data.push({ value: -tcp.up, timestamp: now });
+        this.option.series[1].data.push({ value: -tcpPair.up, timestamp: now });
         if (this.option.series[1].data.length > 300) {
             this.option.series[1].data.shift();
         }
-        this.option.series[2].data.push({ value: udp.down, timestamp: now });
+        this.option.series[2].data.push({ value: udpPair.down, timestamp: now });
         if (this.option.series[2].data.length > 300) {
             this.option.series[2].data.shift();
         }
-        this.option.series[3].data.push({ value: -udp.up, timestamp: now });
+        this.option.series[3].data.push({ value: -udpPair.up, timestamp: now });
         if (this.option.series[3].data.length > 300) {
             this.option.series[3].data.shift();
         }
-        this.option.series[4].data.push({ value: icmp.down, timestamp: now });
+        this.option.series[4].data.push({ value: icmpPair.down, timestamp: now });
         if (this.option.series[4].data.length > 300) {
             this.option.series[4].data.shift();
         }
-        this.option.series[5].data.push({ value: -icmp.up, timestamp: now });
+        this.option.series[5].data.push({ value: -icmpPair.up, timestamp: now });
         if (this.option.series[5].data.length > 300) {
             this.option.series[5].data.shift();
         }

--- a/src/rust/lqosd/src/node_manager/js_build/src/graphs/throughput_ring_graph.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/graphs/throughput_ring_graph.js
@@ -1,6 +1,9 @@
 import {DashboardGraph} from "./dashboard_graph";
 import {GraphOptionsBuilder} from "../lq_js_common/e_charts/chart_builder";
-import {scaleNumber} from "../lq_js_common/helpers/scaling";
+import {
+    normalizeDownUpOrder,
+    scaleNumber,
+} from "../lq_js_common/helpers/scaling";
 
 const RING_SIZE = 60 * 5; // 5 Minutes
 
@@ -159,10 +162,12 @@ class RingBuffer {
     }
 
     push(shaped, unshaped, timestamp) {
-        this.data[this.head][1] = shaped.down;
-        this.data[this.head][0] = 0.0 - shaped.up;
-        this.data[this.head][2] = unshaped.down;
-        this.data[this.head][3] = 0.0 - unshaped.up;
+        const shapedPair = normalizeDownUpOrder(shaped, 0);
+        const unshapedPair = normalizeDownUpOrder(unshaped, 0);
+        this.data[this.head][1] = shapedPair.down;
+        this.data[this.head][0] = 0.0 - shapedPair.up;
+        this.data[this.head][2] = unshapedPair.down;
+        this.data[this.head][3] = 0.0 - unshapedPair.up;
         this.data[this.head][4] = timestamp || Date.now();
         this.head += 1;
         this.head %= this.size;

--- a/src/rust/lqosd/src/node_manager/js_build/src/lq_js_common/helpers/scaling.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/lq_js_common/helpers/scaling.js
@@ -35,6 +35,18 @@ export function toNumber(value, fallback = 0) {
     }
 }
 
+export function normalizeDownUpOrder(value, fallback = 0) {
+    return {
+        down: toNumber(value?.down, fallback),
+        up: toNumber(value?.up, fallback),
+    };
+}
+
+export function sumDownUpOrder(value, fallback = 0) {
+    const pair = normalizeDownUpOrder(value, fallback);
+    return pair.down + pair.up;
+}
+
 function toFixedDigits(value, fallback = 2, min = 0, max = 20) {
     let digits = Math.round(toNumber(value, fallback));
     if (!Number.isFinite(digits)) digits = fallback;


### PR DESCRIPTION
## Summary

This change fixes web console failures caused by BigInt values reaching frontend chart math and ECharts.

CBOR websocket throughput payloads can decode Rust u64 fields as JS BigInt. Several live dashboard charts were assuming plain numbers and
doing arithmetic directly on those values, which caused:

- Cannot mix BigInt and other types
- Cannot convert a BigInt value to a number

## Changes

- Added shared helpers to normalize DownUpOrder payloads to JS numbers before chart use.
- Fixed mapped/unmapped traffic dashlet totals to sum normalized values.
- Fixed live throughput ring graph to normalize download/upload values before storing chart series data.
- Fixed live PPS graph to normalize TCP/UDP/ICMP up/down values before negation and render.

## Impact

- Prevents the mapped/unmapped pie chart from crashing on live throughput updates.
- Prevents the related live throughput and PPS charts from hitting the same BigInt/Number issue.
- Keeps the fix localized to the frontend chart boundary without changing websocket/backend types.

## Testing

- Rebuilt the main frontend bundle successfully with:

/tmp/esbuild/esbuild src/index.js --bundle --minify --sourcemap --target=chrome58,firefox57,safari11 --outdir=out