### PR TITLE
Prototype ASN-aware circuit QoE/RTT rollups

### DIFF
--- a/docs-es/index.rst
+++ b/docs-es/index.rst
@@ -25,6 +25,7 @@ Bienvenido a la documentación de LibreQoS
    v2.0/integrations-es
    v2.0/components-es
    v2.0/node-manager-ui-es
+   v2.0/qoe-rtt-methodology-es
    v2.0/stormguard-es
    v2.0/treeguard-es
    v2.0/high-availability-es

--- a/docs-es/v2.0/configuration-es.md
+++ b/docs-es/v2.0/configuration-es.md
@@ -45,6 +45,33 @@ Nota de topología:
 Lea esto primero antes de cambios en producción:
 - [Modos de operación y fuente de verdad](operating-modes-es.md)
 
+## Perfiles de QoE (`qoo_profiles.json`)
+
+LibreQoS muestra QoE como una estimación de la calidad de Internet basada en latencia y pérdida.
+
+Para la metodología actual de cálculo de RTT/QoE por circuito usada en las vistas de experiencia por circuito de la WebUI, consulte [Metodología de QoE y RTT por circuito](qoe-rtt-methodology-es.md).
+
+### Dónde vive el archivo
+
+`<lqos_directory>/qoo_profiles.json`
+
+### Selección de perfil
+
+- **WebUI**: `Configuration -> General -> QoE Profile`
+- **Archivo de configuración**: configure `qoo_profile_id` en `/etc/lqos.conf`
+
+Ejemplo:
+
+```toml
+# /etc/lqos.conf
+qoo_profile_id = "web_browsing"
+```
+
+### Aplicar cambios
+
+- Los cambios a `qoo_profiles.json` se detectan automáticamente.
+- Si cambia `/etc/lqos.conf`, reinicie `lqosd`.
+
 ## ¿Necesita cambios por CLI o por archivos?
 
 Para edición directa de archivos (`/etc/lqos.conf`, `network.json`, `ShapedDevices.csv`), overrides y material de referencia profundo sobre topología/circuitos, use:
