### PR TITLE
Make full TC reloads drain to default without traffic cutout

### DIFF
--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -1936,6 +1936,91 @@ impl Drop for FullReloadScope {
     }
 }
 
+struct TcClassifyBypassGuard {
+    cleanup_on_drop: bool,
+    setter: fn(bool) -> anyhow::Result<()>,
+}
+
+struct BakeryFullReloadBatchResult {
+    result: ExecuteResult,
+    summary: String,
+    build_duration_ms: u64,
+    total_tc_commands: usize,
+    class_commands: usize,
+    qdisc_commands: usize,
+}
+
+impl BakeryFullReloadBatchResult {
+    fn metrics<'a>(&self, summary: &'a str, ok: bool) -> BakeryApplyMetrics<'a> {
+        BakeryApplyMetrics {
+            apply_type: BakeryApplyType::FullReload,
+            summary,
+            build_duration_ms: self.build_duration_ms,
+            apply_duration_ms: self.result.duration_ms,
+            total_tc_commands: self.total_tc_commands,
+            class_commands: self.class_commands,
+            qdisc_commands: self.qdisc_commands,
+            ok,
+        }
+    }
+}
+
+impl TcClassifyBypassGuard {
+    fn new() -> anyhow::Result<Self> {
+        Self::with_setter(lqos_sys::set_tc_classify_bypass)
+    }
+
+    fn with_setter(setter: fn(bool) -> anyhow::Result<()>) -> anyhow::Result<Self> {
+        setter(true).map_err(|error| {
+            error!(
+                "Bakery full reload failed to enable TC classify bypass via tc_classify_control: {error}"
+            );
+            error
+        })?;
+        info!("Bakery full reload enabled TC classify bypass");
+        Ok(Self {
+            cleanup_on_drop: true,
+            setter,
+        })
+    }
+
+    fn disable(&mut self) -> anyhow::Result<()> {
+        if !self.cleanup_on_drop {
+            return Ok(());
+        }
+        self.cleanup_on_drop = false;
+        (self.setter)(false).map_err(|error| {
+            error!(
+                "Bakery full reload failed to disable TC classify bypass via tc_classify_control: {error}"
+            );
+            error
+        })?;
+        info!("Bakery full reload disabled TC classify bypass");
+        Ok(())
+    }
+
+    fn keep_bypass_enabled_after_failure(&mut self, summary: &str) {
+        self.cleanup_on_drop = false;
+        error!(
+            "Bakery full reload keeping TC classify bypass enabled after failure: {}",
+            summary
+        );
+    }
+}
+
+impl Drop for TcClassifyBypassGuard {
+    fn drop(&mut self) {
+        if !self.cleanup_on_drop {
+            return;
+        }
+        if let Err(error) = self.disable() {
+            mark_reload_required(format!(
+                "Bakery full reload could not disable TC classify bypass after reload: {error}. Operator intervention may be required because traffic may remain unshaped."
+            ));
+        }
+    }
+}
+
 fn telemetry_state() -> &'static RwLock<BakeryTelemetryState> {
     BAKERY_TELEMETRY.get_or_init(|| RwLock::new(BakeryTelemetryState::default()))
 }
@@ -10447,6 +10532,29 @@ fn full_reload(
         trigger_summary,
     );
     let _reload_scope = FullReloadScope;
+    let mut tc_bypass_guard = match TcClassifyBypassGuard::new() {
+        Ok(guard) => guard,
+        Err(error) => {
+            let summary =
+                format!("Failed to enable TC classify bypass before full reload: {error}");
+            error!("{summary}");
+            mark_reload_required(format!(
+                "{summary}. Full reload was not attempted because TC classify could not be safely bypassed."
+            ));
+            mark_bakery_action_finished(BakeryApplyMetrics {
+                apply_type: BakeryApplyType::FullReload,
+                summary: &summary,
+                build_duration_ms: 0,
+                apply_duration_ms: 0,
+                total_tc_commands: 0,
+                class_commands: 0,
+                qdisc_commands: 0,
+                ok: false,
+            });
+            *batch = None;
+            return;
+        }
+    };
     let previous_sites = sites.clone();
     let previous_circuits = circuits.clone();
     let previous_live_circuits = live_circuits.clone();
