### PR TITLE
Feat: add optional cobrand logo support #1032

### DIFF
--- a/docs-es/v2.0/configuration-advanced-es.md
+++ b/docs-es/v2.0/configuration-advanced-es.md
@@ -45,6 +45,11 @@ Nota: Si observa que el tráfico no se está regulando cuando debería, asegúre
 
 Después de cambiar cualquier parte de `/etc/lqos.conf`, se recomienda reiniciar siempre lqosd usando: `sudo systemctl restart lqosd`. Esto integra los nuevos valores en lqos.conf, haciéndolos accesibles tanto para el código en Rust como en Python.
 
+Logo compartido opcional:
+- `display_cobrand` es un booleano opcional de nivel superior en `/etc/lqos.conf`.
+- Si la clave no está presente, LibreQoS la trata como `false`.
+- La WebUI solo muestra el logo del operador cuando `display_cobrand = true` y `cobrand.png` existe en el directorio de assets estáticos en runtime.
+
 ### Netflow (opcional)
 Para habilitar Netflow, agregue la siguiente sección `[flows]` al archivo de configuración `/etc/lqos.conf`, configurando el `netflow_ip` adecuado:
 ```

--- a/docs-es/v2.0/configuration-es.md
+++ b/docs-es/v2.0/configuration-es.md
@@ -40,6 +40,12 @@ Cuando una integración está gestionando sus datos de shaping, los editores `Ne
 Nota de topología:
 - Los nombres de nodo en `network.json` deben ser globalmente únicos en todo el árbol. Los nombres duplicados ahora fallan la validación y no son aceptados por el guardado de la WebUI ni por `LibreQoS.py`.
 
+Nota sobre logo compartido:
+- `Configuration -> General` incluye un toggle opcional y una carga PNG para mostrar un logo del operador junto al logo de LibreQoS.
+- LibreQoS guarda el archivo subido como `cobrand.png` en el directorio de assets estáticos en tiempo de ejecución.
+- La opción de nivel superior `display_cobrand` en `/etc/lqos.conf` es opcional. Si no está presente, LibreQoS la trata como `false`.
+- La barra lateral muestra la imagen compartida con 48px de alto para igualar el logo de LibreQoS, con un ancho máximo de 176px dentro de la barra lateral.
+
 ## Modos de operación y fuente de verdad
 
 Lea esto primero antes de cambios en producción:

--- a/docs/v2.0/configuration-advanced.md
+++ b/docs/v2.0/configuration-advanced.md
@@ -47,6 +47,11 @@ Note: If you find that traffic is not being shaped when it should, please make s
 
 After changing any part of `/etc/lqos.conf` it is highly recommended to always restart lqosd, using `sudo systemctl restart lqosd`. This re-parses any new values in lqos.conf, making those new values accessible to both the Rust and Python sides of the code.
 