@@ -56,5 +83,6 @@ Para edición directa de archivos (`/etc/lqos.conf`, `network.json`, `ShapedDevi
 - [Quickstart](quickstart-es.md)
 - [Modos de operación y fuente de verdad](operating-modes-es.md)
 - [Integraciones CRM/NMS](integrations-es.md)
+- [Metodología de QoE y RTT por circuito](qoe-rtt-methodology-es.md)
 - [Referencia avanzada de configuración](configuration-advanced-es.md)
 - [Solución de problemas](troubleshooting-es.md)

--- a/docs-es/v2.0/node-manager-ui-es.md
+++ b/docs-es/v2.0/node-manager-ui-es.md
@@ -2,6 +2,8 @@
 
 Esta página documenta las vistas clave de la WebUI (Node Manager) y su comportamiento operativo en la interfaz local (`http://ip_del_shaper:9123`).
 
+Para la metodología actual de cálculo de RTT/QoE por circuito usada por las vistas enfocadas en experiencia de circuito, consulte [Metodología de QoE y RTT por circuito](qoe-rtt-methodology-es.md).
+
 ## Vistas principales
 
 ### Dashboard

--- a/docs-es/v2.0/node-manager-ui-es.md
+++ b/docs-es/v2.0/node-manager-ui-es.md
@@ -26,7 +26,7 @@ Esta página documenta las vistas clave de la WebUI (Node Manager) y su comporta
 - Útil para identificar cuellos de botella y patrones de utilización padre/hijo.
 - Las páginas de detalle del árbol muestran una ruta tipo breadcrumb, conteos de rama e indicadores de estado para el nodo seleccionado.
 - `Node Details` resume las velocidades configuradas del nodo seleccionado, el estado de overrides y la velocidad efectiva.
-- `Node Snapshot` ofrece un resumen visual rápido del throughput y el QoO del nodo seleccionado.
+- `Node Snapshot` ofrece un resumen visual rápido del throughput y el QoE del nodo seleccionado.
 - Los circuitos adjuntos se muestran en una tabla dedicada para el nodo seleccionado.
 - La columna de IP de circuitos adjuntos mantiene las filas compactas mostrando una dirección inline y colapsando las adicionales como `+X`, mientras la lista completa sigue disponible al pasar el cursor.
 - Los circuitos adjuntos limitados por Ethernet pueden mostrar insignias `10M`, `100M` o `1G` junto al valor de `Plan (Mbps)`; al pasar el cursor se explica el auto-cap y al hacer clic en la insignia se abre la página dedicada de revisión Ethernet.
@@ -61,7 +61,7 @@ Esta página documenta las vistas clave de la WebUI (Node Manager) y su comporta
 
 ### Site Map
 - Mapa operativo plano de sitios y APs usando geodatos importados de nodos.
-- Usa QoO por defecto con un selector alternativo para RTT, mientras el tamaño del marcador refleja el throughput combinado reciente.
+- Usa QoE por defecto con un selector alternativo para RTT, mientras el tamaño del marcador refleja el throughput combinado reciente.
 - Los APs pueden heredar coordenadas del sitio padre solo para visualización cuando faltan coordenadas explícitas.
 - Los marcadores de sitios cercanos se agrupan y se expanden al acercar el mapa o seleccionar un grupo.
 - Los APs sin coordenadas explícitas se representan a través de su sitio padre y pueden desplegarse temporalmente alrededor del sitio seleccionado para inspección.

--- a/docs-es/v2.0/qoe-rtt-methodology-es.md
+++ b/docs-es/v2.0/qoe-rtt-methodology-es.md
@@ -1,0 +1,91 @@
+# Metodología de QoE y RTT por circuito
+
+## Propósito de esta página
+
+Use esta página para entender cómo LibreQoS calcula actualmente el RTT y el QoE a nivel de circuito en la WebUI.
+
+Esta página describe la metodología enfocada en circuitos usada por las páginas de circuito y otras vistas de experiencia por circuito. Las vistas de sitio, nodo y globales pueden usar rollups diferentes.
+
+## Qué significan estas métricas
+
+- `RTT` es la latencia representativa de ida y vuelta para el circuito.
+- `QoE` es la puntuación representativa de calidad para el circuito, basada en latencia y pérdida.
+- Ambas métricas buscan reflejar la experiencia general del suscriptor a través de sus destinos activos, en lugar de permitir que un solo flujo defina todo el circuito.
+
+## RTT del circuito
+
+LibreQoS calcula actualmente el RTT del circuito en cuatro etapas:
+
+1. Los flujos activos recientes se agrupan por ASN de destino dentro del circuito.
+2. Los flujos muy pequeños se ignoran para el aporte de RTT hasta que hayan transferido al menos `128 KB` en esa dirección.
+3. Cada ASN construye su propia vista de RTT a partir del tráfico con RTT observable que LibreQoS realmente puede ver.
+4. LibreQoS combina esos valores de RTT por ASN en un único RTT de circuito usando una mediana ponderada.
+
+Esto da más peso a los destinos activos relevantes y al mismo tiempo resiste outliers de un solo flujo o de un solo destino.
+
+## QoE del circuito
+
+El QoE del circuito usa la misma agrupación por ASN que el RTT del circuito.
+
+Para cada ASN activo, LibreQoS:
+
+- construye una vista de RTT a partir del tráfico reciente con RTT observable
+- estima la pérdida de transporte usando retransmisiones TCP cuando están disponibles
+- aplica el perfil de QoE seleccionado en `qoo_profiles.json`
+
+Después, LibreQoS combina los valores de QoE por ASN en una sola puntuación de QoE del circuito.
+
+## Cómo funciona la ponderación por ASN
+
+LibreQoS no trata todos los flujos por igual.
+
+En cambio, las versiones actuales:
+
+- agrupan los flujos por ASN de destino
+- dan más influencia a los ASN que transportan más tráfico activo
+- reducen la influencia cuando el tráfico con RTT visible es solo una pequeña parte del tráfico total de ese ASN
+- limitan la influencia de un solo ASN para que un único destino no domine por completo la puntuación del circuito cuando existen suficientes ASN distintos activos
+
+La intención es representar mejor la experiencia del suscriptor cuando un circuito habla con muchos destinos al mismo tiempo.
+
+## Por qué esto es mejor que ponderar flujos crudos
+
+Ponderar flujos crudos puede ser engañoso:
+
+- muchos flujos diminutos pueden introducir ruido
+- un solo flujo grande de streaming puede exagerar un problema que el ISP no puede influir
+- el tráfico dominado por QUIC suele tener visibilidad de RTT más débil que TCP
+
+El método ajustado por ASN reduce esos problemas porque:
+
+- ignora flujos muy pequeños para la contribución al RTT
+- pondera por grupos de destino en lugar de por conteo bruto de flujos
+- reduce el peso de evidencia débil de RTT
+- limita cuánto puede controlar el resultado un solo grupo de destinos
+
+## Límites importantes
+
+Esto sigue siendo una aproximación de la experiencia del usuario, no un clasificador perfecto.
+
+Tenga en cuenta estos límites:
+
+- La visibilidad de RTT es mejor para TCP que para tráfico QUIC cifrado.
+- Un solo ASN aún puede representar múltiples aplicaciones con comportamientos distintos.
+- En circuitos con muy pocos destinos activos, cualquier límite de influencia por ASN tiene menos margen para funcionar.
+- Las métricas de retransmisiones mostradas en otras partes de la WebUI siguen siendo indicadores directos de salud del transporte y no todas están ajustadas por ASN.
+
+## Cómo interpretar el resultado
+
+Use el RTT y el QoE del circuito como señales de experiencia, no como forensia de protocolos.
+
+Ejemplos:
+
+- Si el throughput está sano, la mayoría de destinos se ven bien y un destino de streaming se ve mal, el QoE debería degradarse menos que con un método basado en flujos crudos.
+- Si varios destinos activos importantes se ven mal, el RTT y el QoE del circuito deberían seguir reflejándolo claramente.
+- Si la cobertura de RTT es débil porque la mayor parte del tráfico es QUIC u otro tráfico opaco, trate la puntuación como direccional y no como absoluta.
+
+## Páginas relacionadas
+
+- [Configurar LibreQoS](configuration-es.md)
+- [LibreQoS WebUI (Node Manager)](node-manager-ui-es.md)
+- [TreeGuard](treeguard-es.md)

--- a/docs-es/v2.0/treeguard-es.md
+++ b/docs-es/v2.0/treeguard-es.md
@@ -27,12 +27,12 @@ Si prefiere un comportamiento fijo/manual, deshabilite TreeGuard o reduzca sus l
 
 ## Modelo de Conmutación SQM por Circuito
 
-TreeGuard evalúa utilización, frescura de RTT, guardrails de CPU y guardrails opcionales de QoO.
+TreeGuard evalúa utilización, frescura de RTT, guardrails de CPU y guardrails opcionales de QoE.
 
 Comportamiento de alto nivel:
 
 1. Bajo condiciones sostenidas de baja carga, TreeGuard puede cambiar una dirección de `cake` a `fq_codel`.
-2. Si sube la utilización, los guardrails de QoO no son seguros o se cumplen condiciones de reversión, TreeGuard vuelve hacia la política SQM base del circuito.
+2. Si sube la utilización, los guardrails de QoE no son seguros o se cumplen condiciones de reversión, TreeGuard vuelve hacia la política SQM base del circuito.
 3. Las decisiones pueden ser independientes por dirección cuando `independent_directions = true`.
 
 Esto crea un perfil dinámico en el que direcciones cargadas favorecen `cake diffserv4`, mientras direcciones de baja carga pueden usar `fq_codel` cuando las condiciones son seguras.
@@ -53,7 +53,7 @@ La configuración de TreeGuard vive bajo `[treeguard]` y sus sub-secciones:
 2. `[treeguard.cpu]`: modo basado en CPU vs tráfico/RTT y umbrales.
 3. `[treeguard.links]`: enrolamiento de virtualización de nodos y guardrails.
 4. `[treeguard.circuits]`: enrolamiento de circuitos y guardrails de conmutación SQM.
-5. `[treeguard.qoo]`: umbral opcional de protección QoO.
+5. `[treeguard.qoo]`: umbral opcional de protección QoE.
 
 Comportamiento por defecto actual:
 
@@ -84,7 +84,7 @@ enabled = true
 ```
 
 La virtualización de nodos en TreeGuard está pensada para ser basada en CPU por defecto. El
-tráfico, RTT y QoO siguen siendo señales importantes de seguridad y restauración, pero la nueva
+tráfico, RTT y QoE siguen siendo señales importantes de seguridad y restauración, pero la nueva
 virtualización automática debe ocurrir cuando la presión de CPU indica que el ahorro de HTB vale
 la pena. Las instalaciones actualizadas desde defaults antiguos se migran silenciosamente de
 `traffic_rtt_only` a `cpu_aware`, con un aviso visible en logs/UI.
@@ -128,7 +128,7 @@ TreeGuard también se niega a gestionar nodos que ya estén marcados con `"virtu
 
 Para la gestión SQM por circuito, TreeGuard trata los valores duplicados de `device_id` como colisiones de identidad inseguras. Si el mismo `device_id` aparece en más de un circuito dentro de `ShapedDevices.csv`, TreeGuard omite esos circuitos afectados y limpia cualquier override SQM de TreeGuard asociado a esos `device_id` duplicados.
 
-Si la telemetría RTT no está disponible temporalmente después de un reinicio, TreeGuard no trata la ausencia de RTT por sí sola como evidencia para revertir direcciones en `fq_codel`. Siguen aplicando otros guardrails como utilización, QoO y presión de CPU.
+Si la telemetría RTT no está disponible temporalmente después de un reinicio, TreeGuard no trata la ausencia de RTT por sí sola como evidencia para revertir direcciones en `fq_codel`. Siguen aplicando otros guardrails como utilización, QoE y presión de CPU.
 
 TreeGuard también aplica un presupuesto global conservador de cambios SQM por tick. En poblaciones muy grandes de circuitos enrolados, los cambios SQM excedentes se difieren a ticks posteriores en lugar de saturar Bakery en una sola pasada.
 

--- a/docs/v2.0/configuration.md
+++ b/docs/v2.0/configuration.md
@@ -55,6 +55,8 @@ Read this first before production changes:
 
 LibreQoS displays QoE as an estimate of internet quality based on latency and loss.
 
+For the current circuit RTT/QoE calculation method used in WebUI circuit experience views, see [Circuit QoE and RTT Methodology](qoe-rtt-methodology.md).
+
 ### Where the file lives
 
 `<lqos_directory>/qoo_profiles.json`
@@ -87,5 +89,6 @@ For direct file editing (`/etc/lqos.conf`, `network.json`, `ShapedDevices.csv`),
 - [Quickstart](quickstart.md)
 - [Operating Modes and Source of Truth](operating-modes.md)
 - [CRM/NMS Integrations](integrations.md)
+- [Circuit QoE and RTT Methodology](qoe-rtt-methodology.md)
 - [Advanced Configuration Reference](configuration-advanced.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/v2.0/configuration.md
+++ b/docs/v2.0/configuration.md
@@ -51,9 +51,9 @@ Queue-mode note:
 Read this first before production changes:
 - [Operating Modes and Source of Truth](operating-modes.md)
 
-## QoO (Quality of Outcome) profiles (`qoo_profiles.json`)
+## QoE (Quality of Experience) profiles (`qoo_profiles.json`)
 
-LibreQoS displays QoO as an estimate of internet quality based on latency and loss.
+LibreQoS displays QoE as an estimate of internet quality based on latency and loss.
 
 ### Where the file lives
 
@@ -61,7 +61,7 @@ LibreQoS displays QoO as an estimate of internet quality based on latency and lo
 
 ### Selecting a profile
 
-- **WebUI**: Configuration -> General -> QoO Profile
+- **WebUI**: Configuration -> General -> QoE Profile
 - **Config file**: set `qoo_profile_id` in `/etc/lqos.conf`
 
 Example:

--- a/docs/v2.0/node-manager-ui.md
+++ b/docs/v2.0/node-manager-ui.md
@@ -4,6 +4,8 @@ This page documents key WebUI (Node Manager) views and operational behavior in t
 
 For the full logical-topology versus queue-topology file flow, see [Topology Data Flow](topology-data-flow.md).
 
+For the current circuit RTT/QoE calculation method used by circuit-focused experience views, see [Circuit QoE and RTT Methodology](qoe-rtt-methodology.md).
+
 ## Core Views
 
 ### Dashboard

--- a/docs/v2.0/node-manager-ui.md
+++ b/docs/v2.0/node-manager-ui.md
@@ -28,7 +28,7 @@ For the full logical-topology versus queue-topology file flow, see [Topology Dat
 - Useful for spotting bottlenecks and parent/child utilization patterns.
 - Tree detail pages show a breadcrumb path, branch counts, and status indicators for the selected node.
 - `Node Details` summarizes the selected node’s configured rates, override state, and effective rate.
-- `Node Snapshot` provides a quick visual summary of throughput and QoO for the selected node.
+- `Node Snapshot` provides a quick visual summary of throughput and QoE for the selected node.
 - Attached circuits are shown in a dedicated table for the selected node.
 - The attached-circuits table is attachment-aware, not traffic-aware: idle circuits remain visible even when they have no current throughput, with live columns left empty or zeroed until traffic appears.
 - The attached-circuits IP column keeps rows compact by showing one address inline and collapsing additional addresses as `+X`, with the full list still available on hover.
@@ -110,7 +110,7 @@ Practical meaning:
 
 ### Site Map
 - Flat operational map of Sites and APs using imported node geodata.
-- Defaults to QoO coloring with an RTT toggle, while marker size reflects recent combined throughput.
+- Defaults to QoE coloring with an RTT toggle, while marker size reflects recent combined throughput.
 - APs can inherit parent site coordinates for display when explicit AP coordinates are missing.
 - Nearby site markers cluster and expand as the operator zooms or selects a cluster.
 - APs without explicit coordinates are represented through their parent site and can be expanded temporarily around the selected site for inspection.

--- a/docs/v2.0/qoe-rtt-methodology.md
+++ b/docs/v2.0/qoe-rtt-methodology.md
@@ -1,0 +1,91 @@
+# Circuit QoE and RTT Methodology
+
+## Page Purpose
+
+Use this page to understand how LibreQoS currently calculates circuit-level RTT and QoE in the WebUI.
+
+This page describes the circuit-focused methodology used by circuit pages and other circuit experience views. Site, node, and global views may use different rollups.
+
+## What These Metrics Mean
+
+- `RTT` is the representative round-trip latency for the circuit.
+- `QoE` is the representative quality score for the circuit, based on latency and loss.
+- Both metrics are designed to reflect the subscriber's overall experience across active destinations instead of letting one raw flow define the whole circuit.
+
+## Circuit RTT
+
+LibreQoS currently calculates circuit RTT in four stages:
+
+1. Recent active flows are grouped by destination ASN within the circuit.
+2. Very small flows are ignored for RTT contribution until they have transferred at least `128 KB` in that direction.
+3. Each ASN builds its own RTT view from the RTT-bearing traffic LibreQoS can actually observe.
+4. LibreQoS combines those ASN RTT values into one circuit RTT using a weighted median.
+
+This gives more weight to meaningful active destinations while resisting single-flow or single-destination outliers.
+
+## Circuit QoE
+
+Circuit QoE uses the same ASN grouping as circuit RTT.
+
+For each active ASN, LibreQoS:
+
+- builds an RTT view from recent RTT-bearing traffic
+- estimates transport loss using TCP retransmits where available
+- applies the selected QoE profile from `qoo_profiles.json`
+
+LibreQoS then combines the per-ASN QoE values into one circuit QoE score.
+
+## How ASN Weighting Works
+
+LibreQoS does not treat every flow equally.
+
+Instead, current builds:
+
+- group flows by destination ASN
+- give more influence to ASNs carrying more active traffic
+- reduce influence when RTT-visible traffic is only a small part of that ASN's total traffic
+- cap the influence of any one ASN so a single destination cannot fully dominate the circuit score when enough distinct ASNs are active
+
+This is intended to better represent subscriber experience when a circuit is talking to many destinations at once.
+
+## Why This Is Better Than Raw Flow Weighting
+
+Raw flow weighting can be misleading:
+
+- many tiny flows can create noise
+- one large streaming flow can overstate a problem that the ISP cannot influence
+- QUIC-heavy traffic often has weaker RTT visibility than TCP
+
+The ASN-adjusted method reduces those problems by:
+
+- ignoring very small flows for RTT contribution
+- weighting by destination groups instead of raw flow count
+- discounting weak RTT evidence
+- limiting how much any single destination group can control the result
+
+## Important Limits
+
+This is still an approximation of user experience, not a perfect classifier.
+
+Keep these limits in mind:
+
+- RTT visibility is better for TCP than for encrypted QUIC-heavy traffic.
+- A single ASN can still represent multiple applications with different behavior.
+- On circuits with only a few active destinations, any cap on ASN influence has less room to work.
+- Retransmit metrics shown elsewhere in the WebUI remain direct transport-health indicators and are not all ASN-adjusted.
+
+## How To Interpret The Result
+
+Use circuit RTT and QoE as experience signals, not as protocol-forensics.
+
+Examples:
+
+- If throughput is healthy, most destinations look good, and one streaming destination looks bad, QoE should degrade less than a raw flow-based method.
+- If several major active destinations all look bad, the circuit RTT and QoE should still show that clearly.
+- If RTT coverage is weak because most traffic is QUIC or otherwise opaque, treat the score as directional rather than absolute.
+
+## Related Pages
+
+- [Configure LibreQoS](configuration.md)
+- [LibreQoS WebUI (Node Manager)](node-manager-ui.md)
+- [TreeGuard](treeguard.md)

--- a/docs/v2.0/treeguard.md
+++ b/docs/v2.0/treeguard.md
@@ -32,12 +32,12 @@ Upgraded installs are also migrated to disable `treeguard.links.enabled` and `tr
 
 ## Circuit SQM Switching Model
 
-TreeGuard evaluates utilization, RTT freshness, CPU guardrails, and optional QoO guardrails.
+TreeGuard evaluates utilization, RTT freshness, CPU guardrails, and optional QoE guardrails.
 
 High-level behavior:
 
 1. For sustained low-load conditions, TreeGuard may switch a direction from `cake` to `fq_codel`.
-2. If utilization rises, QoO guardrails are unsafe, or revert conditions are met, TreeGuard switches back toward the circuit's base SQM policy.
+2. If utilization rises, QoE guardrails are unsafe, or revert conditions are met, TreeGuard switches back toward the circuit's base SQM policy.
 3. Decisions can be independent per direction when `independent_directions = true`.
 
 This gives a dynamic profile where loaded directions favor `cake diffserv4`, while low-load directions can use `fq_codel` when conditions are safe.
@@ -58,7 +58,7 @@ TreeGuard config lives under `[treeguard]` and sub-sections:
 2. `[treeguard.cpu]`: CPU-aware vs traffic/RTT mode and thresholds.
 3. `[treeguard.links]`: node virtualization enrollment and guardrails.
 4. `[treeguard.circuits]`: circuit enrollment and SQM switching guardrails.
-5. `[treeguard.qoo]`: optional QoO protection threshold.
+5. `[treeguard.qoo]`: optional QoE protection threshold.
 
 Current default behavior:
 
@@ -88,7 +88,7 @@ independent_directions = true
 enabled = true
 ```
 
-TreeGuard circuit behavior is CPU-aware by default. Traffic, RTT, and QoO remain important safety
+TreeGuard circuit behavior is CPU-aware by default. Traffic, RTT, and QoE remain important safety
 and restore signals for circuit SQM decisions. Upgraded installs from older defaults are also
 migrated from `traffic_rtt_only` to `cpu_aware`, with a visible notice in logs/UI.
 
@@ -127,7 +127,7 @@ TreeGuard also refuses to manage nodes that are already marked `"virtual": true`
 
 For circuit SQM management, TreeGuard treats duplicate `device_id` values as unsafe identity collisions. If the same `device_id` appears in more than one circuit in `ShapedDevices.csv`, TreeGuard skips those affected circuits and clears any TreeGuard-owned SQM overrides for those duplicate device IDs.
 
-If RTT telemetry is temporarily unavailable after a restart, TreeGuard does not treat missing RTT alone as evidence that it should revert `fq_codel` directions. Other guardrails such as utilization, QoO, and CPU pressure still apply.
+If RTT telemetry is temporarily unavailable after a restart, TreeGuard does not treat missing RTT alone as evidence that it should revert `fq_codel` directions. Other guardrails such as utilization, QoE, and CPU pressure still apply.
 
 TreeGuard also applies a conservative global per-tick circuit SQM change budget. On very large enrolled populations, excess circuit SQM changes are deferred to later ticks instead of stampeding Bakery in one pass.
 

--- a/index.rst
+++ b/index.rst
@@ -29,6 +29,7 @@ Welcome to the LibreQoS documentation
    docs/v2.0/integrations
    docs/v2.0/components
    docs/v2.0/node-manager-ui
+   docs/v2.0/qoe-rtt-methodology
    docs/v2.0/scale-topology
    docs/v2.0/stormguard
    docs/v2.0/treeguard

--- a/src/rust/lqosd/src/node_manager/js_build/src/asn_analysis.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/asn_analysis.js
@@ -350,7 +350,7 @@ function rankRationale(row) {
         reasons.push("higher RTT");
     }
     if (!reasons.length) {
-        reasons.push("balanced impact across current QoO signals");
+        reasons.push("balanced impact across current QoE signals");
     }
     return `Within the current top-20 traffic and throughput ASNs, this one stands out due to ${reasons.join(" + ")}.`;
 }
@@ -432,13 +432,13 @@ function renderSelectedAsnSummary() {
     const badgeStyle = qooBadgeClass(row.qooScore);
     kpis.innerHTML = `
         <div class="asn-analysis-kpi">
-            <label>QoO Status</label>
+            <label>QoE Status</label>
             <strong>
                 <span class="asn-analysis-qoo-badge" style="background:${badgeStyle.background};color:${badgeStyle.color};border-color:${badgeStyle.borderColor}">
                     ${row.qooStatus} · ${row.qooScore}
                 </span>
             </strong>
-            <small>Traffic-aware QoO impact score</small>
+            <small>Traffic-aware QoE impact score</small>
         </div>
         <div class="asn-analysis-kpi">
             <label>Median RTT</label>
@@ -545,7 +545,7 @@ function renderBubbleChart() {
                         <div>Median RTT: ${formatRttMs(row.medianRtt)}</div>
                         <div>Median Retransmit: ${formatRetransPct(toNumber(row.medianRetrans, 0))}</div>
                         <div>Recent Flows: ${formatFlowCount(row.flowCount)}</div>
-                        <div>QoO: ${row.qooStatus} · ${row.qooScore}</div>
+                        <div>QoE: ${row.qooStatus} · ${row.qooScore}</div>
                     </div>
                 `;
             },
@@ -646,7 +646,7 @@ function renderRetransmitChart() {
                         <div>Retransmit: ${formatRetransPct(toNumber(row.medianRetrans, 0))}</div>
                         <div>Traffic: ${formatVolume(row.totalBytes)} (${formatTrafficRateMbps(row.avgMbps)})</div>
                         <div>Median RTT: ${formatRttMs(row.medianRtt)}</div>
-                        <div>QoO: ${row.qooStatus} · ${row.qooScore}</div>
+                        <div>QoE: ${row.qooStatus} · ${row.qooScore}</div>
                     </div>
                 `;
             },

--- a/src/rust/lqosd/src/node_manager/js_build/src/circuit.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/circuit.js
@@ -1734,7 +1734,7 @@ function renderTopAsnTab() {
     thead.appendChild(createSortableHeader("Country", "country"));
     thead.appendChild(createSortableHeader("Current Rate (d/u)", "rate", 2));
     thead.appendChild(createSortableHeader("RTT (d/u)", "rtt", 2));
-    thead.appendChild(createSortableHeader("QoO (d/u)", "qoo", 2));
+    thead.appendChild(createSortableHeader("QoE (d/u)", "qoo", 2));
     thead.appendChild(createSortableHeader("TCP rxmit (d/u)", "retransmits", 2));
     thead.appendChild(createSortableHeader("Flows", "flows"));
     table.appendChild(thead);
@@ -1820,7 +1820,7 @@ function renderTrafficTab() {
     thead.appendChild(createSortableHeader("Total Packets (d/u)", "packets", 2));
     thead.appendChild(createSortableHeader("TCP rxmit (d/u)", "retransmits", 2));
     thead.appendChild(createSortableHeader("RTT (d/u)", "rtt", 2));
-    thead.appendChild(createSortableHeader("QoO (d/u)", "qoo", 2));
+    thead.appendChild(createSortableHeader("QoE (d/u)", "qoo", 2));
     thead.appendChild(createSortableHeader("ASN", "asn"));
     thead.appendChild(createSortableHeader("Country", "country"));
     thead.appendChild(createSortableHeader("Remote IP", "ip"));

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_general.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_general.js
@@ -211,7 +211,7 @@ loadConfig(() => {
                     if (selectedId && !qooProfiles.profiles.some(p => p.id === selectedId)) {
                         setQooProfilesAlert(
                             "warning",
-                            `Selected QoO profile '${selectedId}' was not found in ${profilesPath}.`,
+                            `Selected QoE profile '${selectedId}' was not found in ${profilesPath}.`,
                         );
                     } else {
                         setQooProfilesAlert("", "");
@@ -234,7 +234,7 @@ loadConfig(() => {
                     if (!known) {
                         setQooProfilesAlert(
                             "warning",
-                            `Configured QoO profile '${configuredId}' was not found in ${profilesPath}.`,
+                            `Configured QoE profile '${configuredId}' was not found in ${profilesPath}.`,
                         );
                     }
                 }
@@ -245,7 +245,7 @@ loadConfig(() => {
                 renderQooProfilesTable();
                 setQooProfilesAlert(
                     "warning",
-                    `Unable to load QoO profiles. Create or fix ${profilesPath}, then reload this page.`,
+                    `Unable to load QoE profiles. Create or fix ${profilesPath}, then reload this page.`,
                 );
             },
         );

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_treeguard.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_treeguard.js
@@ -421,7 +421,7 @@ function validateConfig() {
     if (!validateNonNegativeInt("Max Switches Per Hour", maxSwitchesPerHour)) return false;
 
     const minScore = parseFloat(document.getElementById("minScore").value);
-    if (!validatePercent("Minimum QoO Score", minScore)) return false;
+    if (!validatePercent("Minimum QoE Score", minScore)) return false;
 
     return true;
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/dashlet_index.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/dashlet_index.js
@@ -125,7 +125,7 @@ export const DashletMenu = [
     { name: "Median RTT Heatmap", tag: "executiveHeatmapRtt", size: 6, category: "Executive" },
     { name: "TCP Retransmits Heatmap", tag: "executiveHeatmapRetrans", size: 6, category: "Executive" },
     { name: "Utilization Heatmap", tag: "executiveHeatmapDownload", size: 6, category: "Executive" },
-    { name: "QoO Heatmap", tag: "executiveHeatmapUpload", size: 6, category: "Executive" },
+    { name: "QoE Heatmap", tag: "executiveHeatmapUpload", size: 6, category: "Executive" },
 ];
 
 export function widgetFactory(widgetName, count) {

--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/executive_heatmap_panels.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/executive_heatmap_panels.js
@@ -15,9 +15,9 @@ import {
 } from "./executive_heatmap_shared";
 
 const QOO_TOOLTIP_HTML = [
-    `Quality of Outcome (QoO) is IETF IPPM “Internet Quality” (draft-ietf-ippm-qoo).`,
-    `https://datatracker.ietf.org/doc/draft-ietf-ippm-qoo/`,
-    `LibreQoS implements a latency- and loss-based model to estimate Quality of Outcome.`,
+    `Quality of Experience (QoE) summarizes latency and loss across active destinations.`,
+    `Higher scores are better.`,
+    `LibreQoS uses QoE throughout these score-based views.`,
 ].join("<br>");
 
 function escapeAttr(value) {
@@ -38,7 +38,7 @@ function escapeHtml(value) {
 
 function qooInfoIconHtml() {
     const title = escapeAttr(QOO_TOOLTIP_HTML);
-    return `<span class="ms-1 text-muted" role="button" tabindex="0" aria-label="QoO information" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="${title}"><i class="fas fa-info-circle"></i></span>`;
+    return `<span class="ms-1 text-muted" role="button" tabindex="0" aria-label="QoE information" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="${title}"><i class="fas fa-info-circle"></i></span>`;
 }
 
 function qoqHeatmapRow(blocks, colorFn) {
@@ -56,7 +56,7 @@ function qoqHeatmapRow(blocks, colorFn) {
             (dlTotal === null || dlTotal === undefined) &&
             (ulTotal === null || ulTotal === undefined);
         if (allMissing) {
-            cells += `<div class="exec-heat-cell empty" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-container="body" data-bs-trigger="hover focus" data-bs-html="true" tabindex="0" title="${escapeAttr(`<div class=&quot;fw-semibold&quot;>15-minute block ${i + 1}</div><div>No data</div><div>This block has no QoO/QoQ totals yet.</div>`)}" aria-label="${escapeAttr(`15-minute block ${i + 1}. No data. This block has no QoO/QoQ totals yet.`)}"></div>`;
+            cells += `<div class="exec-heat-cell empty" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-container="body" data-bs-trigger="hover focus" data-bs-html="true" tabindex="0" title="${escapeAttr(`<div class=&quot;fw-semibold&quot;>15-minute block ${i + 1}</div><div>No data</div><div>This block has no QoE/QoQ totals yet.</div>`)}" aria-label="${escapeAttr(`15-minute block ${i + 1}. No data. This block has no QoE/QoQ totals yet.`)}"></div>`;
             continue;
         }
 
@@ -277,7 +277,7 @@ export class ExecutiveGlobalHeatmapDashlet extends ExecutiveHeatmapBase {
             return;
         }
         const rows = [
-            { kind: "qoo", label: "Overall QoO", labelHtml: `Overall QoO${qooInfoIconHtml()}`, badge: "Global", blocks: globalQoq },
+            { kind: "qoo", label: "Overall QoE", labelHtml: `Overall QoE${qooInfoIconHtml()}`, badge: "Global", blocks: globalQoq },
             { kind: "rtt", label: "RTT (p50/p90)", badge: "Global", blocks: global },
             { kind: "retransmit", label: "TCP Retransmits", badge: "Global", blocks: global, color: (v) => colorByRetransmitPct(Math.min(10, Math.max(0, v || 0))), format: (v) => formatLatest(v, "%", 1) },
             { kind: "utilization", label: "Utilization", badge: "Global", blocks: global, color: colorByCapacity, format: (v) => formatLatest(v, "%") },
@@ -423,7 +423,7 @@ class ExecutiveMetricHeatmapBase extends ExecutiveHeatmapBase {
             : "";
         const isQooMetric = this.config.metricKey === "qoo";
         const titleLabel = isQooMetric
-            ? `QoO${qooInfoIconHtml()} Heatmap`
+            ? `QoE${qooInfoIconHtml()} Heatmap`
             : this.config.title;
         const titleHtml = this.config.link
             ? `<a class="text-decoration-none text-secondary" href="${this.config.link}"><i class="fas ${this.config.icon} me-2 text-primary"></i>${titleLabel}${linkIcon}</a>`
@@ -514,7 +514,7 @@ export class ExecutiveDownloadHeatmapDashlet extends ExecutiveMetricHeatmapBase 
 export class ExecutiveUploadHeatmapDashlet extends ExecutiveMetricHeatmapBase {
     constructor(slot) {
         super(slot, {
-            title: "QoO Heatmap",
+            title: "QoE Heatmap",
             icon: "fa-bullseye",
             metricKey: "qoo",
             colorFn: colorByQoqScore,
@@ -525,5 +525,5 @@ export class ExecutiveUploadHeatmapDashlet extends ExecutiveMetricHeatmapBase {
             minSamples: 3,
         });
     }
-    title() { return "QoO Heatmap"; }
+    title() { return "QoE Heatmap"; }
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/graphs/qoo_score_gauge.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/graphs/qoo_score_gauge.js
@@ -23,7 +23,7 @@ export class QooScoreGauge extends DashboardGraph {
             },
             xAxis: {
                 type: 'category',
-                data: ['QoO'],
+                data: ['QoE'],
                 axisLine: { show: false },
                 axisTick: { show: false },
                 axisLabel: { show: false },
@@ -63,7 +63,7 @@ export class QooScoreGauge extends DashboardGraph {
                     left: 'center',
                     top: 0,
                     style: {
-                        text: 'QoO',
+                        text: 'QoE',
                         fill: '#aaa',
                         fontSize: 11,
                         fontWeight: 'bold',
@@ -117,4 +117,3 @@ export class QooScoreGauge extends DashboardGraph {
         this.chart.setOption(this.option);
     }
 }
-

--- a/src/rust/lqosd/src/node_manager/js_build/src/shaped-devices.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/shaped-devices.js
@@ -22,10 +22,9 @@ let circuitMetricsWatchSignature = null;
 const wsClient = get_ws_client();
 
 const QOO_TOOLTIP_HTML =
-    "<h5>Quality of Outcome (QoO)</h5>" +
-    "<p>Quality of Outcome (QoO) is IETF IPPM “Internet Quality” (draft-ietf-ippm-qoo).<br>" +
-    "https://datatracker.ietf.org/doc/draft-ietf-ippm-qoo/<br>" +
-    "LibreQoS implements a latency and loss-based model to estimate quality of outcome.</p>";
+    "<h5>Quality of Experience (QoE)</h5>" +
+    "<p>Quality of Experience (QoE) summarizes latency and loss across active destinations.<br>" +
+    "Higher scores are better.</p>";
 
 function sendWsRequest(responseEvent, request) {
     return new Promise((resolve, reject) => {
@@ -370,7 +369,7 @@ function buildDeviceCard(device) {
     registerMetricEl(device.circuit_id, "rttUp", rttUp);
 
     const qooLabelWrap = document.createElement("span");
-    qooLabelWrap.innerHTML = "QoO <i class='fas fa-info-circle'></i>";
+    qooLabelWrap.innerHTML = "QoE <i class='fas fa-info-circle'></i>";
     qooLabelWrap.setAttribute("data-bs-toggle", "tooltip");
     qooLabelWrap.setAttribute("data-bs-placement", "top");
     qooLabelWrap.setAttribute("data-bs-html", "true");

--- a/src/rust/lqosd/src/node_manager/js_build/src/site_map.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/site_map.js
@@ -1882,7 +1882,7 @@ class SiteMapPage {
                 <div class="text-muted mb-2">${escapeHtml(String(props.nodeType || "").toUpperCase())}</div>
                 <div><strong>Throughput:</strong> ${escapeHtml(formatBitsPerSecond(props.throughputCombined))}</div>
                 ${attachedApCount > 0 ? `<div><strong>Attached APs:</strong> ${escapeHtml(String(attachedApCount))}</div>` : ""}
-                <div><strong>${this.mode === "qoo" ? "QoO" : "RTT"}:</strong> ${escapeHtml(this.mode === "qoo" ? formatPercent(Math.min(toNumber(props.qooDown, NaN), toNumber(props.qooUp, NaN))) : formatMs(Math.max(toNumber(props.rttDownMs, NaN), toNumber(props.rttUpMs, NaN))))}</div>
+                <div><strong>${this.mode === "qoo" ? "QoE" : "RTT"}:</strong> ${escapeHtml(this.mode === "qoo" ? formatPercent(Math.min(toNumber(props.qooDown, NaN), toNumber(props.qooUp, NaN))) : formatMs(Math.max(toNumber(props.rttDownMs, NaN), toNumber(props.rttUpMs, NaN))))}</div>
             </div>`;
     }
 
@@ -1973,8 +1973,8 @@ class SiteMapPage {
             props.nodeType === "site"
                 ? this.metricCard("Attached APs", String(attachedAps.length))
                 : this.metricCard("Coordinate source", props.inheritedCoords ? "Inherited from site" : "Explicit"),
-            this.metricCard("QoO download", formatPercent(props.qooDown)),
-            this.metricCard("QoO upload", formatPercent(props.qooUp)),
+            this.metricCard("QoE download", formatPercent(props.qooDown)),
+            this.metricCard("QoE upload", formatPercent(props.qooUp)),
             this.metricCard("RTT download", formatMs(props.rttDownMs)),
             this.metricCard("RTT upload", formatMs(props.rttUpMs)),
         ].join("");
@@ -2037,8 +2037,8 @@ class SiteMapPage {
             this.legendGradient.style.background = isColorBlindMode()
                 ? "linear-gradient(90deg, #440154 0%, #3b528b 30%, #21918c 55%, #5ec962 78%, #fde725 100%)"
                 : "linear-gradient(90deg, #ff0000 0%, #bf4000 25%, #808000 50%, #40bf00 75%, #00ff00 100%)";
-            this.legendLow.textContent = "Poor QoO";
-            this.legendHigh.textContent = "Healthy QoO";
+            this.legendLow.textContent = "Poor QoE";
+            this.legendHigh.textContent = "Healthy QoE";
         } else {
             this.legendGradient.style.background = isColorBlindMode()
                 ? "linear-gradient(90deg, #440154 0%, #3b528b 30%, #21918c 55%, #5ec962 78%, #fde725 100%)"

--- a/src/rust/lqosd/src/node_manager/js_build/src/tree.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/tree.js
@@ -45,10 +45,9 @@ var nodeTopologyOverrideState = {
 var nodeOverrideInputsDirty = false;
 var nodeOverrideLastSeedSignature = null;
 const wsClient = get_ws_client();
-const QOO_TOOLTIP_HTML = "<h5>Quality of Outcome (QoO)</h5>" +
-    "<p>Quality of Outcome (QoO) is IETF IPPM “Internet Quality” (draft-ietf-ippm-qoo).<br>" +
-    "https://datatracker.ietf.org/doc/draft-ietf-ippm-qoo/<br>" +
-    "LibreQoS implements a latency and loss-based model to estimate quality of outcome.</p>";
+const QOO_TOOLTIP_HTML = "<h5>Quality of Experience (QoE)</h5>" +
+    "<p>Quality of Experience (QoE) summarizes latency and loss across active destinations.<br>" +
+    "Higher scores are better.</p>";
 const THROUGHPUT_COMPARE_EPSILON_MBPS = 0.01;
 const NODE_OVERRIDE_PENDING_TOOLTIP = "Stored as an operator override. Will be applied to generated network.json on the next scheduler run.";
 const TOPOLOGY_OVERRIDE_PENDING_TOOLTIP = "Stored as an operator topology override. The selected parent will be applied on the next scheduler run.";
@@ -1360,7 +1359,7 @@ function renderTree() {
     thead.appendChild(theading("⬇️"));
     thead.appendChild(theading("⬆️"));
     thead.appendChild(theading("RTT", 2, "<h5>TCP Round-Trip Time</h5><p>Current median TCP round-trip time. Time taken for a full send-acknowledge round trip. Low numbers generally equate to a smoother user experience.</p>", "tts_retransmits"));
-    thead.appendChild(theading("QoO", 2, QOO_TOOLTIP_HTML, "tts_qoo"));
+    thead.appendChild(theading("QoE", 2, QOO_TOOLTIP_HTML, "tts_qoo"));
     thead.appendChild(theading("Retr", 2, "<h5>TCP Retransmits</h5><p>Number of TCP retransmits in the last second.</p>", "tts_retransmits"));
     thead.appendChild(theading("Marks", 2, "<h5>Cake Marks</h5><p>Number of times the Cake traffic manager has applied ECN marks to avoid congestion.</p>", "tts_marks"));
     thead.appendChild(theading("Drops", 2, "<h5>Cake Drops</h5><p>Number of times the Cake traffic manager has dropped packets to avoid congestion.</p>", "tts_drops"));

--- a/src/rust/lqosd/src/node_manager/static2/asn_analysis.html
+++ b/src/rust/lqosd/src/node_manager/static2/asn_analysis.html
@@ -431,7 +431,7 @@
                             <th>Flows</th>
                             <th>RTT</th>
                             <th>Retrans</th>
-                            <th>QoO</th>
+                            <th>QoE</th>
                         </tr>
                         </thead>
                         <tbody id="asnAnalysisLeaderboardBody">

--- a/src/rust/lqosd/src/node_manager/static2/circuit.html
+++ b/src/rust/lqosd/src/node_manager/static2/circuit.html
@@ -43,7 +43,7 @@
                                         aria-label="Exclude from RTT information"
                                         data-bs-toggle="tooltip"
                                         data-bs-placement="top"
-                                        title="Exclude this circuit from RTT heatmaps and QoO RTT scoring. QoO will show as unknown."
+                                        title="Exclude this circuit from RTT heatmaps and QoE RTT scoring. QoE will show as unknown."
                                     ><i class="fas fa-info-circle"></i></span>
                                 </label>
                             </div>

--- a/src/rust/lqosd/src/node_manager/static2/config_general.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_general.html
@@ -93,8 +93,8 @@
         <section class="lqos-config-panel">
             <div class="lqos-config-panel-header">
                 <div>
-                    <h5 class="lqos-config-panel-title">QoO Profiles</h5>
-                    <div class="lqos-config-panel-subtitle">Choose the default Quality of Outcome profile and review the profile catalog currently available on disk.</div>
+                    <h5 class="lqos-config-panel-title">QoE Profiles</h5>
+                    <div class="lqos-config-panel-subtitle">Choose the default Quality of Experience profile and review the profile catalog currently available on disk.</div>
                 </div>
             </div>
 
@@ -102,23 +102,23 @@
                 <div class="col-12 col-xl-4">
                     <div class="lqos-config-section h-100">
                         <h6 class="lqos-config-section-title">Profile Selection</h6>
-                        <div class="lqos-config-section-subtitle">Set the profile used for QoO and QoQ scoring throughout the WebUI.</div>
+                        <div class="lqos-config-section-subtitle">Set the profile used for QoE and QoQ scoring throughout the WebUI.</div>
 
                         <div class="mb-3">
-                            <label for="qooProfileId" class="form-label">QoO Profile</label>
+                            <label for="qooProfileId" class="form-label">QoE Profile</label>
                             <select class="form-select" id="qooProfileId"></select>
                             <div class="form-text">Choose (default) to use the configured default profile.</div>
                         </div>
 
                         <div class="lqos-config-note" role="note">
-                            QoO profiles are defined in <code id="qooProfilesPath">qoo_profiles.json</code>. Edit that file to add or change profiles, then reload this page.
+                            QoE profiles are defined in <code id="qooProfilesPath">qoo_profiles.json</code>. Edit that file to add or change profiles, then reload this page.
                         </div>
                     </div>
                 </div>
 
                 <div class="col-12 col-xl-8">
                     <div class="card h-100">
-                        <div class="card-header">Available QoO Profiles</div>
+                        <div class="card-header">Available QoE Profiles</div>
                         <div class="card-body">
                             <div id="qooProfilesLoadAlert"></div>
                             <div class="table-responsive lqos-table-wrap">

--- a/src/rust/lqosd/src/node_manager/static2/config_rtt.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_rtt.html
@@ -6,12 +6,12 @@
             <div class="lqos-config-panel-header">
                 <div>
                     <h5 class="lqos-config-panel-title">RTT Color Thresholds</h5>
-                    <div class="lqos-config-panel-subtitle">Control how latency is colored across the WebUI without changing QoO or QoQ scoring behavior.</div>
+                    <div class="lqos-config-panel-subtitle">Control how latency is colored across the WebUI without changing QoE or QoQ scoring behavior.</div>
                 </div>
             </div>
 
             <div class="lqos-config-note mb-3" role="note">
-                These values control how RTT (latency) is colored in heatmaps, map markers, and RTT blocks. They do <strong>not</strong> change QoO/QoQ scoring.
+                These values control how RTT (latency) is colored in heatmaps, map markers, and RTT blocks. They do <strong>not</strong> change QoE/QoQ scoring.
             </div>
 
             <div class="row g-3">

--- a/src/rust/lqosd/src/node_manager/static2/config_treeguard.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_treeguard.html
@@ -310,7 +310,7 @@
         <section class="lqos-config-panel">
             <div class="lqos-config-panel-header">
                 <div>
-                    <h5 class="lqos-config-panel-title">QoO Guardrail</h5>
+                    <h5 class="lqos-config-panel-title">QoE Guardrail</h5>
                     <div class="lqos-config-panel-subtitle">Prevent CPU-saving actions when quality is already degraded.</div>
                 </div>
             </div>
@@ -319,18 +319,18 @@
                 <div class="col-12 col-lg-6">
                     <div class="lqos-config-section h-100">
                         <h6 class="lqos-config-section-title">Guardrail Policy</h6>
-                        <div class="lqos-config-section-subtitle">Use QoO as a veto when service quality is already below the desired threshold.</div>
+                        <div class="lqos-config-section-subtitle">Use QoE as a veto when service quality is already below the desired threshold.</div>
 
                         <div class="mb-3 form-check">
                             <input type="checkbox" class="form-check-input" id="qooEnabled">
-                            <label class="form-check-label" for="qooEnabled">Enable QoO Guardrail</label>
-                            <div class="form-text">If QoO is available and below the threshold, do not take CPU-saving actions.</div>
+                            <label class="form-check-label" for="qooEnabled">Enable QoE Guardrail</label>
+                            <div class="form-text">If QoE is available and below the threshold, do not take CPU-saving actions.</div>
                         </div>
 
                         <div class="mb-0">
-                            <label for="minScore" class="form-label">Minimum QoO Score</label>
+                            <label for="minScore" class="form-label">Minimum QoE Score</label>
                             <input type="number" class="form-control" id="minScore" min="0" max="100" step="0.1" value="70.0">
-                            <div class="form-text">0 to 100; enforced only when QoO is available.</div>
+                            <div class="form-text">0 to 100; enforced only when QoE is available.</div>
                         </div>
                     </div>
                 </div>

--- a/src/rust/lqosd/src/node_manager/static2/site_map.html
+++ b/src/rust/lqosd/src/node_manager/static2/site_map.html
@@ -353,7 +353,7 @@
             </div>
         <div class="site-map-controls">
             <div class="site-map-mode-toggle" role="group" aria-label="Site Map mode">
-                <button type="button" class="btn btn-sm btn-primary active" id="siteMapModeQoo">QoO</button>
+                <button type="button" class="btn btn-sm btn-primary active" id="siteMapModeQoo">QoE</button>
                 <button type="button" class="btn btn-sm btn-outline-secondary" id="siteMapModeRtt">RTT</button>
             </div>
             <span class="site-map-divider" aria-hidden="true"></span>

--- a/src/rust/lqosd/src/node_manager/static2/tree.html
+++ b/src/rust/lqosd/src/node_manager/static2/tree.html
@@ -46,7 +46,7 @@
                             <td><span id="parentRttU"></span></td>
                         </tr>
                         <tr class="small">
-                            <td class="table-label-cell">QoO</td>
+                            <td class="table-label-cell">QoE</td>
                             <td><span id="parentQooD"></span></td>
                             <td><span id="parentQooU"></span></td>
                         </tr>

--- a/src/rust/lqosd/src/throughput_tracker/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/mod.rs
@@ -26,7 +26,6 @@ use lqos_bus::{
 };
 use lqos_queue_tracker::{ALL_QUEUE_SUMMARY, queue_stats_stale};
 use lqos_sys::flowbee_data::FlowbeeKey;
-use lqos_utils::rtt::RttBucket;
 use lqos_utils::units::{DownUpOrder, TcpRetransmitSample, down_up_retransmit_sample};
 use lqos_utils::{XdpIpAddress, hash_to_i64, unix_time::time_since_boot};
 use once_cell::sync::Lazy;
@@ -43,37 +42,33 @@ const RELOAD_THROUGHPUT_POLL_INTERVAL_SECONDS: u64 = 5;
 pub static THROUGHPUT_TRACKER: Lazy<ThroughputTracker> = Lazy::new(ThroughputTracker::new);
 pub(crate) static CIRCUIT_RTT_BUFFERS: Lazy<ArcSwap<FxHashMap<i64, RttBuffer>>> =
     Lazy::new(|| ArcSwap::new(Arc::new(FxHashMap::default())));
+pub(crate) static CIRCUIT_REPRESENTATIVE_METRICS: Lazy<
+    ArcSwap<FxHashMap<i64, CircuitRepresentativeMetrics>>,
+> = Lazy::new(|| ArcSwap::new(Arc::new(FxHashMap::default())));
 
-/// Returns the current per-circuit RTT p50 values from the shared circuit RTT buffers.
-pub(crate) fn circuit_current_rtt_p50_nanos(circuit_hash: i64) -> DownUpOrder<Option<u64>> {
-    let snapshot = CIRCUIT_RTT_BUFFERS.load();
-    let rtt = snapshot.get(&circuit_hash);
-
-    DownUpOrder {
-        down: rtt
-            .and_then(|rtt| {
-                rtt.percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50)
-            })
-            .map(|rtt| rtt.as_nanos()),
-        up: rtt
-            .and_then(|rtt| {
-                rtt.percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 50)
-            })
-            .map(|rtt| rtt.as_nanos()),
-    }
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct CircuitRepresentativeMetrics {
+    pub rtt_current_p50_nanos: DownUpOrder<Option<u64>>,
+    pub rtt_current_p90_nanos: DownUpOrder<Option<u64>>,
+    pub qoo: DownUpOrder<Option<f32>>,
 }
 
-/// Returns the current per-circuit QoO values from the shared circuit QoO heatmaps.
+/// Returns the current per-circuit representative RTT p50 values.
+pub(crate) fn circuit_current_rtt_p50_nanos(circuit_hash: i64) -> DownUpOrder<Option<u64>> {
+    CIRCUIT_REPRESENTATIVE_METRICS
+        .load()
+        .get(&circuit_hash)
+        .map(|metrics| metrics.rtt_current_p50_nanos)
+        .unwrap_or_default()
+}
+
+/// Returns the current per-circuit representative QoO values.
 pub(crate) fn circuit_current_qoo(circuit_hash: i64) -> DownUpOrder<Option<f32>> {
-    let qoq_heatmaps = THROUGHPUT_TRACKER.circuit_qoq_heatmaps.lock();
-    let Some(heatmap) = qoq_heatmaps.get(&circuit_hash) else {
-        return DownUpOrder::default();
-    };
-    let blocks = heatmap.blocks();
-    DownUpOrder {
-        down: blocks.download_total.last().copied().flatten(),
-        up: blocks.upload_total.last().copied().flatten(),
-    }
+    CIRCUIT_REPRESENTATIVE_METRICS
+        .load()
+        .get(&circuit_hash)
+        .map(|metrics| metrics.qoo)
+        .unwrap_or_default()
 }
 
 fn shaped_device_for_entry<'a>(
@@ -1425,19 +1420,17 @@ pub struct Lts2Device {
 #[cfg(test)]
 mod compatibility_tests {
     use super::{
-        CIRCUIT_RTT_BUFFERS, Lts2Circuit, circuit_current_qoo, circuit_current_rtt_p50_nanos,
-        resolve_circuit_metadata_for_entry,
+        CIRCUIT_REPRESENTATIVE_METRICS, CircuitRepresentativeMetrics, Lts2Circuit,
+        circuit_current_qoo, circuit_current_rtt_p50_nanos, resolve_circuit_metadata_for_entry,
     };
     use crate::shaped_devices_tracker::ShapedDeviceHashCache;
-    use crate::throughput_tracker::flow_data::{FlowbeeEffectiveDirection, RttData};
+    use crate::throughput_tracker::flow_data::RttData;
     use crate::throughput_tracker::throughput_entry::ThroughputEntry;
     use fxhash::FxHashMap;
     use lqos_bus::TcHandle;
     use lqos_config::{ConfigShapedDevices, ShapedDevice};
     use lqos_utils::XdpIpAddress;
     use lqos_utils::qoo::QoqScores;
-    use lqos_utils::qoq_heatmap::TemporalQoqHeatmap;
-    use lqos_utils::rtt::RttBuffer;
     use lqos_utils::units::DownUpOrder;
     use serde::Deserialize;
     use std::net::Ipv4Addr;
@@ -1550,63 +1543,53 @@ mod compatibility_tests {
     }
 
     #[test]
-    fn circuit_current_rtt_p50_nanos_reads_from_shared_circuit_buffer() {
-        let old_rtt = CIRCUIT_RTT_BUFFERS.load_full();
+    fn circuit_current_rtt_p50_nanos_reads_from_representative_metrics_snapshot() {
+        let old_snapshot = CIRCUIT_REPRESENTATIVE_METRICS.load_full();
 
-        let mut rtt = RttBuffer::default();
-        rtt.push(
-            RttData::from_nanos(11_000_000),
-            FlowbeeEffectiveDirection::Download,
-            1,
+        let mut snapshot = FxHashMap::default();
+        snapshot.insert(
+            123_i64,
+            CircuitRepresentativeMetrics {
+                rtt_current_p50_nanos: DownUpOrder {
+                    down: Some(12_000_000),
+                    up: Some(35_000_000),
+                },
+                rtt_current_p90_nanos: DownUpOrder::default(),
+                qoo: DownUpOrder::default(),
+            },
         );
-        rtt.push(
-            RttData::from_nanos(11_000_000),
-            FlowbeeEffectiveDirection::Download,
-            1,
-        );
-        rtt.push(
-            RttData::from_nanos(31_000_000),
-            FlowbeeEffectiveDirection::Upload,
-            1,
-        );
-        rtt.push(
-            RttData::from_nanos(31_000_000),
-            FlowbeeEffectiveDirection::Upload,
-            1,
-        );
-
-        let mut rtt_map = FxHashMap::default();
-        rtt_map.insert(123_i64, rtt);
-        CIRCUIT_RTT_BUFFERS.store(Arc::new(rtt_map));
+        CIRCUIT_REPRESENTATIVE_METRICS.store(Arc::new(snapshot));
 
         let result = circuit_current_rtt_p50_nanos(123);
 
         assert_eq!(result.down, Some(12_000_000));
         assert_eq!(result.up, Some(35_000_000));
 
-        CIRCUIT_RTT_BUFFERS.store(old_rtt);
+        CIRCUIT_REPRESENTATIVE_METRICS.store(old_snapshot);
     }
 
     #[test]
-    fn circuit_current_qoo_reads_from_shared_circuit_heatmap() {
-        let mut heatmap = TemporalQoqHeatmap::new();
-        heatmap.add_sample(Some(88.0), Some(77.0));
+    fn circuit_current_qoo_reads_from_representative_metrics_snapshot() {
+        let old_snapshot = CIRCUIT_REPRESENTATIVE_METRICS.load_full();
 
-        let mut qoq_heatmaps = crate::throughput_tracker::THROUGHPUT_TRACKER
-            .circuit_qoq_heatmaps
-            .lock();
-        let old_qoq = qoq_heatmaps.clone();
-        qoq_heatmaps.clear();
-        qoq_heatmaps.insert(456_i64, heatmap);
-        drop(qoq_heatmaps);
+        let mut snapshot = FxHashMap::default();
+        snapshot.insert(
+            456_i64,
+            CircuitRepresentativeMetrics {
+                rtt_current_p50_nanos: DownUpOrder::default(),
+                rtt_current_p90_nanos: DownUpOrder::default(),
+                qoo: DownUpOrder {
+                    down: Some(88.0),
+                    up: Some(77.0),
+                },
+            },
+        );
+        CIRCUIT_REPRESENTATIVE_METRICS.store(Arc::new(snapshot));
 
         let result = circuit_current_qoo(456);
         assert_eq!(result.down, Some(88.0));
         assert_eq!(result.up, Some(77.0));
 
-        let mut qoq_heatmaps = crate::throughput_tracker::THROUGHPUT_TRACKER
-            .circuit_qoq_heatmaps
-            .lock();
-        *qoq_heatmaps = old_qoq;
+        CIRCUIT_REPRESENTATIVE_METRICS.store(old_snapshot);
     }
 }

--- a/src/rust/lqosd/src/throughput_tracker/tracking_data.rs
+++ b/src/rust/lqosd/src/throughput_tracker/tracking_data.rs
@@ -1,5 +1,5 @@
 use super::{
-    RETIRE_AFTER_SECONDS,
+    CIRCUIT_REPRESENTATIVE_METRICS, CircuitRepresentativeMetrics, RETIRE_AFTER_SECONDS,
     flow_data::{
         ALL_FLOWS, AsnAggregate, FlowAnalysis, FlowbeeLocalData, RttBuffer, RttData,
         get_flowbee_event_count_and_reset, update_asn_heatmaps,
@@ -8,7 +8,9 @@ use super::{
 };
 use crate::throughput_tracker::CIRCUIT_RTT_BUFFERS;
 use crate::{
-    shaped_devices_tracker::{SHAPED_DEVICE_HASH_CACHE, SHAPED_DEVICES},
+    shaped_devices_tracker::{
+        SHAPED_DEVICE_HASH_CACHE, SHAPED_DEVICES, shaped_device_from_hashes_or_ip,
+    },
     stats::HIGH_WATERMARK,
     throughput_tracker::flow_data::{FlowbeeEffectiveDirection, expire_rtt_flows, flowbee_rtt_map},
 };
@@ -28,7 +30,7 @@ use lqos_utils::{
 };
 use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
-use std::{sync::atomic::AtomicU64, time::Duration};
+use std::{sync::Arc, sync::atomic::AtomicU64, time::Duration};
 use tracing::{debug, info, warn};
 
 // Maximum number of flows to track simultaneously
@@ -36,7 +38,8 @@ use tracing::{debug, info, warn};
 const MAX_FLOWS: usize = 1_000_000;
 
 pub const MAX_RETRY_TIMES: usize = 128;
-const MIN_QOO_FLOW_BYTES: u64 = 1_000_000;
+pub(crate) const MIN_QOO_FLOW_BYTES: u64 = 1_000_000;
+const REPRESENTATIVE_MIN_FLOW_BYTES: u64 = 128 * 1024;
 
 pub(crate) struct FlowApplyContext<'a> {
     pub(crate) timeout_seconds: u64,
@@ -72,6 +75,337 @@ struct CircuitHeatmapAggregate {
     upload_bytes: u64,
     tcp_retransmits: DownUpOrder<u64>,
     tcp_packets: DownUpOrder<u64>,
+}
+
+#[derive(Default)]
+struct RepresentativeAsnAggregate {
+    total_bps: DownUpOrder<u64>,
+    rtt_visible_bps: DownUpOrder<u64>,
+    tcp_packets: DownUpOrder<u64>,
+    tcp_retransmits: DownUpOrder<u64>,
+    rtt: RttBuffer,
+}
+
+const REPRESENTATIVE_MAX_ASN_SHARE: f64 = 0.15;
+
+fn representative_weight(total_bps: u64, visible_bps: u64) -> Option<f64> {
+    if total_bps == 0 || visible_bps == 0 {
+        return None;
+    }
+    let confidence = visible_bps as f64 / total_bps as f64;
+    Some((total_bps as f64).ln_1p() * confidence)
+}
+
+fn accumulate_representative_direction(
+    bucket: &mut RepresentativeAsnAggregate,
+    rtt: &RttBuffer,
+    direction: FlowbeeEffectiveDirection,
+    rate_estimate_bps: u32,
+    bytes_sent: u64,
+) {
+    if bytes_sent < REPRESENTATIVE_MIN_FLOW_BYTES {
+        return;
+    }
+
+    bucket.rtt.accumulate_direction(rtt, direction);
+    if rtt.percentile(RttBucket::Current, direction, 50).is_none() {
+        return;
+    }
+
+    match direction {
+        FlowbeeEffectiveDirection::Download => {
+            bucket.rtt_visible_bps.down = bucket
+                .rtt_visible_bps
+                .down
+                .saturating_add(rate_estimate_bps as u64);
+        }
+        FlowbeeEffectiveDirection::Upload => {
+            bucket.rtt_visible_bps.up = bucket
+                .rtt_visible_bps
+                .up
+                .saturating_add(rate_estimate_bps as u64);
+        }
+    }
+}
+
+fn capped_normalized_weights(raw_weights: &[f64], max_share: f64) -> Vec<f64> {
+    if raw_weights.is_empty() {
+        return Vec::new();
+    }
+    let max_share = max_share.clamp(0.0, 1.0);
+    if max_share <= 0.0 {
+        return vec![0.0; raw_weights.len()];
+    }
+    if max_share >= 1.0 {
+        let total: f64 = raw_weights.iter().copied().sum();
+        if total <= 0.0 {
+            return vec![0.0; raw_weights.len()];
+        }
+        return raw_weights.iter().map(|weight| *weight / total).collect();
+    }
+
+    let active_count = raw_weights.iter().filter(|weight| **weight > 0.0).count();
+    if active_count == 0 {
+        return vec![0.0; raw_weights.len()];
+    }
+    if (active_count as f64) * max_share < 1.0 {
+        let total: f64 = raw_weights.iter().copied().sum();
+        if total <= 0.0 {
+            return vec![0.0; raw_weights.len()];
+        }
+        return raw_weights.iter().map(|weight| *weight / total).collect();
+    }
+
+    let mut normalized = vec![0.0; raw_weights.len()];
+    let mut active: Vec<usize> = raw_weights
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, weight)| (*weight > 0.0).then_some(idx))
+        .collect();
+    let mut remaining_mass = 1.0;
+    let mut remaining_weight: f64 = active.iter().map(|idx| raw_weights[*idx]).sum();
+
+    while !active.is_empty() && remaining_mass > 0.0 && remaining_weight > 0.0 {
+        let max_raw_for_remaining = max_share * remaining_weight / remaining_mass;
+        let mut capped_any = false;
+        active.retain(|idx| {
+            if raw_weights[*idx] > max_raw_for_remaining {
+                normalized[*idx] = max_share;
+                remaining_mass -= max_share;
+                remaining_weight -= raw_weights[*idx];
+                capped_any = true;
+                false
+            } else {
+                true
+            }
+        });
+        if !capped_any {
+            for idx in active {
+                normalized[idx] = raw_weights[idx] * remaining_mass / remaining_weight;
+            }
+            break;
+        }
+    }
+
+    normalized
+}
+
+fn weighted_median_u64(values: &mut Vec<(u64, f64)>) -> Option<u64> {
+    values.retain(|(_, weight)| *weight > 0.0);
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by_key(|(value, _)| *value);
+    let normalized_weights = capped_normalized_weights(
+        &values.iter().map(|(_, weight)| *weight).collect::<Vec<_>>(),
+        REPRESENTATIVE_MAX_ASN_SHARE,
+    );
+    let total_weight: f64 = normalized_weights.iter().sum();
+    if total_weight <= 0.0 {
+        return None;
+    }
+    let threshold = total_weight / 2.0;
+    let mut running = 0.0;
+    for ((value, _), weight) in values.iter().zip(normalized_weights.iter()) {
+        running += *weight;
+        if running >= threshold {
+            return Some(*value);
+        }
+    }
+    values.last().map(|(value, _)| *value)
+}
+
+fn weighted_average_f32(values: &[(f32, f64)]) -> Option<f32> {
+    let normalized_weights = capped_normalized_weights(
+        &values.iter().map(|(_, weight)| *weight).collect::<Vec<_>>(),
+        REPRESENTATIVE_MAX_ASN_SHARE,
+    );
+    let mut weighted_sum = 0.0;
+    let mut total_weight = 0.0;
+    for ((value, _), weight) in values.iter().zip(normalized_weights.iter()) {
+        if *weight <= 0.0 {
+            continue;
+        }
+        weighted_sum += *value as f64 * *weight;
+        total_weight += *weight;
+    }
+    (total_weight > 0.0).then(|| (weighted_sum / total_weight) as f32)
+}
+
+fn build_circuit_representative_metrics(
+    qoo_profile: Option<&lqos_utils::qoo::QooProfile>,
+) -> FxHashMap<i64, CircuitRepresentativeMetrics> {
+    let Ok(now) = time_since_boot() else {
+        return FxHashMap::default();
+    };
+    let recent_cutoff = Duration::from(now)
+        .as_nanos()
+        .saturating_sub((RETIRE_AFTER_SECONDS as u128) * 1_000_000_000)
+        as u64;
+    let shaped = SHAPED_DEVICES.load();
+    let cache = SHAPED_DEVICE_HASH_CACHE.load();
+
+    let mut buckets: FxHashMap<(i64, u32), RepresentativeAsnAggregate> = FxHashMap::default();
+    let all_flows = ALL_FLOWS.lock();
+    for (key, (local, analysis)) in all_flows.flow_data.iter() {
+        if local.last_seen < recent_cutoff {
+            continue;
+        }
+
+        let device = shaped_device_from_hashes_or_ip(
+            &shaped,
+            &cache,
+            &key.local_ip,
+            local.device_hash,
+            local.circuit_hash,
+        );
+        let circuit_hash = local
+            .circuit_hash
+            .or_else(|| device.map(|device| device.circuit_hash));
+        let Some(circuit_hash) = circuit_hash else {
+            continue;
+        };
+        if crate::rtt_exclusions::is_excluded_hash(circuit_hash) {
+            continue;
+        }
+
+        let bucket = buckets
+            .entry((circuit_hash, analysis.asn_id.0))
+            .or_default();
+        bucket.total_bps.checked_add_direct(
+            local.rate_estimate_bps.down as u64,
+            local.rate_estimate_bps.up as u64,
+        );
+
+        let Some(tcp_info) = local.tcp_info.as_ref() else {
+            continue;
+        };
+        bucket
+            .tcp_packets
+            .checked_add_direct(local.packets_sent.down, local.packets_sent.up);
+        bucket.tcp_retransmits.checked_add_direct(
+            local.tcp_retransmits.down as u64,
+            local.tcp_retransmits.up as u64,
+        );
+
+        accumulate_representative_direction(
+            bucket,
+            &tcp_info.rtt,
+            FlowbeeEffectiveDirection::Download,
+            local.rate_estimate_bps.down,
+            local.bytes_sent.down,
+        );
+        accumulate_representative_direction(
+            bucket,
+            &tcp_info.rtt,
+            FlowbeeEffectiveDirection::Upload,
+            local.rate_estimate_bps.up,
+            local.bytes_sent.up,
+        );
+    }
+
+    let mut by_circuit: FxHashMap<i64, Vec<RepresentativeAsnAggregate>> = FxHashMap::default();
+    for ((circuit_hash, _asn), bucket) in buckets {
+        by_circuit.entry(circuit_hash).or_default().push(bucket);
+    }
+
+    build_circuit_representative_metrics_from_buckets(by_circuit, qoo_profile)
+}
+
+fn build_circuit_representative_metrics_from_buckets(
+    by_circuit: FxHashMap<i64, Vec<RepresentativeAsnAggregate>>,
+    qoo_profile: Option<&lqos_utils::qoo::QooProfile>,
+) -> FxHashMap<i64, CircuitRepresentativeMetrics> {
+    let mut results = FxHashMap::default();
+    for (circuit_hash, buckets) in by_circuit {
+        let mut rtt_down = Vec::new();
+        let mut rtt_up = Vec::new();
+        let mut rtt_p90_down = Vec::new();
+        let mut rtt_p90_up = Vec::new();
+        let mut qoo_down = Vec::new();
+        let mut qoo_up = Vec::new();
+
+        for bucket in &buckets {
+            if let Some(rtt) = bucket
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50)
+                .map(|rtt| rtt.as_nanos())
+                && let Some(weight) =
+                    representative_weight(bucket.total_bps.down, bucket.rtt_visible_bps.down)
+            {
+                rtt_down.push((rtt, weight));
+            }
+            if let Some(rtt) = bucket
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 90)
+                .map(|rtt| rtt.as_nanos())
+                && let Some(weight) =
+                    representative_weight(bucket.total_bps.down, bucket.rtt_visible_bps.down)
+            {
+                rtt_p90_down.push((rtt, weight));
+            }
+            if let Some(rtt) = bucket
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 50)
+                .map(|rtt| rtt.as_nanos())
+                && let Some(weight) =
+                    representative_weight(bucket.total_bps.up, bucket.rtt_visible_bps.up)
+            {
+                rtt_up.push((rtt, weight));
+            }
+            if let Some(rtt) = bucket
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 90)
+                .map(|rtt| rtt.as_nanos())
+                && let Some(weight) =
+                    representative_weight(bucket.total_bps.up, bucket.rtt_visible_bps.up)
+            {
+                rtt_p90_up.push((rtt, weight));
+            }
+
+            let Some(profile) = qoo_profile else {
+                continue;
+            };
+            let scores = compute_qoq_scores(
+                profile,
+                &bucket.rtt,
+                tcp_retransmit_loss_proxy(bucket.tcp_retransmits.down, bucket.tcp_packets.down),
+                tcp_retransmit_loss_proxy(bucket.tcp_retransmits.up, bucket.tcp_packets.up),
+            );
+            if let Some(score) = scores.download_total_f32()
+                && let Some(weight) =
+                    representative_weight(bucket.total_bps.down, bucket.rtt_visible_bps.down)
+            {
+                qoo_down.push((score, weight));
+            }
+            if let Some(score) = scores.upload_total_f32()
+                && let Some(weight) =
+                    representative_weight(bucket.total_bps.up, bucket.rtt_visible_bps.up)
+            {
+                qoo_up.push((score, weight));
+            }
+        }
+
+        results.insert(
+            circuit_hash,
+            CircuitRepresentativeMetrics {
+                rtt_current_p50_nanos: DownUpOrder {
+                    down: weighted_median_u64(&mut rtt_down),
+                    up: weighted_median_u64(&mut rtt_up),
+                },
+                rtt_current_p90_nanos: DownUpOrder {
+                    down: weighted_median_u64(&mut rtt_p90_down),
+                    up: weighted_median_u64(&mut rtt_p90_up),
+                },
+                qoo: DownUpOrder {
+                    down: weighted_average_f32(&qoo_down),
+                    up: weighted_average_f32(&qoo_up),
+                },
+            },
+        );
+    }
+
+    results
 }
 
 struct ReducedHostCounters {
@@ -193,6 +527,8 @@ impl ThroughputTracker {
         let mut total_retransmits: DownUpOrder<u64> = DownUpOrder::zeroed();
         let mut total_tcp_packets: DownUpOrder<u64> = DownUpOrder::zeroed();
         let circuit_rtt_snapshot = CIRCUIT_RTT_BUFFERS.load();
+        let representative_snapshot = build_circuit_representative_metrics(qoo_profile.as_deref());
+        CIRCUIT_REPRESENTATIVE_METRICS.store(Arc::new(representative_snapshot.clone()));
         {
             let raw_data = self.raw_data.lock();
             for entry in raw_data.values() {
@@ -251,8 +587,6 @@ impl ThroughputTracker {
         heatmaps.retain(|circuit_hash, _| capacity_lookup.contains_key(circuit_hash));
         let mut qoq_heatmaps = self.circuit_qoq_heatmaps.lock();
         qoq_heatmaps.retain(|circuit_hash, _| capacity_lookup.contains_key(circuit_hash));
-        let empty_rtt = RttBuffer::default();
-
         for (circuit_hash, aggregate) in aggregates {
             let (max_down_mbps, max_up_mbps) = capacity_lookup
                 .get(&circuit_hash)
@@ -263,30 +597,19 @@ impl ThroughputTracker {
                 utilization_percent(aggregate.download_bytes, max_down_mbps).unwrap_or(0.0);
             let upload_util =
                 utilization_percent(aggregate.upload_bytes, max_up_mbps).unwrap_or(0.0);
-            let rtt_p50_down = circuit_rtt_snapshot
-                .get(&circuit_hash)
-                .and_then(|rtt| {
-                    rtt.percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50)
-                })
-                .map(|rtt| rtt.as_millis() as f32);
-            let rtt_p50_up = circuit_rtt_snapshot
-                .get(&circuit_hash)
-                .and_then(|rtt| {
-                    rtt.percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 50)
-                })
-                .map(|rtt| rtt.as_millis() as f32);
-            let rtt_p90_down = circuit_rtt_snapshot
-                .get(&circuit_hash)
-                .and_then(|rtt| {
-                    rtt.percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 90)
-                })
-                .map(|rtt| rtt.as_millis() as f32);
-            let rtt_p90_up = circuit_rtt_snapshot
-                .get(&circuit_hash)
-                .and_then(|rtt| {
-                    rtt.percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 90)
-                })
-                .map(|rtt| rtt.as_millis() as f32);
+            let representative = representative_snapshot.get(&circuit_hash);
+            let rtt_p50_down = representative
+                .and_then(|metrics| metrics.rtt_current_p50_nanos.down)
+                .map(|rtt| RttData::from_nanos(rtt).as_millis() as f32);
+            let rtt_p50_up = representative
+                .and_then(|metrics| metrics.rtt_current_p50_nanos.up)
+                .map(|rtt| RttData::from_nanos(rtt).as_millis() as f32);
+            let rtt_p90_down = representative
+                .and_then(|metrics| metrics.rtt_current_p90_nanos.down)
+                .map(|rtt| RttData::from_nanos(rtt).as_millis() as f32);
+            let rtt_p90_up = representative
+                .and_then(|metrics| metrics.rtt_current_p90_nanos.up)
+                .map(|rtt| RttData::from_nanos(rtt).as_millis() as f32);
             let retransmit_down =
                 retransmit_percent(aggregate.tcp_retransmits.down, aggregate.tcp_packets.down);
             let retransmit_up =
@@ -304,22 +627,11 @@ impl ThroughputTracker {
                 retransmit_up,
             );
 
-            let rtt = circuit_rtt_snapshot
-                .get(&circuit_hash)
-                .unwrap_or(&empty_rtt);
-            let loss_download = tcp_retransmit_loss_proxy(
-                aggregate.tcp_retransmits.down,
-                aggregate.tcp_packets.down,
-            );
-            let loss_upload =
-                tcp_retransmit_loss_proxy(aggregate.tcp_retransmits.up, aggregate.tcp_packets.up);
-            let scores = if let Some(profile) = qoo_profile.as_ref() {
-                compute_qoq_scores(profile.as_ref(), rtt, loss_download, loss_upload)
-            } else {
-                QoqScores::default()
-            };
             let qoq_heatmap = qoq_heatmaps.entry(circuit_hash).or_default();
-            qoq_heatmap.add_sample(scores.download_total_f32(), scores.upload_total_f32());
+            qoq_heatmap.add_sample(
+                representative.and_then(|metrics| metrics.qoo.down),
+                representative.and_then(|metrics| metrics.qoo.up),
+            );
         }
 
         let mut global_rtt_buffer = RttBuffer::default();
@@ -1303,7 +1615,7 @@ fn combine_rtt_ms(rtts: [RttData; 2]) -> Option<f32> {
     median(&mut samples)
 }
 
-fn tcp_retransmit_loss_proxy(retransmits: u64, packets: u64) -> Option<LossMeasurement> {
+pub(crate) fn tcp_retransmit_loss_proxy(retransmits: u64, packets: u64) -> Option<LossMeasurement> {
     if packets == 0 {
         return None;
     }
@@ -1321,9 +1633,17 @@ fn tcp_retransmit_loss_proxy(retransmits: u64, packets: u64) -> Option<LossMeasu
 
 #[cfg(test)]
 mod tests {
-    use super::ThroughputTracker;
+    use super::{
+        REPRESENTATIVE_MAX_ASN_SHARE, REPRESENTATIVE_MIN_FLOW_BYTES, RepresentativeAsnAggregate,
+        ThroughputTracker, accumulate_representative_direction,
+        build_circuit_representative_metrics_from_buckets, capped_normalized_weights,
+        representative_weight,
+    };
     use crate::shaped_devices_tracker::ShapedDeviceHashCache;
+    use crate::throughput_tracker::flow_data::{FlowbeeEffectiveDirection, RttData};
     use lqos_config::{ConfigShapedDevices, ShapedDevice};
+    use lqos_utils::rtt::RttBucket;
+    use lqos_utils::rtt::RttBuffer;
     use lqos_utils::{XdpIpAddress, hash_to_i64};
     use std::net::Ipv4Addr;
 
@@ -1346,5 +1666,183 @@ mod tests {
 
         assert_eq!(matched.circuit_hash, hash_to_i64("circuit-1"));
         assert_eq!(matched.device_hash, hash_to_i64("device-1"));
+    }
+
+    #[test]
+    fn representative_weight_penalizes_low_visibility() {
+        let high_visibility =
+            representative_weight(100_000_000, 100_000_000).expect("weight should exist");
+        let low_visibility =
+            representative_weight(100_000_000, 10_000_000).expect("weight should exist");
+
+        assert!(high_visibility > low_visibility);
+    }
+
+    #[test]
+    fn representative_weight_growth_is_flatter_than_square_root() {
+        let medium = representative_weight(10_000_000, 10_000_000).expect("weight should exist");
+        let large =
+            representative_weight(1_000_000_000, 1_000_000_000).expect("weight should exist");
+
+        assert!(large > medium);
+        assert!(large / medium < 2.0);
+    }
+
+    #[test]
+    fn representative_direction_ignores_tiny_rtt_bearing_flows() {
+        let mut bucket = RepresentativeAsnAggregate::default();
+        let mut rtt = RttBuffer::default();
+        rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+        rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+
+        accumulate_representative_direction(
+            &mut bucket,
+            &rtt,
+            FlowbeeEffectiveDirection::Download,
+            750_000,
+            REPRESENTATIVE_MIN_FLOW_BYTES - 1,
+        );
+
+        assert_eq!(bucket.rtt_visible_bps.down, 0);
+        assert!(
+            bucket
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn representative_direction_counts_flows_over_minimum_floor() {
+        let mut bucket = RepresentativeAsnAggregate::default();
+        let mut rtt = RttBuffer::default();
+        rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+        rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+
+        accumulate_representative_direction(
+            &mut bucket,
+            &rtt,
+            FlowbeeEffectiveDirection::Download,
+            750_000,
+            REPRESENTATIVE_MIN_FLOW_BYTES,
+        );
+
+        assert_eq!(bucket.rtt_visible_bps.down, 750_000);
+        assert!(
+            bucket
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn capped_normalized_weights_limit_single_asn_share() {
+        let normalized = capped_normalized_weights(
+            &[100.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
+            REPRESENTATIVE_MAX_ASN_SHARE,
+        );
+
+        assert_eq!(normalized.len(), 7);
+        assert!(
+            normalized
+                .iter()
+                .all(|weight| *weight <= REPRESENTATIVE_MAX_ASN_SHARE + 0.0000001)
+        );
+        let total: f64 = normalized.iter().sum();
+        assert!((total - 1.0).abs() < 0.000001);
+    }
+
+    #[test]
+    fn capped_normalized_weights_fall_back_when_cap_is_infeasible() {
+        let normalized =
+            capped_normalized_weights(&[100.0, 10.0, 10.0, 10.0], REPRESENTATIVE_MAX_ASN_SHARE);
+
+        assert_eq!(normalized.len(), 4);
+        let total: f64 = normalized.iter().sum();
+        assert!((total - 1.0).abs() < 0.000001);
+        assert!(normalized[0] > REPRESENTATIVE_MAX_ASN_SHARE);
+    }
+
+    #[test]
+    fn representative_metrics_cap_single_dominant_asn() {
+        let mut trusted = RepresentativeAsnAggregate::default();
+        trusted.total_bps.down = 10_000_000;
+        trusted.rtt_visible_bps.down = 10_000_000;
+        trusted.rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+        trusted.rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+
+        let mut trusted2 = RepresentativeAsnAggregate::default();
+        trusted2.total_bps.down = 10_000_000;
+        trusted2.rtt_visible_bps.down = 10_000_000;
+        trusted2.rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+        trusted2.rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+
+        let mut trusted3 = RepresentativeAsnAggregate::default();
+        trusted3.total_bps.down = 10_000_000;
+        trusted3.rtt_visible_bps.down = 10_000_000;
+        trusted3.rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+        trusted3.rtt.push(
+            RttData::from_nanos(31_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+
+        let mut noisy = RepresentativeAsnAggregate::default();
+        noisy.total_bps.down = 500_000_000;
+        noisy.rtt_visible_bps.down = 500_000_000;
+        noisy.rtt.push(
+            RttData::from_nanos(999_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+        noisy.rtt.push(
+            RttData::from_nanos(999_000_000),
+            FlowbeeEffectiveDirection::Download,
+            1,
+        );
+
+        let mut by_circuit = fxhash::FxHashMap::default();
+        by_circuit.insert(1_i64, vec![trusted, trusted2, trusted3, noisy]);
+        let metrics = build_circuit_representative_metrics_from_buckets(by_circuit, None);
+        let circuit = metrics.get(&1_i64).expect("circuit should exist");
+
+        assert_eq!(circuit.rtt_current_p50_nanos.down, Some(35_000_000));
     }
 }


### PR DESCRIPTION
This PR prototypes a new circuit RTT/QoE methodology aimed at matching real subscriber experience more closely than the prior flow-driven rollups.

The main problem this addresses is that a circuit could look unhealthy because of a small number of large or high-latency flows, especially bulk video/streaming traffic, even when the subscriber's general internet experience was otherwise good. That made circuit RTT/QoE less useful as an operational signal.

## What Changed

- Replaced the old circuit-level RTT/QoE rollup path with an ASN-aware representative model.
- Recent active traffic is grouped by destination ASN within each circuit.
- Each ASN builds its own RTT/QoE evidence from RTT-visible traffic.
- ASN influence is confidence-aware, so destinations with weak RTT visibility contribute less.
- Very small flows are excluded from RTT/QoE contribution with a representative flow floor.
- Single-ASN influence is capped so one destination cannot fully dominate a circuit score when enough distinct ASNs are active.
- The traffic weighting curve was flattened so bulk video destinations matter less than before.
- User-facing UI terminology was updated from `QoO` to `QoE`.
- Added operator-facing documentation describing the circuit RTT/QoE methodology.

## Why

This branch exists to improve the accuracy of circuit experience scoring.

In production-like testing, the old approach was too sensitive to:
- a few large high-latency video flows
- devices or applications the ISP cannot realistically control
- uneven TCP/QUIC RTT visibility
- raw flow distributions that did not reflect actual perceived connection quality

The ASN-aware model is intended to answer a better operator question:

"What does this subscriber's connection generally feel like across the destinations they are actively using?"

## Scope

This PR intentionally focuses on circuit experience views.

Updated to use the ASN-aware model:
- circuit page
- Queue Dynamics circuit RTT/QoE
- `circuit_live`
- executive circuit RTT/QoE heatmaps
- attached-circuit views that consume those rollups

Not intentionally changed in this PR:
- raw per-flow views
- site/node/global methodology
- retransmit methodology
- TreeGuard decision logic
- external export/LTS payload semantics

## Current Methodology

At a high level:
- group recent active circuit traffic by destination ASN
- ignore tiny flows for RTT/QoE contribution
- build per-ASN RTT and QoE evidence
- weight ASN influence by active traffic plus RTT visibility confidence
- cap ASN influence
- combine per-ASN values into representative circuit RTT/QoE

## Known Limitations

This is still a heuristic, not a perfect ground-truth model.

Remaining limitations:
- ASN is still a proxy for application experience
- RTT visibility remains stronger for TCP than QUIC-heavy traffic
- with only a small number of active ASNs, cap behavior has less room to work
- retransmits are still direct transport-health signals, not ASN-adjusted
- site/node/global QoE is still on older methodology paths

## Validation

Validated with targeted Rust tests, `cargo check`, `cargo clippy`, frontend bundle/build-contract checks, and a Sphinx dummy docs build.

## Draft PR Intent

This is a draft on purpose.

The goal is to evaluate whether ASN-aware circuit RTT/QoE is a better operational model before deciding whether:
- it should become the default long-term methodology
- QoE should move from weighted average to a more robust median-style combine
- parts of the approach should later extend into other views or remain circuit-only