@@ -10457,6 +10565,10 @@ fn full_reload(
     if let Err(error) = prepare_root_mq_for_full_reload(config) {
         let summary = format!("Failed to prepare root mq state before full reload: {error}");
         error!("{summary}");
+        tc_bypass_guard.keep_bypass_enabled_after_failure(&summary);
+        mark_reload_required(format!(
+            "{summary}. TC classify bypass remains enabled to avoid stale class-handle classification until a successful reload or operator intervention."
+        ));
         mark_bakery_action_finished(BakeryApplyMetrics {
             apply_type: BakeryApplyType::FullReload,
             summary: &summary,
@@ -10479,6 +10591,10 @@ fn full_reload(
             let summary =
                 format!("Failed to snapshot live qdisc handles before full reload: {error}");
             error!("{summary}");
+            tc_bypass_guard.keep_bypass_enabled_after_failure(&summary);
+            mark_reload_required(format!(
+                "{summary}. TC classify bypass remains enabled to avoid stale class-handle classification until a successful reload or operator intervention."
+            ));
             mark_bakery_action_finished(BakeryApplyMetrics {
                 apply_type: BakeryApplyType::FullReload,
                 summary: &summary,
@@ -10502,7 +10618,7 @@ fn full_reload(
         warn!("Bakery: full reload skipped MQ layout restore because layout is unknown");
     }
 
-    let result = process_batch(
+    let batch_result = process_batch(
         new_batch,
         config,
         &mut working_sites,
@@ -10512,7 +10628,7 @@ fn full_reload(
         &live_reserved_handles,
     );
 
-    if result.ok {
+    if batch_result.result.ok {
         *sites = working_sites;
         *circuits = working_circuits;
         live_circuits.clear();
@@ -10538,11 +10654,28 @@ fn full_reload(
         *mq_layout = previous_mq_layout;
         MQ_CREATED.store(previous_mq_created, Ordering::Relaxed);
         SHAPING_TREE_ACTIVE.store(previous_shaping_tree_active, Ordering::Relaxed);
+        let summary = "Bakery full reload failed while applying TC command batch";
+        tc_bypass_guard.keep_bypass_enabled_after_failure(summary);
+        mark_reload_required(format!(
+            "{summary}. TC classify bypass remains enabled to avoid stale class-handle classification until a successful reload or operator intervention."
+        ));
     }
-    if result.ok {
+    if batch_result.result.ok {
         refresh_live_capacity_snapshot(config, true);
+        update_queue_distribution_snapshot(sites, circuits);
+        if let Err(error) = tc_bypass_guard.disable() {
+            let summary = format!(
+                "Bakery full reload applied TC commands but could not disable TC classify bypass: {error}. Operator intervention may be required because traffic may remain unshaped."
+            );
+            mark_reload_required(summary.clone());
+            mark_bakery_action_finished(batch_result.metrics(&summary, false));
+        } else {
+            mark_bakery_action_finished(batch_result.metrics(&batch_result.summary, true));
+        }
+    } else {
+        update_queue_distribution_snapshot(sites, circuits);
+        mark_bakery_action_finished(batch_result.metrics(&batch_result.summary, false));
     }
-    update_queue_distribution_snapshot(sites, circuits);
     *batch = None;
 }
 
@@ -10554,7 +10687,7 @@ fn process_batch(
     mq_layout: &MqDeviceLayout,
     qdisc_handles: &mut QdiscHandleState,
     extra_reserved_handles: &HashMap<String, HashSet<u16>>,
-) -> ExecuteResult {
+) -> BakeryFullReloadBatchResult {
     info!("Bakery: Processing batch of {} commands", batch.len());
     update_bakery_apply_progress(Some("Building tc command batch"), 0, 0, 0, 0);
     let build_started = std::time::Instant::now();
@@ -10620,18 +10753,14 @@ fn process_batch(
     );
     let summary = summarize_apply_result("processing batch", &result);
     maybe_emit_memory_guard_urgent(&summary);
-    mark_bakery_action_finished(BakeryApplyMetrics {
-        apply_type: BakeryApplyType::FullReload,
-        summary: &summary,
+    BakeryFullReloadBatchResult {
+        result,
+        summary,
         build_duration_ms,
-        apply_duration_ms: result.duration_ms,
         total_tc_commands,
         class_commands,
         qdisc_commands,
-        ok: result.ok,
-    });
-
-    result
+    }
 }
 
 fn apply_stormguard_overrides(
@@ -10679,7 +10808,33 @@ fn apply_stormguard_overrides(
 mod tests {
     use super::*;
     use lqos_config::Config;
+    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TC_BYPASS_SETTER_CALLS: Mutex<Vec<bool>> = Mutex::new(Vec::new());
+
+    fn recording_tc_bypass_setter(enabled: bool) -> anyhow::Result<()> {
+        TC_BYPASS_SETTER_CALLS.lock().expect("record setter call").push(enabled);
+        Ok(())
+    }
+
+    fn failing_tc_bypass_setter(enabled: bool) -> anyhow::Result<()> {
+        TC_BYPASS_SETTER_CALLS.lock().expect("record setter call").push(enabled);
+        Err(anyhow::anyhow!("synthetic TC classify bypass setter failure"))
+    }
+
+    fn disable_failing_tc_bypass_setter(enabled: bool) -> anyhow::Result<()> {
+        TC_BYPASS_SETTER_CALLS.lock().expect("record setter call").push(enabled);
+        if enabled {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("synthetic TC classify bypass disable failure"))
+        }
+    }
+
+    fn take_tc_bypass_setter_calls() -> Vec<bool> {
+        std::mem::take(&mut *TC_BYPASS_SETTER_CALLS.lock().expect("take setter calls"))
+    }
 
     fn bakery_test_lock() -> &'static std::sync::Mutex<()> {
         crate::test_state_lock()
@@ -10725,7 +10880,80 @@ mod tests {
         SHAPING_TREE_ACTIVE.store(false, Ordering::Relaxed);
         FIRST_COMMIT_APPLIED.store(false, Ordering::Relaxed);
         FULL_RELOAD_IN_PROGRESS.store(false, Ordering::Relaxed);
+        take_tc_bypass_setter_calls();
         install_bakery_test_config();
+    }
+
+    #[test]
+    fn tc_classify_bypass_guard_disables_on_scope_exit() {
+        let _guard = bakery_test_lock().lock().expect("bakery test lock");
+        reset_bakery_test_state();
+
+        {
+            let _bypass_guard =
+                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
+                    .expect("enable bypass guard");
+            assert_eq!(take_tc_bypass_setter_calls(), vec![true]);
+        }
+
+        assert_eq!(take_tc_bypass_setter_calls(), vec![false]);
+    }
+
+    #[test]
+    fn tc_classify_bypass_guard_disables_on_early_return() {
+        fn early_return() -> Result<(), ()> {
+            let _bypass_guard =
+                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
+                    .map_err(|_| ())?;
+            Err(())
+        }
+
+        let _guard = bakery_test_lock().lock().expect("bakery test lock");
+        reset_bakery_test_state();
+
+        assert_eq!(early_return(), Err(()));
+
+        assert_eq!(take_tc_bypass_setter_calls(), vec![true, false]);
+    }
+
+    #[test]
+    fn tc_classify_bypass_guard_does_not_disable_when_enable_fails() {
+        let _guard = bakery_test_lock().lock().expect("bakery test lock");
+        reset_bakery_test_state();
+
+        assert!(TcClassifyBypassGuard::with_setter(failing_tc_bypass_setter).is_err());
+
+        assert_eq!(take_tc_bypass_setter_calls(), vec![true]);
+    }
+
+    #[test]
+    fn tc_classify_bypass_guard_reports_disable_failure_once() {
+        let _guard = bakery_test_lock().lock().expect("bakery test lock");
+        reset_bakery_test_state();
+
+        {
+            let mut bypass_guard =
+                TcClassifyBypassGuard::with_setter(disable_failing_tc_bypass_setter)
+                    .expect("enable bypass guard");
+            assert!(bypass_guard.disable().is_err());
+        }
+
+        assert_eq!(take_tc_bypass_setter_calls(), vec![true, false]);
+    }
+
+    #[test]
+    fn tc_classify_bypass_guard_keeps_bypass_enabled_after_failure() {
+        let _guard = bakery_test_lock().lock().expect("bakery test lock");
+        reset_bakery_test_state();
+
+        {
+            let mut bypass_guard =
+                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
+                    .expect("enable bypass guard");
+            bypass_guard.keep_bypass_enabled_after_failure("test failure after TC mutation");
+        }
+
+        assert_eq!(take_tc_bypass_setter_calls(), vec![true]);
     }
 
     fn mk_add_circuit(hash: i64, ip_addresses: &str) -> Arc<BakeryCommands> {

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -2847,6 +2847,9 @@ fn root_infra_class_entry(entry: &LiveTcClassEntry, root_child_majors: &HashSet<
 }
 
 fn root_infra_qdisc_entry(entry: &LiveTcQdiscEntry, root_child_majors: &HashSet<u16>) -> bool {
+    if entry.kind == "clsact" {
+        return true;
+    }
     if entry.is_root {
         return true;
     }
@@ -2985,6 +2988,46 @@ fn qdisc_delete_commands(
             ]
         })
         .collect()
+}
+
+fn tc_classify_attached(interface: &str) -> Result<bool, String> {
+    let output = std::process::Command::new("/sbin/tc")
+        .args(["filter", "show", "dev", interface, "egress"])
+        .output()
+        .map_err(|error| {
+            format!("Failed to inspect TC classify attachment on {interface}: {error}")
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!(
+                "Failed to inspect TC classify attachment on {interface}: tc exited with {:?}",
+                output.status.code()
+            )
+        } else {
+            format!("Failed to inspect TC classify attachment on {interface}: {stderr}")
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).contains("tc_iphash_to_cp"))
+}
+
+fn verify_tc_classify_attached(config: &Arc<Config>) -> Result<(), String> {
+    let mut missing = Vec::new();
+    for interface in managed_interfaces_for_config(config) {
+        match tc_classify_attached(&interface) {
+            Ok(true) => {}
+            Ok(false) => missing.push(interface),
+            Err(error) => return Err(error),
+        }
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "TC classify egress attachment missing on interface(s): {}",
+            missing.join(", ")
+        ))
+    }
 }
 
 fn drain_managed_tree_to_defaults(
@@ -10920,6 +10963,18 @@ fn full_reload(
     if batch_result.result.ok {
         refresh_live_capacity_snapshot(config, true);
         update_queue_distribution_snapshot(sites, circuits);
+        if let Err(error) = verify_tc_classify_attached(config) {
+            let summary = format!(
+                "Bakery full reload applied TC commands but TC classify is not attached: {error}. Operator intervention may be required because traffic would otherwise remain unshaped."
+            );
+            tc_bypass_guard.keep_bypass_enabled_after_failure(&summary);
+            mark_reload_required(format!(
+                "{summary}. TC classify bypass remains enabled until a successful reload or lqosd restart restores classifier attachment."
+            ));
+            mark_bakery_action_finished(batch_result.metrics(&summary, false));
+            *batch = None;
+            return;
+        }
         if let Err(error) = tc_bypass_guard.disable() {
             let summary = format!(
                 "Bakery full reload applied TC commands but could not disable TC classify bypass: {error}. Operator intervention may be required because traffic may remain unshaped."
@@ -13483,6 +13538,34 @@ mod tests {
         assert_eq!(
             managed_root_child_parent_handles(&managed_snapshot),
             HashSet::from([TcHandle::from_u32(0x7fff0001)])
+        );
+    }
+
+    #[test]
+    fn root_infra_qdisc_entry_preserves_clsact() {
+        let root_child_majors = HashSet::from([0x1]);
+        assert!(root_infra_qdisc_entry(
+            &live_qdisc_entry("clsact", Some(0xffff0000), Some(0xfffffff1), false),
+            &root_child_majors,
+        ));
+    }
+
+    #[test]
+    fn qdisc_delete_commands_skip_clsact() {
+        let qdisc_snapshot = vec![
+            live_qdisc_entry("clsact", Some(0xffff0000), Some(0xfffffff1), false),
+            live_qdisc_entry("fq_codel", Some(0x95000000), Some(0x10020), false),
+        ];
+        assert_eq!(
+            qdisc_delete_commands("eth0", &qdisc_snapshot, &HashSet::from([0x1])),
+            vec![vec![
+                "qdisc".to_string(),
+                "del".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+                "parent".to_string(),
+                "0x1:0x20".to_string(),
+            ]]
         );
     }
 

--- a/src/rust/lqos_bakery/src/lib.rs
+++ b/src/rust/lqos_bakery/src/lib.rs
@@ -27,6 +27,7 @@ mod utils;
 
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use parking_lot::RwLock;
+use std::cmp::Reverse;
 use std::collections::VecDeque;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -1742,6 +1743,10 @@ pub struct BakeryStatusSnapshot {
     pub reload_required: bool,
     /// Operator-facing reason for why a full reload is now required, if any.
     pub reload_required_reason: Option<String>,
+    /// True when Bakery has put traffic into pass-through mode to avoid stale TC classification.
+    pub passthrough_degraded: bool,
+    /// Operator-facing reason for pass-through mode, if active.
+    pub passthrough_degraded_reason: Option<String>,
     /// Number of runtime node operations currently marked dirty.
     pub dirty_subtree_count: usize,
 }
@@ -1789,6 +1794,8 @@ struct BakeryTelemetryState {
     preflight: Option<BakeryPreflightSnapshot>,
     reload_required: bool,
     reload_required_reason: Option<String>,
+    passthrough_degraded: bool,
+    passthrough_degraded_reason: Option<String>,
     dirty_subtree_count: usize,
     runtime_operations_by_site: HashMap<i64, RuntimeNodeOperationSnapshot>,
     runtime_branch_states_by_site: HashMap<i64, BakeryRuntimeNodeBranchSnapshot>,
@@ -1904,6 +1911,8 @@ impl Default for BakeryTelemetryState {
             preflight: None,
             reload_required: false,
             reload_required_reason: None,
+            passthrough_degraded: false,
+            passthrough_degraded_reason: None,
             dirty_subtree_count: 0,
             runtime_operations_by_site: HashMap::new(),
             runtime_branch_states_by_site: HashMap::new(),
@@ -1950,6 +1959,11 @@ struct BakeryFullReloadBatchResult {
     qdisc_commands: usize,
 }
 
+struct ProcessBatchOptions<'a> {
+    extra_reserved_handles: &'a HashMap<String, HashSet<u16>>,
+    preserved_root_child_majors: &'a HashMap<String, HashSet<u16>>,
+}
+
 impl BakeryFullReloadBatchResult {
     fn metrics<'a>(&self, summary: &'a str, ok: bool) -> BakeryApplyMetrics<'a> {
         BakeryApplyMetrics {
@@ -1978,6 +1992,10 @@ impl TcClassifyBypassGuard {
             error
         })?;
         info!("Bakery full reload enabled TC classify bypass");
+        mark_passthrough_degraded(
+            "Bakery full reload is rebuilding TC. Traffic is temporarily passing without shaping to avoid stale class-handle classification.",
+            false,
+        );
         Ok(Self {
             cleanup_on_drop: true,
             setter,
@@ -1993,9 +2011,15 @@ impl TcClassifyBypassGuard {
             error!(
                 "Bakery full reload failed to disable TC classify bypass via tc_classify_control: {error}"
             );
+            mark_passthrough_degraded(format!(
+                "Bakery full reload applied TC commands but could not disable pass-through mode: {error}. Traffic may remain unshaped until operator intervention or a later successful reload."
+            ), true);
             error
         })?;
         info!("Bakery full reload disabled TC classify bypass");
+        clear_passthrough_degraded(
+            "Bakery full reload disabled pass-through mode; normal shaping is active.",
+        );
         Ok(())
     }
 
@@ -2004,6 +2028,12 @@ impl TcClassifyBypassGuard {
         error!(
             "Bakery full reload keeping TC classify bypass enabled after failure: {}",
             summary
+        );
+        mark_passthrough_degraded(
+            format!(
+                "{summary}. Traffic is passing without shaping until a successful full reload clears TC classify bypass."
+            ),
+            true,
         );
     }
 }
@@ -2098,6 +2128,39 @@ fn mark_reload_required(summary: String) {
     }
     if should_emit {
         push_bakery_event("reload_required", "error", summary);
+    }
+}
+
+fn mark_passthrough_degraded(summary: impl Into<String>, emit_activity: bool) {
+    let summary = summary.into();
+    let mut should_emit = false;
+    {
+        let mut state = telemetry_state().write();
+        if !state.passthrough_degraded
+            || state.passthrough_degraded_reason.as_deref() != Some(summary.as_str())
+        {
+            state.passthrough_degraded = true;
+            state.passthrough_degraded_reason = Some(summary.clone());
+            should_emit = true;
+        }
+    }
+    if should_emit && emit_activity {
+        push_bakery_event("passthrough_degraded", "warning", summary);
+    }
+}
+
+fn clear_passthrough_degraded(summary: &str) {
+    let mut should_emit = false;
+    {
+        let mut state = telemetry_state().write();
+        if state.passthrough_degraded || state.passthrough_degraded_reason.is_some() {
+            state.passthrough_degraded = false;
+            state.passthrough_degraded_reason = None;
+            should_emit = true;
+        }
+    }
+    if should_emit {
+        push_bakery_event("passthrough_degraded_cleared", "info", summary.to_string());
     }
 }
 
@@ -2239,6 +2302,8 @@ pub fn bakery_status_snapshot() -> BakeryStatusSnapshot {
         preflight: state.preflight,
         reload_required: state.reload_required,
         reload_required_reason: state.reload_required_reason,
+        passthrough_degraded: state.passthrough_degraded,
+        passthrough_degraded_reason: state.passthrough_degraded_reason,
         dirty_subtree_count: state.dirty_subtree_count,
     }
 }
@@ -2749,42 +2814,228 @@ fn root_mq_add_command(interface_name: &str) -> Vec<String> {
     ]
 }
 
-fn prepare_root_mq_for_full_reload(config: &Arc<Config>) -> Result<(), String> {
+fn command_token_after<'a>(command: &'a [String], needle: &str) -> Option<&'a str> {
+    command
+        .windows(2)
+        .find(|tokens| tokens[0] == needle)
+        .map(|tokens| tokens[1].as_str())
+}
+
+fn command_handle_after(command: &[String], needle: &str) -> Option<TcHandle> {
+    command_token_after(command, needle).and_then(|token| TcHandle::from_string(token).ok())
+}
+
+fn command_interface(command: &[String]) -> Option<&str> {
+    command_token_after(command, "dev")
+}
+
+fn root_infra_class_handle(handle: TcHandle, root_child_majors: &HashSet<u16>) -> bool {
+    let (major, minor) = handle.get_major_minor();
+    root_child_majors.contains(&major) && matches!(minor, 1 | 2)
+}
+
+fn root_infra_class_entry(entry: &LiveTcClassEntry, root_child_majors: &HashSet<u16>) -> bool {
+    let (major, minor) = entry.class_id.get_major_minor();
+    if !root_child_majors.contains(&major) {
+        return false;
+    }
+    match (minor, entry.parent) {
+        (1, Some(parent)) => parent == tc_handle_from_major_minor(major, 0),
+        (2, Some(parent)) => parent == tc_handle_from_major_minor(major, 1),
+        _ => false,
+    }
+}
+
+fn root_infra_qdisc_entry(entry: &LiveTcQdiscEntry, root_child_majors: &HashSet<u16>) -> bool {
+    if entry.is_root {
+        return true;
+    }
+    if entry
+        .parent
+        .is_some_and(|parent| parent.get_major_minor().0 == ROOT_MQ_MAJOR)
+    {
+        return true;
+    }
+    entry.parent.is_some_and(|parent| {
+        let (major, minor) = parent.get_major_minor();
+        root_child_majors.contains(&major) && matches!(minor, 1 | 2)
+    })
+}
+
+fn root_infra_class_command(
+    command: &[String],
+    preserved_root_child_majors: &HashMap<String, HashSet<u16>>,
+) -> bool {
+    if !matches!(command.first().map(String::as_str), Some("class")) {
+        return false;
+    }
+    let Some(interface) = command_interface(command) else {
+        return false;
+    };
+    let Some(root_child_majors) = preserved_root_child_majors.get(interface) else {
+        return false;
+    };
+    command_handle_after(command, "classid")
+        .is_some_and(|handle| root_infra_class_handle(handle, root_child_majors))
+}
+
+fn root_infra_qdisc_command(
+    command: &[String],
+    preserved_root_child_majors: &HashMap<String, HashSet<u16>>,
+) -> bool {
+    if !matches!(command.first().map(String::as_str), Some("qdisc")) {
+        return false;
+    }
+    let Some(interface) = command_interface(command) else {
+        return false;
+    };
+    let Some(root_child_majors) = preserved_root_child_majors.get(interface) else {
+        return false;
+    };
+    command_handle_after(command, "parent").is_some_and(|parent| {
+        let (major, minor) = parent.get_major_minor();
+        major == ROOT_MQ_MAJOR || root_child_majors.contains(&major) && matches!(minor, 1 | 2)
+    })
+}
+
+fn idempotent_full_reload_command(
+    mut command: Vec<String>,
+    preserved_root_child_majors: &HashMap<String, HashSet<u16>>,
+) -> Vec<String> {
+    if matches!(command.get(1).map(String::as_str), Some("add"))
+        && root_infra_class_command(&command, preserved_root_child_majors)
+    {
+        command[1] = "replace".to_string();
+    }
+    command
+}
+
+fn class_depth(
+    handle: TcHandle,
+    snapshot: &HashMap<TcHandle, LiveTcClassEntry>,
+    seen: &mut HashSet<TcHandle>,
+) -> usize {
+    if !seen.insert(handle) {
+        return 0;
+    }
+    snapshot
+        .get(&handle)
+        .and_then(|entry| entry.parent)
+        .map(|parent| 1 + class_depth(parent, snapshot, seen))
+        .unwrap_or(0)
+}
+
+fn class_delete_commands(
+    interface: &str,
+    class_snapshot: &HashMap<TcHandle, LiveTcClassEntry>,
+    root_child_majors: &HashSet<u16>,
+) -> Vec<Vec<String>> {
+    let mut entries = class_snapshot
+        .values()
+        .filter(|entry| {
+            entry.class_id.get_major_minor().0 != ROOT_MQ_MAJOR
+                && !root_infra_class_entry(entry, root_child_majors)
+        })
+        .filter_map(|entry| {
+            entry.parent.map(|parent| {
+                let mut seen = HashSet::new();
+                (
+                    class_depth(entry.class_id, class_snapshot, &mut seen),
+                    entry.class_id,
+                    parent,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|entry| Reverse(entry.0));
+    entries
+        .into_iter()
+        .map(|(_, class_id, parent)| {
+            vec![
+                "class".to_string(),
+                "del".to_string(),
+                "dev".to_string(),
+                interface.to_string(),
+                "parent".to_string(),
+                parent.as_tc_string(),
+                "classid".to_string(),
+                class_id.as_tc_string(),
+            ]
+        })
+        .collect()
+}
+
+fn qdisc_delete_commands(
+    interface: &str,
+    qdisc_snapshot: &[LiveTcQdiscEntry],
+    root_child_majors: &HashSet<u16>,
+) -> Vec<Vec<String>> {
+    qdisc_snapshot
+        .iter()
+        .filter(|entry| !root_infra_qdisc_entry(entry, root_child_majors))
+        .filter_map(|entry| entry.parent)
+        .map(|parent| {
+            vec![
+                "qdisc".to_string(),
+                "del".to_string(),
+                "dev".to_string(),
+                interface.to_string(),
+                "parent".to_string(),
+                parent.as_tc_string(),
+            ]
+        })
+        .collect()
+}
+
+fn drain_managed_tree_to_defaults(
+    interface: &str,
+    qdisc_snapshot: &[LiveTcQdiscEntry],
+) -> Result<HashSet<u16>, String> {
+    let root_child_majors = managed_root_child_parent_handles(qdisc_snapshot)
+        .into_iter()
+        .map(|parent| parent.get_major_minor().1)
+        .collect::<HashSet<_>>();
+    if root_child_majors.is_empty() {
+        return Ok(root_child_majors);
+    }
+    let class_snapshot = read_live_class_snapshot(interface)?;
+    let mut commands = qdisc_delete_commands(interface, qdisc_snapshot, &root_child_majors);
+    commands.extend(class_delete_commands(
+        interface,
+        &class_snapshot,
+        &root_child_majors,
+    ));
+    if commands.is_empty() {
+        return Ok(root_child_majors);
+    }
+    run_root_preflight_commands(
+        &commands,
+        &format!("full reload drain managed tree to defaults on {interface}"),
+    )?;
+    invalidate_live_tc_snapshots();
+    Ok(root_child_majors)
+}
+
+fn prepare_root_mq_for_full_reload(
+    config: &Arc<Config>,
+) -> Result<HashMap<String, HashSet<u16>>, String> {
+    let mut preserved_root_child_majors = HashMap::new();
     for interface in managed_interfaces_for_config(config) {
         let qdisc_snapshot = read_live_qdisc_snapshot(&interface)?;
         if retained_root_mq_entry(&qdisc_snapshot).is_some() {
-            let prune_commands = managed_root_child_parent_handles(&qdisc_snapshot)
-                .into_iter()
-                .map(|parent| {
-                    vec![
-                        "qdisc".to_string(),
-                        "del".to_string(),
-                        "dev".to_string(),
-                        interface.clone(),
-                        "parent".to_string(),
-                        parent.as_tc_string(),
-                    ]
-                })
-                .collect::<Vec<_>>();
-            if !prune_commands.is_empty() {
-                run_root_preflight_commands(
-                    &prune_commands,
-                    &format!("full reload retained-root child prune on {interface}"),
-                )?;
-                invalidate_live_tc_snapshots();
+            let has_managed_root_children =
+                !managed_root_child_parent_handles(&qdisc_snapshot).is_empty();
+            if has_managed_root_children {
+                let root_child_majors =
+                    drain_managed_tree_to_defaults(&interface, &qdisc_snapshot)?;
+                if !root_child_majors.is_empty() {
+                    preserved_root_child_majors.insert(interface.clone(), root_child_majors);
+                }
             }
-
-            let pruned_qdisc_snapshot = read_live_qdisc_snapshot(&interface)?;
-            let pruned_class_snapshot = read_live_class_snapshot(&interface)?;
-            if verify_clean_root_child_tree(
-                &pruned_qdisc_snapshot,
-                &pruned_class_snapshot,
-                &interface,
-            )
-            .is_ok()
-            {
-                continue;
-            }
+            info!(
+                "Bakery: preserving existing root mq/default path on {interface} during full reload"
+            );
+            continue;
         }
 
         let replace_summary = run_root_preflight_commands(
@@ -2832,7 +3083,7 @@ fn prepare_root_mq_for_full_reload(config: &Arc<Config>) -> Result<(), String> {
         )?;
     }
 
-    Ok(())
+    Ok(preserved_root_child_majors)
 }
 
 fn live_tree_mutations_allowed(config: &Arc<Config>) -> bool {
@@ -10562,26 +10813,29 @@ fn full_reload(
     let previous_mq_created = MQ_CREATED.load(Ordering::Relaxed);
     let previous_shaping_tree_active = SHAPING_TREE_ACTIVE.load(Ordering::Relaxed);
 
-    if let Err(error) = prepare_root_mq_for_full_reload(config) {
-        let summary = format!("Failed to prepare root mq state before full reload: {error}");
-        error!("{summary}");
-        tc_bypass_guard.keep_bypass_enabled_after_failure(&summary);
-        mark_reload_required(format!(
-            "{summary}. TC classify bypass remains enabled to avoid stale class-handle classification until a successful reload or operator intervention."
-        ));
-        mark_bakery_action_finished(BakeryApplyMetrics {
-            apply_type: BakeryApplyType::FullReload,
-            summary: &summary,
-            build_duration_ms: 0,
-            apply_duration_ms: 0,
-            total_tc_commands: 0,
-            class_commands: 0,
-            qdisc_commands: 0,
-            ok: false,
-        });
-        *batch = None;
-        return;
-    }
+    let preserved_root_child_majors = match prepare_root_mq_for_full_reload(config) {
+        Ok(preserved_root_child_majors) => preserved_root_child_majors,
+        Err(error) => {
+            let summary = format!("Failed to prepare root mq state before full reload: {error}");
+            error!("{summary}");
+            tc_bypass_guard.keep_bypass_enabled_after_failure(&summary);
+            mark_reload_required(format!(
+                "{summary}. TC classify bypass remains enabled to avoid stale class-handle classification until a successful reload or operator intervention."
+            ));
+            mark_bakery_action_finished(BakeryApplyMetrics {
+                apply_type: BakeryApplyType::FullReload,
+                summary: &summary,
+                build_duration_ms: 0,
+                apply_duration_ms: 0,
+                total_tc_commands: 0,
+                class_commands: 0,
+                qdisc_commands: 0,
+                ok: false,
+            });
+            *batch = None;
+            return;
+        }
+    };
     invalidate_live_tc_snapshots();
     MQ_CREATED.store(true, Ordering::Relaxed);
 
@@ -10625,7 +10879,10 @@ fn full_reload(
         &mut working_circuits,
         &layout,
         &mut working_qdisc_handles,
-        &live_reserved_handles,
+        ProcessBatchOptions {
+            extra_reserved_handles: &live_reserved_handles,
+            preserved_root_child_majors: &preserved_root_child_majors,
+        },
     );
 
     if batch_result.result.ok {
@@ -10686,7 +10943,7 @@ fn process_batch(
     circuits: &mut HashMap<i64, Arc<BakeryCommands>>,
     mq_layout: &MqDeviceLayout,
     qdisc_handles: &mut QdiscHandleState,
-    extra_reserved_handles: &HashMap<String, HashSet<u16>>,
+    options: ProcessBatchOptions<'_>,
 ) -> BakeryFullReloadBatchResult {
     info!("Bakery: Processing batch of {} commands", batch.len());
     update_bakery_apply_progress(Some("Building tc command batch"), 0, 0, 0, 0);
@@ -10700,7 +10957,7 @@ fn process_batch(
                 config,
                 mq_layout,
                 qdisc_handles,
-                extra_reserved_handles,
+                options.extra_reserved_handles,
             )
         })
         .filter_map(|b| {
@@ -10718,6 +10975,8 @@ fn process_batch(
             b.to_commands(config, ExecutionMode::Builder)
         })
         .flatten()
+        .map(|command| idempotent_full_reload_command(command, options.preserved_root_child_majors))
+        .filter(|command| !root_infra_qdisc_command(command, options.preserved_root_child_majors))
         .collect::<Vec<Vec<String>>>();
 
     let path = config.debug_state_file_path("linux_tc_rust.txt");
@@ -10814,21 +11073,34 @@ mod tests {
     static TC_BYPASS_SETTER_CALLS: Mutex<Vec<bool>> = Mutex::new(Vec::new());
 
     fn recording_tc_bypass_setter(enabled: bool) -> anyhow::Result<()> {
-        TC_BYPASS_SETTER_CALLS.lock().expect("record setter call").push(enabled);
+        TC_BYPASS_SETTER_CALLS
+            .lock()
+            .expect("record setter call")
+            .push(enabled);
         Ok(())
     }
 
     fn failing_tc_bypass_setter(enabled: bool) -> anyhow::Result<()> {
-        TC_BYPASS_SETTER_CALLS.lock().expect("record setter call").push(enabled);
-        Err(anyhow::anyhow!("synthetic TC classify bypass setter failure"))
+        TC_BYPASS_SETTER_CALLS
+            .lock()
+            .expect("record setter call")
+            .push(enabled);
+        Err(anyhow::anyhow!(
+            "synthetic TC classify bypass setter failure"
+        ))
     }
 
     fn disable_failing_tc_bypass_setter(enabled: bool) -> anyhow::Result<()> {
-        TC_BYPASS_SETTER_CALLS.lock().expect("record setter call").push(enabled);
+        TC_BYPASS_SETTER_CALLS
+            .lock()
+            .expect("record setter call")
+            .push(enabled);
         if enabled {
             Ok(())
         } else {
-            Err(anyhow::anyhow!("synthetic TC classify bypass disable failure"))
+            Err(anyhow::anyhow!(
+                "synthetic TC classify bypass disable failure"
+            ))
         }
     }
 
@@ -10890,21 +11162,22 @@ mod tests {
         reset_bakery_test_state();
 
         {
-            let _bypass_guard =
-                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
-                    .expect("enable bypass guard");
+            let _bypass_guard = TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
+                .expect("enable bypass guard");
             assert_eq!(take_tc_bypass_setter_calls(), vec![true]);
         }
 
         assert_eq!(take_tc_bypass_setter_calls(), vec![false]);
+        let status = bakery_status_snapshot();
+        assert!(!status.passthrough_degraded);
+        assert!(status.passthrough_degraded_reason.is_none());
     }
 
     #[test]
     fn tc_classify_bypass_guard_disables_on_early_return() {
         fn early_return() -> Result<(), ()> {
             let _bypass_guard =
-                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
-                    .map_err(|_| ())?;
+                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter).map_err(|_| ())?;
             Err(())
         }
 
@@ -10924,6 +11197,9 @@ mod tests {
         assert!(TcClassifyBypassGuard::with_setter(failing_tc_bypass_setter).is_err());
 
         assert_eq!(take_tc_bypass_setter_calls(), vec![true]);
+        let status = bakery_status_snapshot();
+        assert!(!status.passthrough_degraded);
+        assert!(status.passthrough_degraded_reason.is_none());
     }
 
     #[test]
@@ -10939,6 +11215,15 @@ mod tests {
         }
 
         assert_eq!(take_tc_bypass_setter_calls(), vec![true, false]);
+        let status = bakery_status_snapshot();
+        assert!(status.passthrough_degraded);
+        assert!(
+            status
+                .passthrough_degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("could not disable pass-through mode")
+        );
     }
 
     #[test]
@@ -10947,13 +11232,21 @@ mod tests {
         reset_bakery_test_state();
 
         {
-            let mut bypass_guard =
-                TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
-                    .expect("enable bypass guard");
+            let mut bypass_guard = TcClassifyBypassGuard::with_setter(recording_tc_bypass_setter)
+                .expect("enable bypass guard");
             bypass_guard.keep_bypass_enabled_after_failure("test failure after TC mutation");
         }
 
         assert_eq!(take_tc_bypass_setter_calls(), vec![true]);
+        let status = bakery_status_snapshot();
+        assert!(status.passthrough_degraded);
+        assert!(
+            status
+                .passthrough_degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Traffic is passing without shaping")
+        );
     }
 
     fn mk_add_circuit(hash: i64, ip_addresses: &str) -> Arc<BakeryCommands> {
@@ -13191,6 +13484,141 @@ mod tests {
             managed_root_child_parent_handles(&managed_snapshot),
             HashSet::from([TcHandle::from_u32(0x7fff0001)])
         );
+    }
+
+    #[test]
+    fn idempotent_full_reload_command_replaces_class_adds() {
+        let root_child_majors = HashMap::from([("eth0".to_string(), HashSet::from([0x1]))]);
+        assert_eq!(
+            idempotent_full_reload_command(
+                vec![
+                    "class".to_string(),
+                    "add".to_string(),
+                    "dev".to_string(),
+                    "eth0".to_string(),
+                    "classid".to_string(),
+                    "0x1:1".to_string(),
+                ],
+                &root_child_majors,
+            ),
+            vec![
+                "class".to_string(),
+                "replace".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+                "classid".to_string(),
+                "0x1:1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn idempotent_full_reload_command_leaves_non_add_commands_unchanged() {
+        let root_child_majors = HashMap::from([("eth0".to_string(), HashSet::from([0x1]))]);
+        assert_eq!(
+            idempotent_full_reload_command(
+                vec![
+                    "qdisc".to_string(),
+                    "add".to_string(),
+                    "dev".to_string(),
+                    "eth0".to_string(),
+                ],
+                &root_child_majors,
+            ),
+            vec![
+                "qdisc".to_string(),
+                "add".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+            ]
+        );
+        assert_eq!(
+            idempotent_full_reload_command(
+                vec![
+                    "class".to_string(),
+                    "del".to_string(),
+                    "dev".to_string(),
+                    "eth0".to_string(),
+                ],
+                &root_child_majors,
+            ),
+            vec![
+                "class".to_string(),
+                "del".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+            ]
+        );
+        assert_eq!(
+            idempotent_full_reload_command(
+                vec![
+                    "filter".to_string(),
+                    "add".to_string(),
+                    "dev".to_string(),
+                    "eth0".to_string(),
+                ],
+                &root_child_majors,
+            ),
+            vec![
+                "filter".to_string(),
+                "add".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn root_infra_qdisc_command_matches_root_and_default_qdiscs() {
+        let root_child_majors = HashMap::from([("eth0".to_string(), HashSet::from([0x1]))]);
+        assert!(root_infra_qdisc_command(
+            &[
+                "qdisc".to_string(),
+                "add".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+                "parent".to_string(),
+                "7FFF:0x1".to_string()
+            ],
+            &root_child_majors,
+        ));
+        assert!(root_infra_qdisc_command(
+            &[
+                "qdisc".to_string(),
+                "add".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+                "parent".to_string(),
+                "0x1:2".to_string()
+            ],
+            &root_child_majors,
+        ));
+        assert!(!root_infra_qdisc_command(
+            &[
+                "qdisc".to_string(),
+                "add".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+                "parent".to_string(),
+                "0x1:0x20".to_string()
+            ],
+            &root_child_majors,
+        ));
+        assert!(!root_infra_qdisc_command(
+            &[
+                "qdisc".to_string(),
+                "add".to_string(),
+                "dev".to_string(),
+                "eth0".to_string(),
+                "parent".to_string(),
+                "0x3:2".to_string()
+            ],
+            &root_child_majors,
+        ));
+        assert!(!root_infra_qdisc_command(
+            &["class".to_string(), "replace".to_string()],
+            &root_child_majors,
+        ));
     }
 
     #[test]

--- a/src/rust/lqos_sys/src/bpf/common/lpm.h
+++ b/src/rust/lqos_sys/src/bpf/common/lpm.h
@@ -19,6 +19,28 @@ struct ip_hash_info {
 	__u64 device_id;
 };
 
+struct tc_classify_control {
+	__u32 bypass;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct tc_classify_control);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+} tc_classify_control SEC(".maps");
+
+static __always_inline bool tc_classify_bypass_enabled(void) {
+	__u32 key = 0;
+	struct tc_classify_control *control = bpf_map_lookup_elem(&tc_classify_control, &key);
+	if (!control) {
+		// Fail safe: bypass classification rather than risk stale TC handles.
+		return true;
+	}
+	return control->bypass != 0;
+}
+
 // In on-a-stick mode, upload classes/CPUs are offset by this amount.
 // This is configured by userspace at load time.
 extern __u32 stick_offset;

--- a/src/rust/lqos_sys/src/bpf/lqos_kern.c
+++ b/src/rust/lqos_sys/src/bpf/lqos_kern.c
@@ -109,6 +109,9 @@ int xdp_prog(struct xdp_md *ctx)
         bpf_debug("Error: interface direction unspecified, aborting.");
         return XDP_PASS;
     }
+    if (tc_classify_bypass_enabled()) {
+        return XDP_PASS;
+    }
 
     // Do we need to perform a VLAN redirect?
     bool vlan_redirect = false;

--- a/src/rust/lqos_sys/src/bpf/lqos_kern.c
+++ b/src/rust/lqos_sys/src/bpf/lqos_kern.c
@@ -266,6 +266,9 @@ int tc_iphash_to_cpu(struct __sk_buff *skb)
         bpf_debug("(TC) Error: interface direction unspecified, aborting.");
         return TC_ACT_OK;
     }
+    if (tc_classify_bypass_enabled()) {
+        return TC_ACT_OK;
+    }
 #ifdef VERBOSE
     bpf_debug("(TC) SKB VLAN TCI: %u", skb->vlan_tci);    
 #endif

--- a/src/rust/lqos_sys/src/lib.rs
+++ b/src/rust/lqos_sys/src/lib.rs
@@ -22,6 +22,7 @@ mod ip_mapping;
 mod kernel_wrapper;
 mod linux;
 mod lqos_kernel;
+mod tc_classify_control;
 mod throughput;
 
 pub use bpf_iterator::{end_flows, expire_throughput, iterate_flows};
@@ -35,4 +36,5 @@ pub use lqos_kernel::interface_name_to_index;
 pub use lqos_kernel::ip_mapping_capacity;
 pub use lqos_kernel::max_tracked_ips;
 pub use lqos_kernel::unload_xdp_from_interface;
+pub use tc_classify_control::{initialize_tc_classify_bypass, set_tc_classify_bypass};
 pub use throughput::{HostCounter, throughput_for_each};

--- a/src/rust/lqos_sys/src/lqos_kernel.rs
+++ b/src/rust/lqos_sys/src/lqos_kernel.rs
@@ -153,6 +153,11 @@ fn ensure_ip_mapping_maps_abi() -> Result<()> {
         std::mem::size_of::<u32>() as u32,
     )?;
     remove_incompatible_pinned_map(
+        "/sys/fs/bpf/tc_classify_control",
+        std::mem::size_of::<u32>() as u32,
+        std::mem::size_of::<crate::tc_classify_control::TcClassifyControl>() as u32,
+    )?;
+    remove_incompatible_pinned_map(
         "/sys/fs/bpf/map_traffic",
         std::mem::size_of::<XdpIpAddress>() as u32,
         std::mem::size_of::<crate::HostCounter>() as u32,
@@ -339,6 +344,7 @@ pub fn attach_xdp_and_tc_to_interface(
         // Ensure no lingering XDP programs before loading/attaching
         let _ = unload_xdp_from_interface(interface_name);
         load_kernel(skeleton)?;
+        crate::initialize_tc_classify_bypass()?;
         let prog_fd = bpf::bpf_program__fd((*skeleton).progs.xdp_prog);
         attach_xdp_best_available(interface_index, prog_fd, interface_name)?;
         skeleton

--- a/src/rust/lqos_sys/src/tc_classify_control.rs
+++ b/src/rust/lqos_sys/src/tc_classify_control.rs
@@ -1,0 +1,144 @@
+//! Control-map helpers for temporarily bypassing TC classification.
+
+use crate::lqos_kernel::bpf::libbpf_num_possible_cpus;
+use anyhow::{Error, Result};
+use libbpf_sys::{bpf_map_update_elem, bpf_obj_get};
+use nix::libc::close;
+use std::{
+    ffi::{CString, c_void},
+    io,
+    mem::size_of,
+};
+use tracing::error;
+
+const TC_CLASSIFY_CONTROL_PATH: &str = "/sys/fs/bpf/tc_classify_control";
+const TC_CLASSIFY_CONTROL_KEY: u32 = 0;
+const PER_CPU_VALUE_ALIGNMENT: usize = 8;
+
+/// Rust mirror of `struct tc_classify_control` in the eBPF program.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct TcClassifyControl {
+    /// Non-zero tells TC classify to pass packets without setting TC handles.
+    pub bypass: u32,
+}
+
+fn aligned_per_cpu_value_size() -> usize {
+    size_of::<TcClassifyControl>().div_ceil(PER_CPU_VALUE_ALIGNMENT) * PER_CPU_VALUE_ALIGNMENT
+}
+
+fn per_cpu_payload(enabled: bool, cpu_count: u32) -> Vec<u8> {
+    let stride = aligned_per_cpu_value_size();
+    let mut payload = vec![0u8; stride * cpu_count as usize];
+    let control = TcClassifyControl {
+        bypass: u32::from(enabled),
+    };
+    let bytes = control.bypass.to_ne_bytes();
+    for cpu in 0..cpu_count as usize {
+        let offset = cpu * stride;
+        payload[offset..offset + bytes.len()].copy_from_slice(&bytes);
+    }
+    payload
+}
+
+fn update_tc_classify_control(enabled: bool) -> Result<()> {
+    let path_c = CString::new(TC_CLASSIFY_CONTROL_PATH)?;
+    let fd = unsafe { bpf_obj_get(path_c.as_ptr()) };
+    if fd < 0 {
+        let error = io::Error::last_os_error();
+        let errno = error.raw_os_error().unwrap_or(0);
+        return Err(Error::msg(format!(
+            "Unable to open BPF map '{TC_CLASSIFY_CONTROL_PATH}' for TC classify bypass update (fd={fd}, errno={errno}, error={error})"
+        )));
+    }
+
+    let cpu_count = unsafe { libbpf_num_possible_cpus() };
+    if cpu_count <= 0 {
+        unsafe {
+            close(fd);
+        }
+        return Err(Error::msg(format!(
+            "Unable to determine CPU count for TC classify bypass update: libbpf_num_possible_cpus returned {cpu_count}"
+        )));
+    }
+    let cpu_count = u32::try_from(cpu_count).map_err(|e| {
+        unsafe {
+            close(fd);
+        }
+        Error::msg(format!(
+            "Unable to convert CPU count for TC classify bypass update: {e}"
+        ))
+    })?;
+    let mut key = TC_CLASSIFY_CONTROL_KEY;
+    let payload = per_cpu_payload(enabled, cpu_count);
+    let err = unsafe {
+        bpf_map_update_elem(
+            fd,
+            &mut key as *mut u32 as *mut c_void,
+            payload.as_ptr() as *mut c_void,
+            0,
+        )
+    };
+    let update_error = (err != 0).then(io::Error::last_os_error);
+    unsafe {
+        close(fd);
+    }
+    if err != 0 {
+        let error = update_error.unwrap_or_else(|| io::Error::from_raw_os_error(0));
+        let errno = error.raw_os_error().unwrap_or(0);
+        error!(
+            "Unable to update BPF map '{}' for TC classify bypass={} (err={}, errno={}, error={})",
+            TC_CLASSIFY_CONTROL_PATH, enabled, err, errno, error
+        );
+        return Err(Error::msg(format!(
+            "Unable to update BPF map '{TC_CLASSIFY_CONTROL_PATH}' for TC classify bypass={enabled} (err={err}, errno={errno}, error={error})"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Initializes TC classify bypass to disabled.
+///
+/// This function has side effects: it writes all per-CPU values for the pinned
+/// `tc_classify_control` BPF map.
+pub fn initialize_tc_classify_bypass() -> Result<()> {
+    update_tc_classify_control(false)
+}
+
+/// Enables or disables TC classify bypass.
+///
+/// This function has side effects: it writes all per-CPU values for the pinned
+/// `tc_classify_control` BPF map. When enabled, TC classify returns `TC_ACT_OK`
+/// before consuming XDP metadata, flow cache, hot cache, or LPM mappings.
+pub fn set_tc_classify_bypass(enabled: bool) -> Result<()> {
+    update_tc_classify_control(enabled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_cpu_payload_uses_eight_byte_stride() {
+        let payload = per_cpu_payload(true, 3);
+        assert_eq!(payload.len(), 3 * PER_CPU_VALUE_ALIGNMENT);
+        for cpu in 0..3 {
+            let offset = cpu * PER_CPU_VALUE_ALIGNMENT;
+            assert_eq!(
+                &payload[offset..offset + size_of::<u32>()],
+                &1u32.to_ne_bytes()
+            );
+            assert_eq!(
+                &payload[offset + size_of::<u32>()..offset + PER_CPU_VALUE_ALIGNMENT],
+                &[0, 0, 0, 0]
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_payload_clears_all_per_cpu_values() {
+        let payload = per_cpu_payload(false, 2);
+        assert_eq!(payload, vec![0u8; 2 * PER_CPU_VALUE_ALIGNMENT]);
+    }
+}

--- a/src/rust/lqos_sys/src/tc_classify_control.rs
+++ b/src/rust/lqos_sys/src/tc_classify_control.rs
@@ -1,4 +1,4 @@
-//! Control-map helpers for temporarily bypassing TC classification.
+//! Control-map helpers for temporarily bypassing XDP redirection and TC classification.
 
 use crate::lqos_kernel::bpf::libbpf_num_possible_cpus;
 use anyhow::{Error, Result};
@@ -19,7 +19,8 @@ const PER_CPU_VALUE_ALIGNMENT: usize = 8;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct TcClassifyControl {
-    /// Non-zero tells TC classify to pass packets without setting TC handles.
+    /// Non-zero tells XDP and TC classify to pass packets without redirecting
+    /// or setting TC handles.
     pub bypass: u32,
 }
 
@@ -109,8 +110,9 @@ pub fn initialize_tc_classify_bypass() -> Result<()> {
 /// Enables or disables TC classify bypass.
 ///
 /// This function has side effects: it writes all per-CPU values for the pinned
-/// `tc_classify_control` BPF map. When enabled, TC classify returns `TC_ACT_OK`
-/// before consuming XDP metadata, flow cache, hot cache, or LPM mappings.
+/// `tc_classify_control` BPF map. When enabled, XDP returns `XDP_PASS` before
+/// CPU redirection, and TC classify returns `TC_ACT_OK` before consuming XDP
+/// metadata, flow cache, hot cache, or LPM mappings.
 pub fn set_tc_classify_bypass(enabled: bool) -> Result<()> {
     update_tc_classify_control(enabled)
 }

--- a/src/rust/lqosd/src/lts2_sys/control_channel.rs
+++ b/src/rust/lqosd/src/lts2_sys/control_channel.rs
@@ -1169,38 +1169,6 @@ async fn persistent_connection(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn encode_ws_binary_round_trips_begin_ingest() {
-        let encoded = encode_ws_binary(
-            &messages::WsMessage::BeginIngest {
-                unique_id: 42,
-                n_chunks: 7,
-            },
-            "BeginIngest",
-        )
-        .expect("BeginIngest should encode");
-
-        let Message::Binary(bytes) = encoded else {
-            panic!("BeginIngest should encode to a binary websocket frame");
-        };
-
-        match messages::WsMessage::from_bytes(&bytes).expect("BeginIngest should decode") {
-            messages::WsMessage::BeginIngest {
-                unique_id,
-                n_chunks,
-            } => {
-                assert_eq!(unique_id, 42);
-                assert_eq!(n_chunks, 7);
-            }
-            other => panic!("unexpected decoded message: {other:?}"),
-        }
-    }
-}
-
 async fn connect() -> anyhow::Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
     let remote_host = crate::lts2_sys::lts2_client::get_remote_host();
     let target = format!("wss://{}:443/shaper_gateway/ws", &remote_host);
@@ -1788,4 +1756,36 @@ async fn tree_snapshot_streaming(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_ws_binary_round_trips_begin_ingest() {
+        let encoded = encode_ws_binary(
+            &messages::WsMessage::BeginIngest {
+                unique_id: 42,
+                n_chunks: 7,
+            },
+            "BeginIngest",
+        )
+        .expect("BeginIngest should encode");
+
+        let Message::Binary(bytes) = encoded else {
+            panic!("BeginIngest should encode to a binary websocket frame");
+        };
+
+        match messages::WsMessage::from_bytes(&bytes).expect("BeginIngest should decode") {
+            messages::WsMessage::BeginIngest {
+                unique_id,
+                n_chunks,
+            } => {
+                assert_eq!(unique_id, 42);
+                assert_eq!(n_chunks, 7);
+            }
+            other => panic!("unexpected decoded message: {other:?}"),
+        }
+    }
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/bakery_activity.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/bakery_activity.js
@@ -86,12 +86,12 @@ function classifyEvent(entry) {
     if (event.endsWith("_started")) {
         outcome = "Running";
         outcomeClass = "bg-primary-subtle text-primary border border-primary-subtle";
-    } else if (event === "reload_required") {
+    } else if (event === "reload_required" || event === "passthrough_degraded") {
         stage = "Verify";
         scope = "Full Reload";
-        outcome = "Reload Required";
+        outcome = event === "passthrough_degraded" ? "Pass-Through" : "Reload Required";
         outcomeClass = "bg-danger-subtle text-danger border border-danger-subtle";
-    } else if (event === "reload_required_cleared") {
+    } else if (event === "reload_required_cleared" || event === "passthrough_degraded_cleared") {
         stage = "Verify";
         scope = "Full Reload";
         outcome = "Cleared";
@@ -182,6 +182,8 @@ function describeOperation(entry, meta) {
         || event === "full_reload_started"
         || event === "reload_required"
         || event === "reload_required_cleared"
+        || event === "passthrough_degraded"
+        || event === "passthrough_degraded_cleared"
         || meta.scope === "Full Reload"
     ) {
         return {

--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/bakery_status.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/bakery_status.js
@@ -16,10 +16,16 @@ function classifyOutcome(entry) {
     const event = (entry?.event ?? "").toString().trim().toLowerCase();
     const status = (entry?.status ?? "").toString().trim().toLowerCase();
 
-    if (event === "reload_required") {
+    if (event === "reload_required" || event === "passthrough_degraded") {
         return {
-            label: "Reload Required",
+            label: event === "passthrough_degraded" ? "Pass-Through" : "Reload Required",
             className: "bg-danger-subtle text-danger border border-danger-subtle",
+        };
+    }
+    if (event === "passthrough_degraded_cleared") {
+        return {
+            label: "Shaping Restored",
+            className: "bg-success-subtle text-success border border-success-subtle",
         };
     }
     if (event === "apply_failed" || status === "error") {

--- a/src/rust/lqosd/src/node_manager/js_build/src/dashlets/bakery_status_summary.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/dashlets/bakery_status_summary.js
@@ -58,6 +58,10 @@ export class BakeryStatusSummaryDashlet extends BaseDashlet {
         this.lastFailureSummaryEl = document.createElement("span");
         this.lastFailureSummaryEl.style.whiteSpace = "normal";
         this.lastFailureSummaryEl.style.wordBreak = "break-word";
+        this.shapingStateEl = document.createElement("div");
+        this.passthroughReasonEl = document.createElement("span");
+        this.passthroughReasonEl.style.whiteSpace = "normal";
+        this.passthroughReasonEl.style.wordBreak = "break-word";
         this.reloadRequiredEl = document.createElement("div");
         this.reloadReasonEl = document.createElement("span");
         this.reloadReasonEl.style.whiteSpace = "normal";
@@ -65,10 +69,12 @@ export class BakeryStatusSummaryDashlet extends BaseDashlet {
 
         tbody.appendChild(mkRow("Current Mode", this.modeEl));
         tbody.appendChild(mkRow("Current Duration", this.durationEl));
+        tbody.appendChild(mkRow("Shaping State", this.shapingStateEl));
         tbody.appendChild(mkRow("Runtime Drift", this.reloadRequiredEl));
         tbody.appendChild(mkRow("Last Success", this.lastSuccessEl));
         tbody.appendChild(mkRow("Last Failure", this.lastFailureEl));
         tbody.appendChild(mkRow("Failure Summary", this.lastFailureSummaryEl));
+        tbody.appendChild(mkRow("Pass-Through Reason", this.passthroughReasonEl));
         tbody.appendChild(mkRow("Reload Reason", this.reloadReasonEl));
 
         table.appendChild(tbody);
@@ -91,6 +97,12 @@ export class BakeryStatusSummaryDashlet extends BaseDashlet {
 
         this.modeEl.innerHTML = "";
         this.modeEl.appendChild(bakeryModeBadge(status.mode));
+        this.shapingStateEl.innerHTML = "";
+        this.shapingStateEl.appendChild(
+            status.passthroughDegraded
+                ? mkBadge("Pass-Through / Unshaped", "bg-danger-subtle text-danger border border-danger-subtle")
+                : mkBadge("Normal Shaping", "bg-success-subtle text-success border border-success-subtle"),
+        );
         this.reloadRequiredEl.innerHTML = "";
         this.reloadRequiredEl.appendChild(
             status.reloadRequired
@@ -104,6 +116,7 @@ export class BakeryStatusSummaryDashlet extends BaseDashlet {
         this.lastSuccessEl.textContent = formatUnixSecondsToLocalDateTime(status.lastSuccessUnix);
         this.lastFailureEl.textContent = formatUnixSecondsToLocalDateTime(status.lastFailureUnix);
         this.lastFailureSummaryEl.textContent = status.lastFailureSummary || "—";
+        this.passthroughReasonEl.textContent = status.passthroughDegradedReason || "—";
         this.reloadReasonEl.textContent = status.reloadRequiredReason || "—";
     }
 }

--- a/src/rust/lqosd/src/node_manager/js_build/src/template.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/template.js
@@ -1159,13 +1159,16 @@ function initUrgentIssues() {
                 const td = document.createElement('td');
                 const when = new Date(it.ts * 1000).toLocaleString();
                 const sev = it.severity === 'Error' ? 'danger' : 'warning';
+                const clearControl = it.clearable === false
+                    ? '<span class="badge bg-secondary-subtle text-secondary border float-end ms-3">Active</span>'
+                    : `<button type="button" class="btn btn-link btn-sm text-secondary float-end ms-3 p-0 urgent-clear" data-id="${it.id}" title="Acknowledge issue" aria-label="Acknowledge issue ${escapeAttr(it.code)}"><i class="fa fa-times" aria-hidden="true"></i></button>`;
                 td.innerHTML = `
                     <div>
                         <span class="badge bg-${sev}">${it.severity}</span>
                         <strong class="ms-2">${it.code}</strong>
                         <span class="text-muted ms-2">(${it.source})</span>
                         <span class="text-muted float-end">${when}</span>
-                        <button type="button" class="btn btn-link btn-sm text-secondary float-end ms-3 p-0 urgent-clear" data-id="${it.id}" title="Acknowledge issue" aria-label="Acknowledge issue ${escapeAttr(it.code)}"><i class="fa fa-times" aria-hidden="true"></i></button>
+                        ${clearControl}
                     </div>
                     <div class="mt-1" style="white-space: pre-wrap;">${it.message}</div>
                     ${it.context ? `<pre class="mt-2">${it.context}</pre>` : ''}

--- a/src/rust/lqosd/src/node_manager/local_api/shaped_devices_page.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/shaped_devices_page.rs
@@ -234,7 +234,7 @@ mod tests {
             ("fast", 40, 90, 2_000),
             ("idle", 0, 0, u64::MAX),
         ]);
-        let mut rows = vec![
+        let mut rows = [
             test_device("slow", "Slow Circuit", "Slow Device"),
             test_device("idle", "Idle Circuit", "Idle Device"),
             test_device("fast", "Fast Circuit", "Fast Device"),
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn dynamic_inventory_order_uses_alphabetic_tie_breakers() {
         let snapshot = test_snapshot(&[("alpha", 25, 25, 100), ("beta", 25, 25, 100)]);
-        let mut rows = vec![
+        let mut rows = [
             test_device("beta", "Beta Circuit", "Second Device"),
             test_device("alpha", "Alpha Circuit", "First Device"),
         ];

--- a/src/rust/lqosd/src/node_manager/local_api/urgent.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/urgent.rs
@@ -73,6 +73,7 @@ pub struct UrgentItem {
     pub code: String,
     pub message: String,
     pub context: Option<String>,
+    pub clearable: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -80,17 +81,32 @@ pub struct UrgentList {
     pub items: Vec<UrgentItem>,
 }
 
-pub fn urgent_status_data() -> UrgentStatus {
-    let items = urgent::list();
-    UrgentStatus {
-        has_urgent: !items.is_empty(),
-        count: items.len(),
+fn bakery_passthrough_issue() -> Option<UrgentItem> {
+    let status = lqos_bakery::bakery_status_snapshot();
+    if !status.reload_required || !status.passthrough_degraded {
+        return None;
     }
+    Some(UrgentItem {
+        id: u64::MAX,
+        ts: status
+            .last_failure_unix
+            .or(status.current_action_started_unix)
+            .unwrap_or_default(),
+        source: "System".to_string(),
+        severity: "Error".to_string(),
+        code: "BAKERY_PASSTHROUGH_DEGRADED".to_string(),
+        message: status.passthrough_degraded_reason.unwrap_or_else(|| {
+            "Bakery full reload failed while pass-through mode was active. Traffic may be unshaped until a successful full reload clears the degraded state.".to_string()
+        }),
+        context: status.reload_required_reason.map(|reason| {
+            format!("Reload required reason: {reason}")
+        }),
+        clearable: false,
+    })
 }
 
-pub fn urgent_list_data() -> UrgentList {
-    let items = urgent::list();
-    let items: Vec<UrgentItem> = items
+fn merged_urgent_items() -> Vec<UrgentItem> {
+    let mut items: Vec<UrgentItem> = urgent::list()
         .into_iter()
         .map(|i| UrgentItem {
             id: i.id,
@@ -100,9 +116,29 @@ pub fn urgent_list_data() -> UrgentList {
             code: i.code,
             message: strip_ansi(&i.message),
             context: i.context,
+            clearable: true,
         })
         .collect();
-    UrgentList { items }
+    if let Some(issue) = bakery_passthrough_issue() {
+        items.push(issue);
+    }
+    items.sort_by_key(|item| item.ts);
+    items.reverse();
+    items
+}
+
+pub fn urgent_status_data() -> UrgentStatus {
+    let items = merged_urgent_items();
+    UrgentStatus {
+        has_urgent: !items.is_empty(),
+        count: items.len(),
+    }
+}
+
+pub fn urgent_list_data() -> UrgentList {
+    UrgentList {
+        items: merged_urgent_items(),
+    }
 }
 
 pub fn urgent_clear_id(id: u64) -> bool {

--- a/src/rust/lqosd/src/node_manager/template.rs
+++ b/src/rust/lqosd/src/node_manager/template.rs
@@ -287,10 +287,11 @@ mod tests {
     }
 
     fn test_config(runtime_dir: &std::path::Path, display_cobrand: bool) -> Config {
-        let mut config = Config::default();
-        config.lqos_directory = runtime_dir.display().to_string();
-        config.display_cobrand = display_cobrand;
-        config
+        Config {
+            lqos_directory: runtime_dir.display().to_string(),
+            display_cobrand,
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/src/rust/lqosd/src/node_manager/ws/messages.rs
+++ b/src/rust/lqosd/src/node_manager/ws/messages.rs
@@ -447,6 +447,8 @@ pub struct BakeryStatusState {
     pub preflight: Option<BakeryPreflightData>,
     pub reload_required: bool,
     pub reload_required_reason: Option<String>,
+    pub passthrough_degraded: bool,
+    pub passthrough_degraded_reason: Option<String>,
     pub dirty_subtree_count: usize,
 }
 

--- a/src/rust/lqosd/src/node_manager/ws/ticker/bakery.rs
+++ b/src/rust/lqosd/src/node_manager/ws/ticker/bakery.rs
@@ -152,6 +152,8 @@ fn map_status(snapshot: BakeryStatusSnapshot) -> BakeryStatusData {
             },
             reload_required: snapshot.reload_required,
             reload_required_reason: snapshot.reload_required_reason,
+            passthrough_degraded: snapshot.passthrough_degraded,
+            passthrough_degraded_reason: snapshot.passthrough_degraded_reason,
             dirty_subtree_count: snapshot.dirty_subtree_count,
             queue_distribution: snapshot
                 .queue_distribution

--- a/src/rust/lqosd/src/shaped_devices_tracker/mod.rs
+++ b/src/rust/lqosd/src/shaped_devices_tracker/mod.rs
@@ -121,12 +121,12 @@ fn active_runtime_shaping_inputs_path(config: &lqos_config::Config) -> Result<Op
 fn load_active_runtime_shaping_inputs(
     config: &lqos_config::Config,
 ) -> Result<Option<TopologyShapingInputsFile>> {
-    if let Some(active_path) = active_runtime_shaping_inputs_path(config)? {
-        if active_path.exists() {
-            let raw = std::fs::read_to_string(&active_path)?;
-            let shaping_inputs = serde_json::from_str(&raw)?;
-            return Ok(Some(shaping_inputs));
-        }
+    if let Some(active_path) = active_runtime_shaping_inputs_path(config)?
+        && active_path.exists()
+    {
+        let raw = std::fs::read_to_string(&active_path)?;
+        let shaping_inputs = serde_json::from_str(&raw)?;
+        return Ok(Some(shaping_inputs));
     }
 
     let fallback_path = topology_shaping_inputs_path(config);

--- a/src/rust/uisp_integration/src/strategies/common.rs
+++ b/src/rust/uisp_integration/src/strategies/common.rs
@@ -213,7 +213,7 @@ fn dedup_raw_devices_by_id(
     let mut deduped_devices = Vec::with_capacity(original_raw_len);
     let mut deduped_json = Vec::with_capacity(original_json_len);
 
-    for (device, raw_json) in devices_raw.into_iter().zip(devices_as_json.into_iter()) {
+    for (device, raw_json) in devices_raw.into_iter().zip(devices_as_json) {
         let device_id = device.identification.id.clone();
         if !seen_ids.insert(device_id.clone()) {
             *duplicate_counts.entry(device_id).or_insert(0) += 1;


### PR DESCRIPTION
## Summary

This PR changes Bakery full reload behavior so topology/layout changes can rebuild TC without sending active subscriber traffic to stale or deleted class handles.

The reload path now:

- Preserves root MQ and the default pass-through path during full reload cleanup.
- Enables XDP/TC classify bypass while destructive TC work is in progress.
- Rebuilds managed TC classes/qdiscs, refreshes mappings, then disables bypass only after the reload succeeds.
- Preserves `clsact`, so TC classify remains attached across full reload pruning.
- Verifies `tc_iphash_to_cp` is still attached on managed egress interfaces before disabling bypass.
- Keeps bypass enabled and reports a degraded pass-through state if TC commands fail or TC classify is missing after a reload.
- Surfaces pass-through degraded state through Bakery status and Urgent Issues.

The intended failure mode changes from possible traffic cutout to temporary unshaped pass-through. That is a safer operational tradeoff during full reload failures because packets continue to forward instead of being classified to nonexistent queues.

## Why

On develop, a full reload can delete managed TC classes while XDP/IP mappings and TC classify still point at old handles. If packets are classified to a deleted handle during that window, shaped customer traffic can stop until TC and mapping state converges again.

Clearing the large XDP mapping tables first is not ideal because emptying BPF maps takes locks and can stall dataplane lookups. This PR instead keeps the default path valid and temporarily bypasses classification during the dangerous part of the rebuild.

## Validation

Private testbed validation was performed on the LibreQoS simulation environment:

- Testbed VM: `100.99.0.4`
- Internet simulation VM: `100.99.0.3`
- Network simulation VM: `100.99.0.5`
- 10,000 shaped devices
- All shaped devices set to `5 Mbps` download and `5 Mbps` upload
- Active shaped traffic using `100.97.x.x` test IPs

Validated full-reload triggers:

- Add topology marker sites.
- Remove topology marker sites.
- Move an AP between parent sites.
- Move the AP back.
- Repeat add/remove.
- Restore original topology.

Harness checks after each reload:

- Desired HTB classes from `linux_tc_rust.txt` exist live.
- No stale live HTB classes remain outside the desired tree.
- Desired qdisc handles exist live.
- Sampled XDP IP mappings point to live TC handles on both managed interfaces.
- `tc_classify_control.bypass` returns to `0` on every CPU.
- Live qdisc counts do not drift across repeated topology changes.

Observed fixed-branch results:

- Seven full-reload validation snapshots passed.
- 10,000 XDP mappings were present after every reload.
- Bypass returned to `0` on all CPUs after every successful reload.
- qdisc counts stayed stable across the reload sequence.
- Four continuous shaped-IP ping streams had `0.0%` loss across roughly 5,500 packets each.
- Post-reload iperf enforcement remained active at about `4.7-4.9 Mbps` on a `5 Mbps` shaped device.
- `bpftool net` showed `clsact/egress tc_iphash_to_cp` attached on both managed interfaces after reloads.

Develop comparison on the same testbed showed full-reload ping loss of about `8.6-8.9%` on the same shaped-IP traffic pattern.

## Local Checks

- `cargo fmt --check`
- `cargo check -p lqos_bakery`
- `cargo clippy -p lqos_bakery -- -D warnings`
- Targeted `lqos_bakery` unit tests for full-reload command handling and bypass guard behavior

Note: the full `cargo test -p lqos_bakery --lib` run still hits the existing unrelated `restore_with_pending_cleanup_is_not_reported_completed` failure.

## Operational Notes

During a full reload, traffic may briefly pass unshaped while bypass is enabled. If the reload fails or TC classify is missing afterward, bypass remains enabled instead of risking stale-handle classification. Operators should see the degraded pass-through state in Bakery status and Urgent Issues until a successful reload or restart restores normal shaping.