+Optional cobrand logo:
+- `display_cobrand` is an optional top-level boolean in `/etc/lqos.conf`.
+- If the key is omitted, LibreQoS treats it as `false`.
+- The WebUI only shows the operator logo when `display_cobrand = true` and `cobrand.png` exists in the runtime static assets directory.
+
 #### Netflow (optional)
 To enable netflow, add the following `[flows]` section to the `/etc/lqos.conf` configuration file, setting the appropriate `netflow_ip`:
 ```

--- a/docs/v2.0/configuration.md
+++ b/docs/v2.0/configuration.md
@@ -46,6 +46,12 @@ Topology note:
 Queue-mode note:
 - Current builds use `queue_mode` with `shape` and `observe` values. Older `monitor_only` wording is a compatibility alias rather than the primary operator-facing setting.
 
+Cobrand logo note:
+- `Configuration -> General` includes an optional cobrand image toggle and PNG upload.
+- LibreQoS saves the uploaded file as `cobrand.png` in the runtime static assets directory.
+- The top-level `display_cobrand` setting in `/etc/lqos.conf` is optional. If it is omitted, LibreQoS treats it as `false`.
+- The sidebar renders the cobrand image at 48px tall to match the LibreQoS logo, with a maximum sidebar width of 176px.
+
 ## Operating Modes and Source of Truth
 
 Read this first before production changes:

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1227,6 +1227,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +2444,7 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot",
+ "png",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -3066,6 +3076,19 @@ dependencies = [
  "pnet_base",
  "pnet_macros",
  "pnet_macros_support",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]

--- a/src/rust/lqos_config/src/etc/v15/example.toml
+++ b/src/rust/lqos_config/src/etc/v15/example.toml
@@ -5,6 +5,7 @@ node_id = "0000-0000-0000"
 node_name = "Example Node"
 packet_capture_time = 10
 queue_check_period_ms = 1000
+display_cobrand = false
 enable_circuit_heatmaps = true
 enable_site_heatmaps = true
 enable_asn_heatmaps = true

--- a/src/rust/lqos_config/src/etc/v15/top_config.rs
+++ b/src/rust/lqos_config/src/etc/v15/top_config.rs
@@ -169,6 +169,10 @@ pub struct Config {
     /// Listen options for the webserver
     pub webserver_listen: Option<String>,
 
+    /// Controls whether an operator-provided cobrand image should be shown in the WebUI.
+    #[serde(default)]
+    pub display_cobrand: bool,
+
     /// Support for Tornado/Auto-rate.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stormguard: Option<stormguard::StormguardConfig>,
@@ -378,6 +382,7 @@ impl Default for Config {
             flows: None,
             disable_webserver: None,
             webserver_listen: None,
+            display_cobrand: false,
             stormguard: None,
             treeguard: treeguard::TreeguardConfig::default(),
             disable_icmp_ping: Some(false),
@@ -608,6 +613,16 @@ mod test {
         output.join("\n")
     }
 
+    fn remove_keys(raw: &str, keys: &[&str]) -> String {
+        raw.lines()
+            .filter(|line| {
+                let trimmed = line.trim_start();
+                !keys.iter().any(|key| trimmed.starts_with(&format!("{key} =")))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn load_example() {
         let config = Config::load_from_string(include_str!("example.toml"))
@@ -810,6 +825,14 @@ mod test {
         let config = Config::load_from_string(&stripped)
             .expect("Config without stormguard should still deserialize");
         assert!(config.stormguard.is_none());
+    }
+
+    #[test]
+    fn display_cobrand_defaults_false_when_omitted() {
+        let stripped = remove_keys(include_str!("example.toml"), &["display_cobrand"]);
+        let config = Config::load_from_string(&stripped)
+            .expect("Config without display_cobrand should still deserialize");
+        assert!(!config.display_cobrand);
     }
 
     #[test]

--- a/src/rust/lqosd/Cargo.toml
+++ b/src/rust/lqosd/Cargo.toml
@@ -68,6 +68,7 @@ ureq = { version = "2.12.1", features = ["json", "native-tls"] }
 csv = { workspace = true }
 parking_lot = { workspace = true }
 smallvec = "1"
+png = "0.17.16"
 
 # For memory debugging
 allocative.workspace = true

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_general.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_general.js
@@ -11,6 +11,56 @@ function escapeHtml(value) {
         .replace(/'/g, "&#039;");
 }
 
+function setCobrandUploadStatus(kind, message) {
+    const holder = document.getElementById("cobrandUploadStatus");
+    if (!holder) return;
+    const safeKind = kind === "danger" || kind === "warning" || kind === "info" || kind === "success"
+        ? kind
+        : "secondary";
+    holder.innerHTML = `<div class="alert alert-${safeKind} mb-0">${message}</div>`;
+}
+
+function selectedCobrandFile() {
+    const input = document.getElementById("cobrandFile");
+    return input?.files?.[0] ?? null;
+}
+
+function selectedCobrandLooksLikePng(file) {
+    if (!file) return true;
+    const typeOk = file.type === "image/png";
+    const extensionOk = String(file.name || "").toLowerCase().endsWith(".png");
+    return typeOk || extensionOk;
+}
+
+async function uploadCobrandIfSelected() {
+    const file = selectedCobrandFile();
+    if (!file) {
+        return;
+    }
+    if (!selectedCobrandLooksLikePng(file)) {
+        throw new Error("Cobrand image must be a PNG file.");
+    }
+
+    setCobrandUploadStatus("info", "Uploading cobrand.png...");
+    const response = await fetch("/local-api/config/cobrand", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+            "Content-Type": "image/png",
+        },
+        body: file,
+    });
+
+    if (!response.ok) {
+        const detail = (await response.text().catch(() => "")).trim();
+        const message = detail || `Upload failed with HTTP ${response.status}.`;
+        throw new Error(message);
+    }
+
+    document.getElementById("cobrandFile").value = "";
+    setCobrandUploadStatus("success", "Uploaded cobrand.png. Saving configuration...");
+}
+
 function getProfilesPath() {
     const dir = window.config?.lqos_directory;
     if (!dir) return "qoo_profiles.json";
@@ -161,6 +211,7 @@ function updateConfig() {
     window.config.enable_circuit_heatmaps = document.getElementById("enableCircuitHeatmaps").checked;
     window.config.enable_site_heatmaps = document.getElementById("enableSiteHeatmaps").checked;
     window.config.enable_asn_heatmaps = document.getElementById("enableAsnHeatmaps").checked;
+    window.config.display_cobrand = document.getElementById("displayCobrand").checked;
 
     const selectedProfileId = selectedQooProfileId();
     window.config.qoo_profile_id = selectedProfileId ? selectedProfileId : null;
@@ -198,6 +249,33 @@ loadConfig(() => {
         document.getElementById("enableCircuitHeatmaps").checked = window.config.enable_circuit_heatmaps ?? true;
         document.getElementById("enableSiteHeatmaps").checked = window.config.enable_site_heatmaps ?? true;
         document.getElementById("enableAsnHeatmaps").checked = window.config.enable_asn_heatmaps ?? true;
+        document.getElementById("displayCobrand").checked = window.config.display_cobrand ?? false;
+        setCobrandUploadStatus(
+            "secondary",
+            "Leave blank to keep the current <code>cobrand.png</code>. Uploads are applied when you click Save Changes.",
+        );
+
+        const cobrandInput = document.getElementById("cobrandFile");
+        if (cobrandInput) {
+            cobrandInput.addEventListener("change", () => {
+                const file = selectedCobrandFile();
+                if (!file) {
+                    setCobrandUploadStatus(
+                        "secondary",
+                        "Leave blank to keep the current <code>cobrand.png</code>. Uploads are applied when you click Save Changes.",
+                    );
+                    return;
+                }
+                if (!selectedCobrandLooksLikePng(file)) {
+                    setCobrandUploadStatus("warning", "Selected file does not look like a PNG. Choose a .png file.");
+                    return;
+                }
+                setCobrandUploadStatus(
+                    "info",
+                    `Selected ${escapeHtml(file.name)}. It will be saved as <code>cobrand.png</code> when you click Save Changes.`,
+                );
+            });
+        }
 
         const profilesPath = getProfilesPath();
         const profilesPathEl = document.getElementById("qooProfilesPath");
@@ -251,12 +329,29 @@ loadConfig(() => {
         );
 
         // Add save button click handler
-        document.getElementById('saveButton').addEventListener('click', () => {
+        document.getElementById('saveButton').addEventListener('click', async () => {
             if (validateConfig()) {
-                updateConfig();
-                saveConfig(() => {
-                    alert("Configuration saved successfully!");
-                });
+                try {
+                    await uploadCobrandIfSelected();
+                    updateConfig();
+                    saveConfig((msg) => {
+                        if (!msg?.ok) {
+                            const message = msg?.message || "Configuration save failed.";
+                            setCobrandUploadStatus("danger", escapeHtml(message));
+                            return;
+                        }
+                        setCobrandUploadStatus(
+                            "success",
+                            "Cobrand settings saved. The sidebar will show the image when display is enabled and cobrand.png exists.",
+                        );
+                    }, (msg) => {
+                        const message = msg?.message || "Configuration save failed.";
+                        setCobrandUploadStatus("danger", escapeHtml(message));
+                    });
+                } catch (error) {
+                    const message = error instanceof Error ? error.message : "Cobrand upload failed.";
+                    setCobrandUploadStatus("danger", escapeHtml(message));
+                }
             }
         });
     } else {

--- a/src/rust/lqosd/src/node_manager/local_api.rs
+++ b/src/rust/lqosd/src/node_manager/local_api.rs
@@ -55,6 +55,7 @@ pub fn local_api(shaper_query: tokio::sync::mpsc::Sender<ShaperQueryCommand>) ->
             "/network-mode/retry-shaping",
             post(network_mode::retry_shaping),
         )
+        .route("/config/cobrand", post(config::upload_cobrand))
         .with_state(network_mode::NetworkModeApiState::default())
         .layer(Extension(shaper_query))
         .layer(CorsLayer::very_permissive())

--- a/src/rust/lqosd/src/node_manager/local_api/config.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/config.rs
@@ -1,7 +1,10 @@
 use crate::node_manager::auth::LoginResult;
 use crate::node_manager::local_api::network_mode::NetworkModeInspection;
 use crate::shaping_runtime::ShapingRuntimeStatus;
+use axum::Extension;
+use axum::body::Bytes;
 use axum::http::StatusCode;
+use axum::http::header;
 use default_net::get_interfaces;
 use lqos_bus::{BusRequest, bus_request};
 use lqos_config::{Config, ConfigShapedDevices, ShapedDevice, UserRole, WebUser, WebUsers};
@@ -9,6 +12,23 @@ use lqos_utils::hash_to_i64;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::io::{Cursor, ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const COBRAND_FILE_NAME: &str = "cobrand.png";
+const COBRAND_DISPLAY_HEIGHT_PX: u64 = 48;
+const COBRAND_MAX_DISPLAY_WIDTH_PX: u64 = 176;
+const COBRAND_MAX_DECODE_BYTES: usize = 64 * 1024 * 1024;
+const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CobrandUploadValidationError {
+    UnsupportedMediaType,
+    InvalidPng,
+    TooLarge,
+    TooWideForSidebar,
+}
 
 type TopologySourceIntegration = (&'static str, fn(&Config) -> bool);
 
@@ -329,6 +349,137 @@ pub fn get_config_data(login: LoginResult) -> Result<ConfigView, StatusCode> {
             }
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn cobrand_path(config: &Config) -> PathBuf {
+    Path::new(&config.lqos_directory)
+        .join("bin")
+        .join("static2")
+        .join(COBRAND_FILE_NAME)
+}
+
+fn validate_cobrand_upload(
+    content_type: Option<&str>,
+    body: &[u8],
+) -> Result<(), CobrandUploadValidationError> {
+    if content_type != Some("image/png") {
+        return Err(CobrandUploadValidationError::UnsupportedMediaType);
+    }
+    inspect_png(body)?;
+    Ok(())
+}
+
+fn inspect_png(body: &[u8]) -> Result<(u32, u32), CobrandUploadValidationError> {
+    if body.len() < PNG_SIGNATURE.len() || &body[..PNG_SIGNATURE.len()] != PNG_SIGNATURE {
+        return Err(CobrandUploadValidationError::InvalidPng);
+    }
+
+    let decoder = png::Decoder::new(Cursor::new(body));
+    let Ok(mut reader) = decoder.read_info() else {
+        return Err(CobrandUploadValidationError::InvalidPng);
+    };
+    let info = reader.info();
+    let (width, height) = (info.width, info.height);
+    let output_buffer_size = reader.output_buffer_size();
+    if output_buffer_size > COBRAND_MAX_DECODE_BYTES {
+        return Err(CobrandUploadValidationError::TooLarge);
+    }
+    if rendered_cobrand_width_exceeds_sidebar(width, height) {
+        return Err(CobrandUploadValidationError::TooWideForSidebar);
+    }
+    let mut output = vec![0; output_buffer_size];
+    reader
+        .next_frame(&mut output)
+        .map_err(|_| CobrandUploadValidationError::InvalidPng)?;
+    Ok((width, height))
+}
+
+fn rendered_cobrand_width_exceeds_sidebar(width: u32, height: u32) -> bool {
+    u64::from(width) * COBRAND_DISPLAY_HEIGHT_PX
+        > u64::from(height) * COBRAND_MAX_DISPLAY_WIDTH_PX
+}
+
+fn persist_cobrand_png(body: &[u8]) -> Result<(), StatusCode> {
+    let config = lqos_config::load_config().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let target_path = cobrand_path(config.as_ref());
+    let Some(parent_dir) = target_path.parent() else {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    std::fs::create_dir_all(parent_dir).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let temp_root = parent_dir
+        .parent()
+        .unwrap_or(parent_dir)
+        .join(".tmp");
+    std::fs::create_dir_all(&temp_root).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut temp_path = None;
+    for attempt in 0..32 {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let candidate = temp_root.join(format!(
+            "cobrand-upload-{}-{unique_suffix}-{attempt}.png",
+            std::process::id()
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(mut file) => {
+                if file.write_all(body).is_err() {
+                    let _ = std::fs::remove_file(&candidate);
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+                temp_path = Some(candidate);
+                break;
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+        }
+    }
+    let Some(temp_path) = temp_path else {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    std::fs::rename(&temp_path, &target_path).map_err(|_| {
+        let _ = std::fs::remove_file(&temp_path);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    Ok(())
+}
+
+pub async fn upload_cobrand(
+    Extension(login): Extension<LoginResult>,
+    headers: axum::http::HeaderMap,
+    body: Bytes,
+) -> Result<StatusCode, (StatusCode, &'static str)> {
+    if login != LoginResult::Admin {
+        return Err((StatusCode::FORBIDDEN, "Administrator access is required."));
+    }
+    let content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim);
+    validate_cobrand_upload(content_type, &body).map_err(|error| match error {
+        CobrandUploadValidationError::UnsupportedMediaType => (
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "Cobrand uploads must use Content-Type image/png.",
+        ),
+        CobrandUploadValidationError::InvalidPng => {
+            (StatusCode::BAD_REQUEST, "Uploaded file is not a valid PNG.")
+        }
+        CobrandUploadValidationError::TooLarge => (
+            StatusCode::BAD_REQUEST,
+            "Cobrand image is too large to validate safely.",
+        ),
+        CobrandUploadValidationError::TooWideForSidebar => (
+            StatusCode::BAD_REQUEST,
+            "Cobrand image is too wide for the sidebar at 48px tall. Keep the rendered width at or below 176px.",
+        ),
+    })?;
+    persist_cobrand_png(&body)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Unable to save cobrand.png."))?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 pub fn list_nics_data(login: LoginResult) -> Result<Vec<(String, String, String)>, StatusCode> {
@@ -867,11 +1018,41 @@ pub struct UserRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfigSecretClearRequest, apply_secret_updates, redact_config_secrets,
-        validate_network_json,
+        CobrandUploadValidationError, ConfigSecretClearRequest, apply_secret_updates,
+        cobrand_path, persist_cobrand_png, redact_config_secrets, upload_cobrand,
+        validate_cobrand_upload, validate_network_json,
     };
+    use crate::node_manager::auth::LoginResult;
+    use axum::Extension;
+    use axum::body::Bytes;
+    use axum::http::HeaderMap;
     use lqos_config::Config;
     use serde_json::json;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    const VALID_PNG: &[u8] = &[
+        0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, b'I', b'H',
+        b'D', b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+        0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, b'I', b'D', b'A', b'T', 0x78,
+        0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, b'I', b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    fn encode_test_png(width: u32, height: u32) -> Vec<u8> {
+        let mut png_bytes = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut png_bytes, width, height);
+            encoder.set_color(png::ColorType::Rgba);
+            encoder.set_depth(png::BitDepth::Eight);
+            let mut writer = encoder.write_header().expect("write png header");
+            let pixel_count = usize::try_from(width)
+                .expect("width fits usize")
+                .saturating_mul(usize::try_from(height).expect("height fits usize"));
+            let data = vec![0u8; pixel_count.saturating_mul(4)];
+            writer.write_image_data(&data).expect("write png bytes");
+        }
+        png_bytes
+    }
 
     #[test]
     fn accepts_unique_node_names() {
@@ -1059,5 +1240,160 @@ mod tests {
             incoming.powercode_integration.powercode_api_key,
             "old-powercode"
         );
+    }
+
+    #[test]
+    fn validate_cobrand_upload_requires_exact_png_content_type() {
+        let body = VALID_PNG.to_vec();
+        assert_eq!(
+            validate_cobrand_upload(Some("image/jpeg"), &body),
+            Err(CobrandUploadValidationError::UnsupportedMediaType)
+        );
+        assert_eq!(
+            validate_cobrand_upload(Some("image/png"), b"not-a-png"),
+            Err(CobrandUploadValidationError::InvalidPng)
+        );
+        let truncated_png = &VALID_PNG[..VALID_PNG.len() - 8];
+        assert_eq!(
+            validate_cobrand_upload(Some("image/png"), truncated_png),
+            Err(CobrandUploadValidationError::InvalidPng)
+        );
+        assert_eq!(validate_cobrand_upload(Some("image/png"), &body), Ok(()));
+    }
+
+    #[test]
+    fn validate_cobrand_upload_rejects_pngs_too_wide_for_sidebar() {
+        let too_wide = encode_test_png(177, 48);
+        assert_eq!(
+            validate_cobrand_upload(Some("image/png"), &too_wide),
+            Err(CobrandUploadValidationError::TooWideForSidebar)
+        );
+    }
+
+    #[test]
+    fn validate_cobrand_upload_rejects_pngs_with_huge_dimensions() {
+        let too_large = encode_test_png(4097, 4096);
+        assert_eq!(
+            validate_cobrand_upload(Some("image/png"), &too_large),
+            Err(CobrandUploadValidationError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn validate_cobrand_upload_accepts_boundary_dimensions() {
+        let max_width = encode_test_png(176, 48);
+        let max_height = encode_test_png(1, 4096);
+        assert_eq!(validate_cobrand_upload(Some("image/png"), &max_width), Ok(()));
+        assert_eq!(validate_cobrand_upload(Some("image/png"), &max_height), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn upload_cobrand_requires_admin() {
+        let result = upload_cobrand(
+            Extension(LoginResult::ReadOnly),
+            HeaderMap::new(),
+            Bytes::from_static(VALID_PNG),
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err((
+                axum::http::StatusCode::FORBIDDEN,
+                "Administrator access is required.",
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_cobrand_accepts_admin_png_and_persists_file() {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        let runtime_dir = std::env::temp_dir().join(format!("lqosd-cobrand-test-{unique_suffix}"));
+        fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+        let config_path = runtime_dir.join("lqos.conf");
+        let runtime_dir_string = runtime_dir.display().to_string();
+        let state_dir_string = runtime_dir.join("state").display().to_string();
+        let raw = include_str!("../../../../lqos_config/src/etc/v15/example.toml")
+            .replace("/opt/libreqos/src", &runtime_dir_string)
+            .replace("/opt/libreqos/state", &state_dir_string)
+            .replace("node_id = \"0000-0000-0000\"", "node_id = \"node\"");
+        fs::write(&config_path, raw).expect("write config");
+        let previous = std::env::var_os("LQOS_CONFIG");
+        unsafe {
+            std::env::set_var("LQOS_CONFIG", &config_path);
+        }
+        lqos_config::clear_cached_config();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("image/png"),
+        );
+        let result = upload_cobrand(
+            Extension(LoginResult::Admin),
+            headers,
+            Bytes::from_static(VALID_PNG),
+        )
+        .await;
+
+        assert_eq!(result, Ok(axum::http::StatusCode::NO_CONTENT));
+        let config = lqos_config::load_config().expect("load config");
+        let path = cobrand_path(config.as_ref());
+        assert_eq!(fs::read(path).expect("read cobrand"), VALID_PNG);
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var("LQOS_CONFIG", value);
+            },
+            None => unsafe {
+                std::env::remove_var("LQOS_CONFIG");
+            },
+        }
+        lqos_config::clear_cached_config();
+        let _ = fs::remove_dir_all(runtime_dir);
+    }
+
+    #[test]
+    fn persist_cobrand_png_writes_runtime_static_file() {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        let runtime_dir = std::env::temp_dir().join(format!("lqosd-cobrand-test-{unique_suffix}"));
+        fs::create_dir_all(&runtime_dir).expect("create runtime dir");
+        let config_path = runtime_dir.join("lqos.conf");
+        let runtime_dir_string = runtime_dir.display().to_string();
+        let state_dir_string = runtime_dir.join("state").display().to_string();
+        let raw = include_str!("../../../../lqos_config/src/etc/v15/example.toml")
+            .replace("/opt/libreqos/src", &runtime_dir_string)
+            .replace("/opt/libreqos/state", &state_dir_string)
+            .replace("node_id = \"0000-0000-0000\"", "node_id = \"node\"");
+        fs::write(&config_path, raw).expect("write config");
+        let previous = std::env::var_os("LQOS_CONFIG");
+        unsafe {
+            std::env::set_var("LQOS_CONFIG", &config_path);
+        }
+        lqos_config::clear_cached_config();
+
+        let png_body = VALID_PNG.to_vec();
+        persist_cobrand_png(&png_body).expect("write cobrand");
+
+        let config = lqos_config::load_config().expect("load config");
+        let path = cobrand_path(config.as_ref());
+        assert_eq!(fs::read(path).expect("read cobrand"), png_body);
+
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var("LQOS_CONFIG", value);
+            },
+            None => unsafe {
+                std::env::remove_var("LQOS_CONFIG");
+            },
+        }
+        lqos_config::clear_cached_config();
+        let _ = fs::remove_dir_all(runtime_dir);
     }
 }

--- a/src/rust/lqosd/src/node_manager/static2/config_general.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_general.html
@@ -140,6 +140,47 @@
             </div>
         </section>
 
+        <section class="lqos-config-panel">
+            <div class="lqos-config-panel-header">
+                <div>
+                    <h5 class="lqos-config-panel-title">Cobrand Image</h5>
+                    <div class="lqos-config-panel-subtitle">Optionally show an operator PNG next to the LibreQoS logo in the sidebar.</div>
+                </div>
+            </div>
+
+            <div class="row g-3">
+                <div class="col-12 col-xl-6">
+                    <div class="lqos-config-section h-100">
+                        <h6 class="lqos-config-section-title">Display</h6>
+                        <div class="lqos-config-section-subtitle">The image is shown only when this setting is enabled and <code>cobrand.png</code> exists.</div>
+
+                        <div class="mb-0 form-check">
+                            <input type="checkbox" class="form-check-input" id="displayCobrand">
+                            <label class="form-check-label" for="displayCobrand">Display Cobrand Image</label>
+                            <div class="form-text">If <code>display_cobrand</code> is omitted from <code>/etc/lqos.conf</code>, LibreQoS defaults it to off.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-12 col-xl-6">
+                    <div class="lqos-config-section h-100">
+                        <h6 class="lqos-config-section-title">Upload PNG</h6>
+                        <div class="lqos-config-section-subtitle">Uploaded images are saved as <code>cobrand.png</code> in the runtime static assets directory and overwrite any existing file.</div>
+
+                        <div class="mb-3">
+                            <label for="cobrandFile" class="form-label">Cobrand PNG</label>
+                            <input type="file" class="form-control" id="cobrandFile" accept="image/png,.png">
+                            <div class="form-text">Rendered size: 48px tall to match the existing LibreQoS logo, with a maximum sidebar width of 176px.</div>
+                        </div>
+
+                        <div id="cobrandUploadStatus" class="lqos-config-note" aria-live="polite">
+                            Leave blank to keep the current <code>cobrand.png</code>. Uploads are applied when you click Save Changes.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <div class="lqos-config-actions">
             <button type="button" id="saveButton" class="btn btn-outline-primary">Save Changes</button>
         </div>

--- a/src/rust/lqosd/src/node_manager/static2/node_manager.css
+++ b/src/rust/lqosd/src/node_manager/static2/node_manager.css
@@ -97,6 +97,27 @@ html[data-bs-theme="light"] .lqos_logo {
 html[data-bs-theme="dark"] .lqos_logo {
     filter: none;
 }
+.lqos-logo-row {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    min-height: 48px;
+    max-width: 100%;
+    flex-wrap: wrap;
+    min-width: 0;
+}
+.lqos_cobrand_logo {
+    display: block;
+    height: 48px;
+    width: auto;
+    object-fit: contain;
+}
+@media (max-width: 575.98px) {
+    .lqos-logo-row {
+        flex-direction: column;
+    }
+}
 .sidebar {
     width: var(--lqos-sidebar-width);
     align-self: flex-start;
@@ -134,6 +155,9 @@ html[data-bs-theme="dark"] .lqos_logo {
     border-radius: 0.85rem;
     color: var(--bs-body-color);
     transition: background-color 120ms ease, color 120ms ease, transform 120ms ease;
+}
+.sidebar .nav-item.text-center .nav-link {
+    justify-content: center;
 }
 .sidebar .nav-link.no-hover,
 .sidebar .nav-link.no-hover:hover {

--- a/src/rust/lqosd/src/node_manager/static2/template.html
+++ b/src/rust/lqosd/src/node_manager/static2/template.html
@@ -45,9 +45,13 @@
                 <ul class="navbar-nav flex-column">
                     <!-- Logo -->
                     <li class="nav-item text-center mb-2">
-                        <a class="nav-link" href="index.html">
-                            <img class="lqos_logo" src="tinylogo.svg" alt="LibreQoS SVG Logo" width="48" height="48">
+                        <a class="nav-link" href="index.html" aria-label="LibreQoS home" %%COBRAND_LOGO_DESCRIBEDBY%%>
+                            <span class="lqos-logo-row">
+                                <img class="lqos_logo" src="tinylogo.svg" alt="LibreQoS SVG Logo" width="48" height="48">
+                                %%COBRAND_LOGO%%
+                            </span>
                         </a>
+                        %%COBRAND_LOGO_STATUS%%
                     </li>
                     <!-- Search -->
                     <li class="text-center">

--- a/src/rust/lqosd/src/node_manager/template.rs
+++ b/src/rust/lqosd/src/node_manager/template.rs
@@ -11,6 +11,7 @@ use axum::response::IntoResponse;
 use axum_extra::extract::CookieJar;
 use lqos_config::{RttThresholds, load_config};
 use std::path::Path;
+use std::time::UNIX_EPOCH;
 
 const VERSION_STRING: &str = include_str!("../../../../VERSION_STRING");
 
@@ -68,6 +69,47 @@ const CHAT_LINK_ACTIVE: &str = r#"
 
 static GIT_HASH: &str = env!("GIT_HASH");
 
+fn cobrand_logo_html(config: &lqos_config::Config) -> String {
+    let cobrand_path = Path::new(&config.lqos_directory)
+        .join("bin")
+        .join("static2")
+        .join("cobrand.png");
+    if config.display_cobrand && cobrand_path.exists() {
+        let cache_buster = std::fs::metadata(&cobrand_path)
+            .ok()
+            .map(|metadata| {
+                let modified_nanos = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_nanos())
+                    .unwrap_or(0);
+                format!("{modified_nanos}-{}", metadata.len())
+            })
+            .unwrap_or_else(|| "0".to_string());
+        format!(
+            r#"<img class="lqos_cobrand_logo" src="cobrand.png?v={cache_buster}" alt="" aria-hidden="true" height="48">"#
+        )
+    } else {
+        String::new()
+    }
+}
+
+fn cobrand_logo_status_html(config: &lqos_config::Config) -> (&'static str, &'static str) {
+    let cobrand_path = Path::new(&config.lqos_directory)
+        .join("bin")
+        .join("static2")
+        .join("cobrand.png");
+    if config.display_cobrand && cobrand_path.exists() {
+        (
+            r#"aria-describedby="cobrandLogoStatus""#,
+            r#"<span id="cobrandLogoStatus" class="visually-hidden">Custom operator cobrand logo displayed next to the LibreQoS logo in the sidebar.</span>"#,
+        )
+    } else {
+        ("", "")
+    }
+}
+
 pub async fn apply_templates(
     jar: CookieJar,
     req: Request<axum::body::Body>,
@@ -115,6 +157,9 @@ pub async fn apply_templates(
         let title = config.node_name.clone();
         let node_id_js = escape_html_attr(&config.node_id);
         let rtt_thresholds: RttThresholds = config.rtt_thresholds.clone().unwrap_or_default();
+        let cobrand_logo = cobrand_logo_html(config.as_ref());
+        let (cobrand_logo_describedby, cobrand_logo_status) =
+            cobrand_logo_status_html(config.as_ref());
 
         // "LTS script" - which is increasingly becoming a misnomer
         let lts_script = format!(
@@ -148,7 +193,10 @@ pub async fn apply_templates(
             .replace("%%VERSION%%", version_string)
             .replace("%%TITLE%%", &title)
             .replace("%%LTS_LINK%%", &trial_link)
-            .replace("%%%LTS_SCRIPT%%%", &lts_script);
+            .replace("%%%LTS_SCRIPT%%%", &lts_script)
+            .replace("%%COBRAND_LOGO%%", &cobrand_logo)
+            .replace("%%COBRAND_LOGO_DESCRIBEDBY%%", cobrand_logo_describedby)
+            .replace("%%COBRAND_LOGO_STATUS%%", cobrand_logo_status);
         // Handle API_LINK placeholder (require service + valid Insight)
         let api_link = if is_api_available() && capabilities.can_use_api_link {
             API_LINK_ACTIVE
@@ -210,5 +258,63 @@ pub async fn apply_templates(
         Ok(res)
     } else {
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cobrand_logo_html, cobrand_logo_status_html};
+    use lqos_config::Config;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const VALID_PNG: &[u8] = &[
+        0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, b'I', b'H',
+        b'D', b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+        0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, b'I', b'D', b'A', b'T', 0x78,
+        0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, b'I', b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    fn temp_runtime_dir() -> std::path::PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should move forward")
+            .as_nanos();
+        let runtime_dir = std::env::temp_dir().join(format!("lqos-template-test-{unique_suffix}"));
+        fs::create_dir_all(runtime_dir.join("bin/static2")).expect("create runtime static dir");
+        runtime_dir
+    }
+
+    fn test_config(runtime_dir: &std::path::Path, display_cobrand: bool) -> Config {
+        let mut config = Config::default();
+        config.lqos_directory = runtime_dir.display().to_string();
+        config.display_cobrand = display_cobrand;
+        config
+    }
+
+    #[test]
+    fn cobrand_logo_requires_file_and_flag() {
+        let runtime_dir = temp_runtime_dir();
+        let static_dir = runtime_dir.join("bin/static2");
+        let without_file = test_config(&runtime_dir, true);
+        let disabled = test_config(&runtime_dir, false);
+
+        assert!(cobrand_logo_html(&without_file).is_empty());
+        assert_eq!(cobrand_logo_status_html(&without_file), ("", ""));
+        assert!(cobrand_logo_html(&disabled).is_empty());
+        assert_eq!(cobrand_logo_status_html(&disabled), ("", ""));
+
+        fs::write(static_dir.join("cobrand.png"), VALID_PNG).expect("write cobrand png");
+        let enabled = test_config(&runtime_dir, true);
+        let logo_html = cobrand_logo_html(&enabled);
+        let (describedby, status_html) = cobrand_logo_status_html(&enabled);
+
+        assert!(logo_html.contains(r#"class="lqos_cobrand_logo""#));
+        assert!(logo_html.contains(r#"src="cobrand.png?v="#));
+        assert_eq!(describedby, r#"aria-describedby="cobrandLogoStatus""#);
+        assert!(status_html.contains("Custom operator cobrand logo displayed"));
+
+        let _ = fs::remove_dir_all(runtime_dir);
     }
 }


### PR DESCRIPTION
FIXES #1032 

On Config - General:
<img width="1370" height="888" alt="image" src="https://github.com/user-attachments/assets/20a214ad-f4fe-46f1-a73c-a68830f974cc" />

And that yields:
<img width="666" height="363" alt="image" src="https://github.com/user-attachments/assets/81b98b58-071d-45e5-ac3d-af8e079e0b13" />
