### PR TITLE
Fix topology reload churn

### DIFF
--- a/src/rust/lqos_config/src/lib.rs
+++ b/src/rust/lqos_config/src/lib.rs
@@ -93,13 +93,15 @@ pub use topology_runtime_state::{
     TOPOLOGY_IMPORT_FILENAME, TOPOLOGY_RUNTIME_STATUS_FILENAME, TOPOLOGY_SHAPING_INPUTS_FILENAME,
     TopologyAttachmentEndpointStatus, TopologyAttachmentHealthEntry,
     TopologyAttachmentHealthStateFile, TopologyEffectiveAttachmentState,
-    TopologyEffectiveNodeState, TopologyEffectiveStateFile, TopologyRuntimeStateError,
-    TopologyRuntimeStatusFile, TopologyShapingCircuitInput, TopologyShapingDeviceInput,
-    TopologyShapingInputsFile, TopologyShapingResolutionSource, active_runtime_shaping_inputs_path,
-    compute_effective_network_generation, compute_topology_source_generation,
-    load_active_runtime_shaping_inputs, topology_attachment_health_state_path,
-    topology_compiled_shaping_path, topology_effective_network_path, topology_effective_state_path,
-    topology_import_path, topology_runtime_status_path, topology_shaping_inputs_path,
+    TopologyEffectiveNodeState, TopologyEffectiveStateFile, TopologyRuntimeShapingPayloadIdentity,
+    TopologyRuntimeStateError, TopologyRuntimeStatusFile, TopologyShapingCircuitInput,
+    TopologyShapingDeviceInput, TopologyShapingInputsFile, TopologyShapingResolutionSource,
+    active_runtime_shaping_inputs_path, compute_effective_network_generation,
+    active_runtime_shaping_inputs_path_from_status, compute_topology_source_generation,
+    load_active_runtime_shaping_inputs, load_active_runtime_shaping_inputs_from_status,
+    topology_attachment_health_state_path, topology_compiled_shaping_path,
+    topology_effective_network_path, topology_effective_state_path, topology_import_path,
+    topology_runtime_status_path, topology_shaping_inputs_path,
 };
 
 /// Returns whether an integration-backed topology ingress is enabled in the

--- a/src/rust/lqos_config/src/topology_runtime_state.rs
+++ b/src/rust/lqos_config/src/topology_runtime_state.rs
@@ -356,6 +356,20 @@ pub struct TopologyRuntimeStatusFile {
     pub error: Option<String>,
 }
 
+/// Shaping-relevant runtime status identity used by consumers that only need
+/// to know whether the active shaping payload changed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TopologyRuntimeShapingPayloadIdentity {
+    /// Whether runtime outputs are ready.
+    pub ready: bool,
+    /// Stable generation hash of the source topology inputs.
+    pub source_generation: String,
+    /// Stable generation hash of the shaping payload.
+    pub shaping_generation: String,
+    /// Path to the active shaping inputs payload.
+    pub shaping_inputs_path: String,
+}
+
 fn default_runtime_schema_version() -> u32 {
     1
 }
@@ -428,20 +442,33 @@ pub fn active_runtime_shaping_inputs_path(
 ) -> Result<Option<PathBuf>, TopologyRuntimeStateError> {
     let current_generation = compute_topology_source_generation(config)?;
     let status = TopologyRuntimeStatusFile::load(config)?;
+    Ok(active_runtime_shaping_inputs_path_from_status(
+        &status,
+        &current_generation,
+    ))
+}
+
+/// Returns the active runtime shaping-inputs path from an already-loaded status file.
+///
+/// This function is pure: it has no side effects.
+pub fn active_runtime_shaping_inputs_path_from_status(
+    status: &TopologyRuntimeStatusFile,
+    current_generation: &str,
+) -> Option<PathBuf> {
     if !status.ready {
-        return Ok(None);
+        return None;
     }
     if status.shaping_generation.trim().is_empty() {
-        return Ok(None);
+        return None;
     }
     if status.source_generation.trim() != current_generation {
-        return Ok(None);
+        return None;
     }
     let path = status.shaping_inputs_path.trim();
     if path.is_empty() {
-        return Ok(None);
+        return None;
     }
-    Ok(Some(PathBuf::from(path)))
+    Some(PathBuf::from(path))
 }
 
 /// Loads the currently active runtime shaping-inputs file when the topology
@@ -450,6 +477,20 @@ pub fn load_active_runtime_shaping_inputs(
     config: &Config,
 ) -> Result<Option<TopologyShapingInputsFile>, TopologyRuntimeStateError> {
     let Some(path) = active_runtime_shaping_inputs_path(config)? else {
+        return Ok(None);
+    };
+    let raw = std::fs::read_to_string(&path)?;
+    Ok(Some(serde_json::from_str(&raw)?))
+}
+
+/// Loads the active runtime shaping-inputs file from an already-loaded status file.
+pub fn load_active_runtime_shaping_inputs_from_status(
+    config: &Config,
+    status: &TopologyRuntimeStatusFile,
+) -> Result<Option<TopologyShapingInputsFile>, TopologyRuntimeStateError> {
+    let current_generation = compute_topology_source_generation(config)?;
+    let Some(path) = active_runtime_shaping_inputs_path_from_status(status, &current_generation)
+    else {
         return Ok(None);
     };
     let raw = std::fs::read_to_string(&path)?;
@@ -741,6 +782,29 @@ impl TopologyRuntimeStatusFile {
             &config.topology_state_file_path(TOPOLOGY_RUNTIME_STATUS_FILENAME),
             self,
         )
+    }
+
+    /// Returns true when runtime status is equal except for the generated timestamp.
+    pub fn semantic_equals_for_publish(&self, other: &Self) -> bool {
+        self.schema_version == other.schema_version
+            && self.source_generation == other.source_generation
+            && self.shaping_generation == other.shaping_generation
+            && self.effective_generation == other.effective_generation
+            && self.ready == other.ready
+            && self.effective_state_path == other.effective_state_path
+            && self.effective_network_path == other.effective_network_path
+            && self.shaping_inputs_path == other.shaping_inputs_path
+            && self.error == other.error
+    }
+
+    /// Returns the shaping payload identity used by cache consumers.
+    pub fn shaping_payload_identity(&self) -> TopologyRuntimeShapingPayloadIdentity {
+        TopologyRuntimeShapingPayloadIdentity {
+            ready: self.ready,
+            source_generation: self.source_generation.clone(),
+            shaping_generation: self.shaping_generation.clone(),
+            shaping_inputs_path: self.shaping_inputs_path.clone(),
+        }
     }
 }
 
@@ -1297,6 +1361,41 @@ mod tests {
                 .join("state")
                 .join("topology")
                 .join(TOPOLOGY_RUNTIME_STATUS_FILENAME)
+        );
+    }
+
+    #[test]
+    fn topology_runtime_status_publish_compare_ignores_generated_unix() {
+        let first = TopologyRuntimeStatusFile {
+            schema_version: 1,
+            source_generation: "source-1".to_string(),
+            shaping_generation: "shape-1".to_string(),
+            effective_generation: "effective-1".to_string(),
+            ready: true,
+            generated_unix: Some(1),
+            effective_state_path: "/tmp/effective.json".to_string(),
+            effective_network_path: "/tmp/network.effective.json".to_string(),
+            shaping_inputs_path: "/tmp/shaping_inputs.json".to_string(),
+            error: None,
+        };
+        let second = TopologyRuntimeStatusFile {
+            generated_unix: Some(2),
+            ..first.clone()
+        };
+        let changed = TopologyRuntimeStatusFile {
+            shaping_generation: "shape-2".to_string(),
+            ..first.clone()
+        };
+
+        assert!(first.semantic_equals_for_publish(&second));
+        assert!(!first.semantic_equals_for_publish(&changed));
+        assert_eq!(
+            first.shaping_payload_identity(),
+            second.shaping_payload_identity()
+        );
+        assert_ne!(
+            first.shaping_payload_identity(),
+            changed.shaping_payload_identity()
         );
     }
 

--- a/src/rust/lqos_network_devices/README.md
+++ b/src/rust/lqos_network_devices/README.md
@@ -11,8 +11,8 @@ Centralized, shared access to LibreQoS topology inputs:
 In daemon mode, this crate starts:
 
 - A single-thread actor that owns reload/apply commands.
-- Watchers for the config directory and topology-state directory that coalesce
-  filesystem events and request reloads.
+- Watchers for the config directory, topology-state directory, and shaping-state
+  directory that coalesce filesystem events and request reloads.
 
 Callers access state through public accessor functions; the underlying channel sender is kept in a
 private static.
@@ -27,7 +27,7 @@ private static.
 - `with_network_json_write(|net_json| ...)`: mutable access to in-memory `NetworkJson` (used by runtime counters).
 - `resolve_parent_node_reference(parent_node, parent_node_id)`: canonicalize shaped-device parent references against `network.json`.
 - `request_reload_shaped_devices(reason)` / `request_reload_network_json(reason)`: ask actor to reload from disk.
-- `apply_shaped_devices_snapshot(reason, shaped)`: publish a caller-provided shaped-devices snapshot via actor.
+- `apply_shaped_devices_snapshot(reason, shaped, provenance)`: publish a caller-provided shaped-devices snapshot via actor.
 - `swap_shaped_devices_snapshot(reason, shaped_arc)`: replace shaped-devices snapshot without actor (intended for tests).
 
 ## `ShapedDevicesCatalog` helpers
@@ -48,16 +48,18 @@ Runtime throughput tracking mutates the in-memory `NetworkJson` via `with_networ
 
 ## Access & update catalog
 
-Current (2026-04) call sites and update patterns:
+Call sites and update patterns:
 
 - Daemon startup: `lqosd` calls `start_daemon_mode()` once at boot and provides `DaemonHooks`.
 - Shaped-device updates:
-  - Directory watcher requests reload when `topology_runtime_status.json`,
-    `ShapedDevices.csv`, or `ShapedDevices.insight.csv` changes.
-  - Reload precedence is: ready runtime shaping inputs, then `topology_import.json`,
-    then `ShapedDevices.csv`.
+  - Directory watcher requests reload when `shaping_inputs.json`,
+    `topology_import.json`, `ShapedDevices.csv`, or `ShapedDevices.insight.csv` changes.
+  - `topology_runtime_status.json` is readiness metadata and does not trigger a shaped-device reload by itself.
+  - In integration-ingress mode, reload precedence is: ready runtime shaping inputs,
+    then `topology_import.json`, then an empty snapshot until the topology runtime publishes.
+  - In manual mode, reloads use `ShapedDevices.csv` or `ShapedDevices.insight.csv`.
   - Node manager admin edits write `ShapedDevices.csv` and immediately publish the new snapshot via
-    `apply_shaped_devices_snapshot()`.
+    `apply_shaped_devices_snapshot()` with external-snapshot provenance.
 - Network topology updates:
   - Directory watcher requests reload when `network.json`, `network.insight.json`, or
     `network.effective.json` changes, including the runtime topology-state copy.

--- a/src/rust/lqos_network_devices/src/actor.rs
+++ b/src/rust/lqos_network_devices/src/actor.rs
@@ -3,12 +3,17 @@ use crate::dynamic::{
 };
 use crate::dynamic_store::{load_dynamic_circuits_from_disk, persist_dynamic_circuits_to_disk};
 use crate::state;
-use crate::{DaemonHooks, ShapedDevicesCatalog, load_network_json, load_shaped_devices};
+use crate::{
+    DaemonHooks, LoadedShapedDevices, LoadedShapedDevicesSource, ShapedDevicesCatalog,
+    ShapedDevicesSnapshotProvenance, load_network_json, load_shaped_devices_with_source,
+};
 use anyhow::{Context, Result, anyhow};
 use crossbeam_channel::{Receiver, Sender};
 use ip_network_table::IpNetworkTable;
 use once_cell::sync::OnceCell;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -69,11 +74,13 @@ pub(crate) fn request_reload_network_json(reason: &str) -> Result<()> {
 pub(crate) fn apply_shaped_devices_snapshot(
     reason: &str,
     shaped: lqos_config::ConfigShapedDevices,
+    provenance: ShapedDevicesSnapshotProvenance,
 ) -> Result<()> {
     let (reply_tx, reply_rx) = oneshot::channel();
     sender()?.send(NetworkDevicesCommand::ApplyShapedDevicesSnapshot {
         reason: reason.to_string(),
         shaped: Box::new(shaped),
+        provenance,
         reply: reply_tx,
     })?;
     reply_rx
@@ -128,6 +135,7 @@ enum NetworkDevicesCommand {
     ApplyShapedDevicesSnapshot {
         reason: String,
         shaped: Box<lqos_config::ConfigShapedDevices>,
+        provenance: ShapedDevicesSnapshotProvenance,
         reply: oneshot::Sender<Result<()>>,
     },
     ReportObservations {
@@ -145,8 +153,11 @@ enum NetworkDevicesCommand {
 
 fn actor_loop(rx: Receiver<NetworkDevicesCommand>, hooks: Option<Arc<dyn DaemonHooks>>) {
     debug!("lqos_network_devices actor starting");
+    let mut active_shaped_key = None;
 
-    if let Err(err) = reload_shaped_devices_inner("startup", hooks.as_deref()) {
+    if let Err(err) =
+        reload_shaped_devices_inner("startup", hooks.as_deref(), &mut active_shaped_key)
+    {
         warn!("Initial shaped-devices load failed: {err}");
     }
     if let Err(err) = reload_network_json_inner("startup", hooks.as_deref()) {
@@ -169,7 +180,11 @@ fn actor_loop(rx: Receiver<NetworkDevicesCommand>, hooks: Option<Arc<dyn DaemonH
 
                 match command {
                     NetworkDevicesCommand::ReloadShapedDevices { reason, reply } => {
-                        let result = reload_shaped_devices_inner(&reason, hooks.as_deref());
+                        let result = reload_shaped_devices_inner(
+                            &reason,
+                            hooks.as_deref(),
+                            &mut active_shaped_key,
+                        );
                         let _ = reply.send(result);
                     }
                     NetworkDevicesCommand::ReloadNetworkJson { reason, reply } => {
@@ -179,15 +194,18 @@ fn actor_loop(rx: Receiver<NetworkDevicesCommand>, hooks: Option<Arc<dyn DaemonH
                     NetworkDevicesCommand::ApplyShapedDevicesSnapshot {
                         reason,
                         shaped,
+                        provenance,
                         reply,
                     } => {
-                        debug!("Publishing shaped-devices snapshot reason={reason}");
-                        state::publish_shaped_devices(*shaped);
-                        prune_dynamic_circuits_superseded_by_shaped_devices_inner(hooks.as_deref());
-                        if let Some(hooks) = &hooks {
-                            hooks.on_shaped_devices_updated();
-                        }
-                        let _ = reply.send(Ok(()));
+                        let key = shaped_devices_key_for_snapshot(provenance, &shaped);
+                        let result = publish_shaped_devices_if_changed(
+                            &reason,
+                            *shaped,
+                            key,
+                            hooks.as_deref(),
+                            &mut active_shaped_key,
+                        );
+                        let _ = reply.send(result);
                     }
                     NetworkDevicesCommand::ReportObservations { observations } => {
                         handle_observations(&observations, hooks.as_deref());
@@ -222,6 +240,119 @@ fn recompute_hashes(device: &mut lqos_config::ShapedDevice) {
     device.circuit_hash = lqos_utils::hash_to_i64(&device.circuit_id);
     device.device_hash = lqos_utils::hash_to_i64(&device.device_id);
     device.parent_hash = lqos_utils::hash_to_i64(&device.parent_node);
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ShapedDevicesProvenanceKey {
+    RuntimeTopology {
+        shaping_generation: String,
+    },
+    TopologyImport {
+        devices_fingerprint: u64,
+    },
+    Csv {
+        devices_fingerprint: u64,
+    },
+    ExternalSnapshot {
+        devices_fingerprint: u64,
+    },
+}
+
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct ShapedDeviceSemanticKey {
+    circuit_id: String,
+    circuit_name: String,
+    device_id: String,
+    device_name: String,
+    parent_node: String,
+    parent_node_id: Option<String>,
+    anchor_node_id: Option<String>,
+    mac: String,
+    ipv4: Vec<(std::net::Ipv4Addr, u32)>,
+    ipv6: Vec<(std::net::Ipv6Addr, u32)>,
+    download_min_mbps_bits: u32,
+    upload_min_mbps_bits: u32,
+    download_max_mbps_bits: u32,
+    upload_max_mbps_bits: u32,
+    comment: String,
+    sqm_override: Option<String>,
+    circuit_hash: i64,
+    device_hash: i64,
+    parent_hash: i64,
+}
+
+fn shaped_device_semantic_key(device: &lqos_config::ShapedDevice) -> ShapedDeviceSemanticKey {
+    let mut ipv4 = device.ipv4.clone();
+    ipv4.sort_unstable();
+    let mut ipv6 = device.ipv6.clone();
+    ipv6.sort_unstable();
+
+    ShapedDeviceSemanticKey {
+        circuit_id: device.circuit_id.clone(),
+        circuit_name: device.circuit_name.clone(),
+        device_id: device.device_id.clone(),
+        device_name: device.device_name.clone(),
+        parent_node: device.parent_node.clone(),
+        parent_node_id: device.parent_node_id.clone(),
+        anchor_node_id: device.anchor_node_id.clone(),
+        mac: device.mac.clone(),
+        ipv4,
+        ipv6,
+        download_min_mbps_bits: device.download_min_mbps.to_bits(),
+        upload_min_mbps_bits: device.upload_min_mbps.to_bits(),
+        download_max_mbps_bits: device.download_max_mbps.to_bits(),
+        upload_max_mbps_bits: device.upload_max_mbps.to_bits(),
+        comment: device.comment.clone(),
+        sqm_override: device.sqm_override.clone(),
+        circuit_hash: device.circuit_hash,
+        device_hash: device.device_hash,
+        parent_hash: device.parent_hash,
+    }
+}
+
+fn shaped_devices_fingerprint(devices: &[lqos_config::ShapedDevice]) -> u64 {
+    let mut sorted = devices
+        .iter()
+        .map(shaped_device_semantic_key)
+        .collect::<Vec<_>>();
+    sorted.sort_unstable();
+    let mut hasher = DefaultHasher::new();
+    for key in sorted {
+        key.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn shaped_devices_key_for_loaded(loaded: &LoadedShapedDevices) -> ShapedDevicesProvenanceKey {
+    match &loaded.source {
+        LoadedShapedDevicesSource::RuntimeTopology {
+            shaping_generation,
+            ..
+        } => ShapedDevicesProvenanceKey::RuntimeTopology {
+            shaping_generation: shaping_generation.clone(),
+        },
+        LoadedShapedDevicesSource::TopologyImport => {
+            ShapedDevicesProvenanceKey::TopologyImport {
+                devices_fingerprint: shaped_devices_fingerprint(&loaded.shaped.devices),
+            }
+        }
+        LoadedShapedDevicesSource::Csv => ShapedDevicesProvenanceKey::Csv {
+            devices_fingerprint: shaped_devices_fingerprint(&loaded.shaped.devices),
+        },
+    }
+}
+
+fn shaped_devices_key_for_snapshot(
+    provenance: ShapedDevicesSnapshotProvenance,
+    shaped: &lqos_config::ConfigShapedDevices,
+) -> ShapedDevicesProvenanceKey {
+    match provenance {
+        ShapedDevicesSnapshotProvenance::ExternalSnapshot => {
+            ShapedDevicesProvenanceKey::ExternalSnapshot {
+                devices_fingerprint: shaped_devices_fingerprint(&shaped.devices),
+            }
+        }
+    }
 }
 
 fn reload_dynamic_circuits_inner(reason: &str) {
@@ -562,17 +693,45 @@ fn shaped_device_from_unknown_ip(
     device
 }
 
-fn reload_shaped_devices_inner(reason: &str, hooks: Option<&dyn DaemonHooks>) -> Result<()> {
+fn publish_shaped_devices_if_changed(
+    reason: &str,
+    shaped: lqos_config::ConfigShapedDevices,
+    key: ShapedDevicesProvenanceKey,
+    hooks: Option<&dyn DaemonHooks>,
+    active_key: &mut Option<ShapedDevicesProvenanceKey>,
+) -> Result<()> {
+    if active_key.as_ref() == Some(&key) {
+        debug!("Skipping unchanged shaped-devices snapshot reason={reason}");
+        return Ok(());
+    }
+
+    debug!("Publishing shaped-devices snapshot reason={reason}");
+    state::publish_shaped_devices(shaped);
+    *active_key = Some(key);
+    prune_dynamic_circuits_superseded_by_shaped_devices_inner(hooks);
+    if let Some(hooks) = hooks {
+        hooks.on_shaped_devices_updated();
+    }
+    Ok(())
+}
+
+fn reload_shaped_devices_inner(
+    reason: &str,
+    hooks: Option<&dyn DaemonHooks>,
+    active_key: &mut Option<ShapedDevicesProvenanceKey>,
+) -> Result<()> {
     for attempt in 1..=RELOAD_ATTEMPTS {
-        match load_shaped_devices() {
-            Ok(shaped) => {
+        match load_shaped_devices_with_source() {
+            Ok(loaded) => {
                 debug!("Loaded shaped devices reason={reason}");
-                state::publish_shaped_devices(shaped);
-                prune_dynamic_circuits_superseded_by_shaped_devices_inner(hooks);
-                if let Some(hooks) = hooks {
-                    hooks.on_shaped_devices_updated();
-                }
-                return Ok(());
+                let key = shaped_devices_key_for_loaded(&loaded);
+                return publish_shaped_devices_if_changed(
+                    reason,
+                    loaded.shaped,
+                    key,
+                    hooks,
+                    active_key,
+                );
             }
             Err(err) if attempt < RELOAD_ATTEMPTS => {
                 warn!(
@@ -681,4 +840,86 @@ fn reload_network_json_inner(reason: &str, hooks: Option<&dyn DaemonHooks>) -> R
         }
     }
     unreachable!("reload loop must return");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shaped_devices_fingerprint;
+
+    fn shaped_device(circuit_id: &str, device_id: &str) -> lqos_config::ShapedDevice {
+        let mut device = lqos_config::ShapedDevice {
+            circuit_id: circuit_id.to_string(),
+            circuit_name: circuit_id.to_string(),
+            device_id: device_id.to_string(),
+            device_name: device_id.to_string(),
+            parent_node: "Tower A".to_string(),
+            ipv4: vec![("192.0.2.1".parse().expect("valid IP"), 32)],
+            download_min_mbps: 10.0,
+            upload_min_mbps: 10.0,
+            download_max_mbps: 100.0,
+            upload_max_mbps: 100.0,
+            ..lqos_config::ShapedDevice::default()
+        };
+        device.circuit_hash = lqos_utils::hash_to_i64(&device.circuit_id);
+        device.device_hash = lqos_utils::hash_to_i64(&device.device_id);
+        device.parent_hash = lqos_utils::hash_to_i64(&device.parent_node);
+        device
+    }
+
+    #[test]
+    fn shaped_devices_fingerprint_ignores_row_order() {
+        let first = vec![
+            shaped_device("circuit-1", "device-1"),
+            shaped_device("circuit-2", "device-2"),
+        ];
+        let second = vec![
+            shaped_device("circuit-2", "device-2"),
+            shaped_device("circuit-1", "device-1"),
+        ];
+
+        assert_eq!(
+            shaped_devices_fingerprint(&first),
+            shaped_devices_fingerprint(&second)
+        );
+    }
+
+    #[test]
+    fn shaped_devices_fingerprint_ignores_address_order() {
+        let first = vec![shaped_device("circuit-1", "device-1")];
+        let mut second = vec![shaped_device("circuit-1", "device-1")];
+        second[0].ipv4 = vec![
+            ("192.0.2.2".parse().expect("valid IPv4"), 32),
+            ("192.0.2.1".parse().expect("valid IPv4"), 32),
+        ];
+        second[0].ipv6 = vec![
+            ("2001:db8::2".parse().expect("valid IPv6"), 128),
+            ("2001:db8::1".parse().expect("valid IPv6"), 128),
+        ];
+        let mut first = first;
+        first[0].ipv4 = vec![
+            ("192.0.2.1".parse().expect("valid IPv4"), 32),
+            ("192.0.2.2".parse().expect("valid IPv4"), 32),
+        ];
+        first[0].ipv6 = vec![
+            ("2001:db8::1".parse().expect("valid IPv6"), 128),
+            ("2001:db8::2".parse().expect("valid IPv6"), 128),
+        ];
+
+        assert_eq!(
+            shaped_devices_fingerprint(&first),
+            shaped_devices_fingerprint(&second)
+        );
+    }
+
+    #[test]
+    fn shaped_devices_fingerprint_detects_payload_changes() {
+        let first = vec![shaped_device("circuit-1", "device-1")];
+        let mut second = vec![shaped_device("circuit-1", "device-1")];
+        second[0].download_max_mbps = 200.0;
+
+        assert_ne!(
+            shaped_devices_fingerprint(&first),
+            shaped_devices_fingerprint(&second)
+        );
+    }
 }

--- a/src/rust/lqos_network_devices/src/directory_watcher.rs
+++ b/src/rust/lqos_network_devices/src/directory_watcher.rs
@@ -25,6 +25,11 @@ pub(crate) fn start_network_devices_directory_watch() -> Result<()> {
         "LibreQoS topology state directory",
         config.resolved_state_directory().join("topology"),
     )?;
+    spawn_directory_watch_thread(
+        "Network Devices Shaping Dir Watcher",
+        "LibreQoS shaping state directory",
+        config.resolved_state_directory().join("shaping"),
+    )?;
     Ok(())
 }
 
@@ -88,7 +93,7 @@ fn classify_changed_path(path: &Path) -> Option<DirectoryReloadEvent> {
         "ShapedDevices.csv"
         | "ShapedDevices.insight.csv"
         | "topology_import.json"
-        | "topology_runtime_status.json" => Some(DirectoryReloadEvent::ShapedDevices),
+        | "shaping_inputs.json" => Some(DirectoryReloadEvent::ShapedDevices),
         "network.effective.json" | "network.insight.json" | "network.json" => {
             Some(DirectoryReloadEvent::NetworkJson)
         }
@@ -118,8 +123,14 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn topology_runtime_status_triggers_shaped_device_reload() {
+    fn topology_runtime_status_does_not_trigger_shaped_device_reload() {
         let event = classify_changed_path(&PathBuf::from("/tmp/topology_runtime_status.json"));
+        assert_eq!(event, None);
+    }
+
+    #[test]
+    fn shaping_inputs_triggers_shaped_device_reload() {
+        let event = classify_changed_path(&PathBuf::from("/tmp/shaping_inputs.json"));
         assert_eq!(event, Some(DirectoryReloadEvent::ShapedDevices));
     }
 
@@ -134,7 +145,7 @@ mod tests {
         let events = classify_changed_paths(&[
             PathBuf::from("/tmp/network.json"),
             PathBuf::from("/tmp/network.effective.json"),
-            PathBuf::from("/tmp/topology_runtime_status.json"),
+            PathBuf::from("/tmp/shaping_inputs.json"),
         ]);
         assert_eq!(
             events,

--- a/src/rust/lqos_network_devices/src/lib.rs
+++ b/src/rust/lqos_network_devices/src/lib.rs
@@ -20,7 +20,9 @@ mod topology;
 mod tests;
 
 use anyhow::{Context, Result};
-use lqos_config::{Config, ConfigShapedDevices, NetworkJson, TopologyShapingInputsFile};
+use lqos_config::{
+    Config, ConfigShapedDevices, NetworkJson, TopologyShapingInputsFile,
+};
 use std::sync::Arc;
 use tracing::debug;
 
@@ -29,6 +31,27 @@ pub use combined_catalog::NetworkDevicesCatalog;
 pub use dynamic::{CircuitObservation, DynamicCircuit};
 pub use hash_cache::ShapedDeviceHashCache;
 pub use topology::{ResolvedParentNode, resolve_parent_node, resolve_parent_node_reference};
+
+/// Provenance for caller-provided shaped-device snapshots.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShapedDevicesSnapshotProvenance {
+    /// Snapshot came from an external caller that already constructed a complete payload.
+    ExternalSnapshot,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum LoadedShapedDevicesSource {
+    RuntimeTopology {
+        shaping_generation: String,
+    },
+    TopologyImport,
+    Csv,
+}
+
+pub(crate) struct LoadedShapedDevices {
+    pub(crate) shaped: ConfigShapedDevices,
+    pub(crate) source: LoadedShapedDevicesSource,
+}
 
 /// Hooks that `lqosd` can provide to run side effects after updates.
 pub trait DaemonHooks: Send + Sync + 'static {
@@ -67,13 +90,18 @@ pub fn load_runtime_shaping_inputs_for_config(
     runtime_inputs::load_ready_runtime_shaping_inputs(config)
 }
 
-fn load_shaped_devices_for_config(config: &lqos_config::Config) -> Result<ConfigShapedDevices> {
+fn load_shaped_devices_for_config(config: &lqos_config::Config) -> Result<LoadedShapedDevices> {
     if lqos_config::integration_ingress_enabled(config) {
         if let Some(shaping_inputs) = load_runtime_shaping_inputs_for_config(config)? {
             let shaped_devices =
                 runtime_inputs::shaped_devices_from_runtime_inputs(&shaping_inputs);
             if !shaped_devices.devices.is_empty() {
-                return Ok(shaped_devices);
+                return Ok(LoadedShapedDevices {
+                    shaped: shaped_devices,
+                    source: LoadedShapedDevicesSource::RuntimeTopology {
+                        shaping_generation: shaping_inputs.shaping_generation,
+                    },
+                });
             }
             debug!(
                 "Active runtime shaping inputs contained 0 shaped devices; checking other integration sources"
@@ -83,13 +111,19 @@ fn load_shaped_devices_for_config(config: &lqos_config::Config) -> Result<Config
             debug!(
                 "topology_import.json is missing or contains 0 shaped devices; keeping integration mode empty until topology is published"
             );
-            return Ok(ConfigShapedDevices::default());
+            return Ok(LoadedShapedDevices {
+                shaped: ConfigShapedDevices::default(),
+                source: LoadedShapedDevicesSource::TopologyImport,
+            });
         }
         match lqos_topology_compile::TopologyImportFile::load(config) {
             Ok(Some(topology_import)) => {
                 let shaped_devices = topology_import.into_imported_bundle().shaped_devices;
                 if !shaped_devices.devices.is_empty() {
-                    return Ok(shaped_devices);
+                    return Ok(LoadedShapedDevices {
+                        shaped: shaped_devices,
+                        source: LoadedShapedDevicesSource::TopologyImport,
+                    });
                 }
                 debug!(
                     "topology_import.json advertised shaped devices but loaded empty; keeping integration mode empty until topology is published"
@@ -106,16 +140,28 @@ fn load_shaped_devices_for_config(config: &lqos_config::Config) -> Result<Config
                 );
             }
         }
-        return Ok(ConfigShapedDevices::default());
+        return Ok(LoadedShapedDevices {
+            shaped: ConfigShapedDevices::default(),
+            source: LoadedShapedDevicesSource::TopologyImport,
+        });
     }
-    ConfigShapedDevices::load_for_config(config).context("Unable to load ShapedDevices.csv")
+    Ok(LoadedShapedDevices {
+        shaped: ConfigShapedDevices::load_for_config(config)
+            .context("Unable to load ShapedDevices.csv")?,
+        source: LoadedShapedDevicesSource::Csv,
+    })
 }
 
 /// Loads shaped-device configuration from disk.
 ///
-/// When an integration-backed topology ingress is enabled, this loads shaped devices from the
-/// active `topology_import.json` bundle. Otherwise, it loads `ShapedDevices.csv`.
+/// When integration-backed topology ingress is enabled, this prefers ready runtime shaping inputs,
+/// then `topology_import.json`, then an empty snapshot until the topology runtime publishes.
+/// Manual mode loads `ShapedDevices.csv`.
 pub fn load_shaped_devices() -> Result<ConfigShapedDevices> {
+    Ok(load_shaped_devices_with_source()?.shaped)
+}
+
+pub(crate) fn load_shaped_devices_with_source() -> Result<LoadedShapedDevices> {
     let config = lqos_config::load_config().context("Unable to load /etc/lqos.conf")?;
     load_shaped_devices_for_config(config.as_ref())
 }
@@ -183,8 +229,12 @@ pub fn request_reload_network_json(reason: &str) -> Result<()> {
 }
 
 /// Publishes a caller-provided shaped-devices snapshot through the runtime actor.
-pub fn apply_shaped_devices_snapshot(reason: &str, shaped: ConfigShapedDevices) -> Result<()> {
-    actor::apply_shaped_devices_snapshot(reason, shaped)
+pub fn apply_shaped_devices_snapshot(
+    reason: &str,
+    shaped: ConfigShapedDevices,
+    provenance: ShapedDevicesSnapshotProvenance,
+) -> Result<()> {
+    actor::apply_shaped_devices_snapshot(reason, shaped, provenance)
 }
 
 /// Reports kernel observations that may indicate dynamic circuit activity.

--- a/src/rust/lqos_network_devices/src/tests.rs
+++ b/src/rust/lqos_network_devices/src/tests.rs
@@ -431,8 +431,8 @@ fn load_shaped_devices_uses_topology_import_when_runtime_inputs_are_empty() {
 
     let loaded = load_shaped_devices_for_config(&config)
         .expect("preferred shaped-device source should load");
-    assert_eq!(loaded.devices.len(), 1);
-    assert_eq!(loaded.devices[0].circuit_id, "import-circuit");
+    assert_eq!(loaded.shaped.devices.len(), 1);
+    assert_eq!(loaded.shaped.devices[0].circuit_id, "import-circuit");
 }
 
 #[test]
@@ -493,8 +493,8 @@ fn load_shaped_devices_uses_topology_import_when_runtime_is_not_ready() {
 
     let loaded =
         load_shaped_devices_for_config(&config).expect("topology import fallback should load");
-    assert_eq!(loaded.devices.len(), 1);
-    assert_eq!(loaded.devices[0].circuit_id, "import-circuit");
+    assert_eq!(loaded.shaped.devices.len(), 1);
+    assert_eq!(loaded.shaped.devices[0].circuit_id, "import-circuit");
 }
 
 #[test]
@@ -534,7 +534,7 @@ fn load_shaped_devices_stays_empty_when_topology_import_is_empty() {
 
     let loaded =
         load_shaped_devices_for_config(&config).expect("integration mode should stay empty");
-    assert!(loaded.devices.is_empty());
+    assert!(loaded.shaped.devices.is_empty());
 }
 
 #[test]
@@ -582,8 +582,8 @@ fn load_shaped_devices_ignores_stale_runtime_inputs_in_manual_mode() {
 
     let loaded =
         load_shaped_devices_for_config(&config).expect("manual mode should use shaped devices csv");
-    assert_eq!(loaded.devices.len(), 1);
-    assert_eq!(loaded.devices[0].circuit_id, "csv-circuit");
+    assert_eq!(loaded.shaped.devices.len(), 1);
+    assert_eq!(loaded.shaped.devices[0].circuit_id, "csv-circuit");
 }
 
 #[test]
@@ -610,5 +610,5 @@ fn load_shaped_devices_stays_empty_when_runtime_status_is_malformed() {
 
     let loaded =
         load_shaped_devices_for_config(&config).expect("malformed status should stay empty");
-    assert!(loaded.devices.is_empty());
+    assert!(loaded.shaped.devices.is_empty());
 }

--- a/src/rust/lqos_overrides/src/file_lock.rs
+++ b/src/rust/lqos_overrides/src/file_lock.rs
@@ -64,7 +64,7 @@ impl FileLock {
         }
         let unix_path = CString::new(LOCK_PATH)?;
         unsafe {
-            nix::libc::chmod(unix_path.as_ptr(), mode_t::from_le(666));
+            nix::libc::chmod(unix_path.as_ptr(), mode_t::from_le(0o666));
         }
         Ok(())
     }
@@ -77,7 +77,7 @@ impl FileLock {
             std::fs::create_dir(dir_path)?;
             let unix_path = CString::new(LOCK_DIR_PERMS)?;
             unsafe {
-                nix::libc::chmod(unix_path.as_ptr(), 777);
+                nix::libc::chmod(unix_path.as_ptr(), 0o777);
             }
             Ok(())
         }

--- a/src/rust/lqos_overrides/src/overrides_file.rs
+++ b/src/rust/lqos_overrides/src/overrides_file.rs
@@ -1130,15 +1130,15 @@ impl OverrideStore {
     ///
     /// This function reads override files from the config's LibreQoS directory without
     /// reloading `/etc/lqos.conf`.
+    ///
+    /// Side effects: reads override files from disk and may create the operator
+    /// overrides file if it does not exist.
     pub fn load_effective_for_config(
         config: &lqos_config::Config,
         apply_stormguard: bool,
         apply_treeguard: bool,
     ) -> Result<OverrideFile> {
-        let lock = FileLock::new()?;
-        let merged = Self::load_effective_for_config_inner(config, apply_stormguard, apply_treeguard)?;
-        drop(lock);
-        Ok(merged)
+        Self::load_effective_for_config_inner(config, apply_stormguard, apply_treeguard)
     }
 
     fn load_effective_for_config_inner(

--- a/src/rust/lqos_topology/src/lib.rs
+++ b/src/rust/lqos_topology/src/lib.rs
@@ -1696,6 +1696,13 @@ pub fn publish_topology_runtime_status(
         ready,
         error,
     );
+    if TopologyRuntimeStatusFile::load(config)
+        .ok()
+        .as_ref()
+        .is_some_and(|current| current.semantic_equals_for_publish(&status))
+    {
+        return Ok(());
+    }
     status.save(config).with_context(|| {
         format!(
             "Unable to publish topology runtime status at {:?}",

--- a/src/rust/lqos_topology/src/runtime.rs
+++ b/src/rust/lqos_topology/src/runtime.rs
@@ -2,12 +2,14 @@ use anyhow::{Context, Result};
 use lqos_bus::{BusRequest, BusResponse, bus_request};
 use lqos_config::{
     TopologyAttachmentEndpointStatus, TopologyAttachmentHealthEntry,
-    TopologyAttachmentHealthStateFile, TopologyAttachmentHealthStatus,
+    TopologyAttachmentHealthStateFile, TopologyAttachmentHealthStatus, TopologyCanonicalStateFile,
     compute_topology_source_generation, load_config,
 };
 use lqos_overrides::TopologyOverridesFile;
 use lqos_probe::{ProbeClass, ProbeRequest};
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::net::IpAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
@@ -313,6 +315,61 @@ fn refresh_health_state(
     Ok(true)
 }
 
+fn hash_health_status(status: TopologyAttachmentHealthStatus, hasher: &mut impl Hasher) {
+    match status {
+        TopologyAttachmentHealthStatus::Healthy => 0_u8.hash(hasher),
+        TopologyAttachmentHealthStatus::Suppressed => 1_u8.hash(hasher),
+        TopologyAttachmentHealthStatus::ProbeUnavailable => 2_u8.hash(hasher),
+        TopologyAttachmentHealthStatus::Disabled => 3_u8.hash(hasher),
+    }
+}
+
+fn hash_health_effective_entry(entry: &TopologyAttachmentHealthEntry, hasher: &mut impl Hasher) {
+    entry.attachment_pair_id.hash(hasher);
+    entry.attachment_id.hash(hasher);
+    entry.child_node_id.hash(hasher);
+    entry.parent_node_id.hash(hasher);
+    entry.local_probe_ip.hash(hasher);
+    entry.remote_probe_ip.hash(hasher);
+    hash_health_status(entry.status, hasher);
+    entry.probeable.hash(hasher);
+    entry.enabled.hash(hasher);
+    entry.suppressed_until_unix.hash(hasher);
+}
+
+fn health_effective_signature(health_state: &TopologyAttachmentHealthStateFile) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for entry in &health_state.attachments {
+        hash_health_effective_entry(entry, &mut hasher);
+    }
+    hasher.finish()
+}
+
+#[derive(Clone, Debug, Default)]
+struct RuntimeBuildGate {
+    last_source_generation: Option<String>,
+    last_overrides_generation: Option<u64>,
+    last_health_effective_signature: Option<u64>,
+    cached_probe_specs: Vec<AttachmentProbeSpec>,
+    publish_completed: bool,
+    next_error_retry_after_unix: Option<u64>,
+}
+
+fn topology_overrides_generation(config: &lqos_config::Config) -> u64 {
+    let path = TopologyOverridesFile::path_for_config(config);
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    if let Ok(contents) = std::fs::read(&path) {
+        match serde_json::from_slice::<TopologyOverridesFile>(&contents)
+            .and_then(|overrides| serde_json::to_vec(&overrides))
+        {
+            Ok(canonical) => canonical.hash(&mut hasher),
+            Err(_) => contents.hash(&mut hasher),
+        }
+    }
+    hasher.finish()
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 struct RoundHints {
     probes_enabled: bool,
@@ -321,28 +378,61 @@ struct RoundHints {
 async fn run_round(
     health_state: &mut TopologyAttachmentHealthStateFile,
     last_effective: &mut HashMap<String, Option<String>>,
+    gate: &mut RuntimeBuildGate,
 ) -> Result<RoundHints> {
     let config = load_config().context("Unable to load config for topology runtime")?;
     let source_generation = compute_topology_source_generation(config.as_ref())
         .context("Unable to compute topology source generation")?;
-    let canonical = load_canonical_topology_state(config.as_ref());
-    let overrides =
-        TopologyOverridesFile::load().context("Unable to load topology overrides file")?;
-    let prepared = prepare_runtime_topology_editor_state_from_canonical(&canonical, &overrides);
-    let specs = probe_specs_from_state(&prepared, &overrides);
+    let overrides_generation = topology_overrides_generation(config.as_ref());
+    let source_changed = gate.last_source_generation.as_deref() != Some(source_generation.as_str());
+    let overrides_changed = gate.last_overrides_generation != Some(overrides_generation);
+    let mut loaded_inputs: Option<(TopologyCanonicalStateFile, TopologyOverridesFile)> = None;
+    if source_changed || overrides_changed || gate.cached_probe_specs.is_empty() {
+        let canonical = load_canonical_topology_state(config.as_ref());
+        let overrides =
+            TopologyOverridesFile::load().context("Unable to load topology overrides file")?;
+        let prepared = prepare_runtime_topology_editor_state_from_canonical(&canonical, &overrides);
+        gate.cached_probe_specs = probe_specs_from_state(&prepared, &overrides);
+        loaded_inputs = Some((canonical, overrides));
+    }
+    let specs = &gate.cached_probe_specs;
     let probes_enabled = specs.iter().any(|spec| spec.enabled);
     if probes_enabled {
-        match probe_specs(&specs, Duration::from_millis(750)).await {
+        match probe_specs(specs, Duration::from_millis(750)).await {
             Ok(probe_results) => {
-                refresh_health_state(config.as_ref(), health_state, &specs, &probe_results)?;
+                refresh_health_state(config.as_ref(), health_state, specs, &probe_results)?;
             }
             Err(err) => {
                 warn!("Topology probe round could not query shared probe manager: {err:#}");
             }
         }
     } else {
-        refresh_health_state(config.as_ref(), health_state, &specs, &HashMap::new())?;
+        refresh_health_state(config.as_ref(), health_state, specs, &HashMap::new())?;
     }
+
+    let next_signature = health_effective_signature(health_state);
+    let retry_due = gate
+        .next_error_retry_after_unix
+        .is_some_and(|deadline| now_unix().is_some_and(|now| now >= deadline));
+    let retry_pending = gate.next_error_retry_after_unix.is_some() && !retry_due;
+    let source_or_health_changed = source_changed
+        || overrides_changed
+        || gate.last_health_effective_signature.as_ref() != Some(&next_signature);
+    let should_publish =
+        source_or_health_changed || (!retry_pending && (!gate.publish_completed || retry_due));
+    if !should_publish {
+        return Ok(RoundHints { probes_enabled });
+    }
+
+    let (canonical, overrides) = match loaded_inputs {
+        Some(inputs) => inputs,
+        None => {
+            let canonical = load_canonical_topology_state(config.as_ref());
+            let overrides =
+                TopologyOverridesFile::load().context("Unable to load topology overrides file")?;
+            (canonical, overrides)
+        }
+    };
 
     let artifacts = build_effective_topology_artifacts_from_canonical_with_runtime_queue_context(
         config.as_ref(),
@@ -368,8 +458,21 @@ async fn run_round(
                 "Unable to publish failed topology runtime status after publish error: {status_err:#}"
             );
         }
+        let health = &config.integration_common.topology_attachment_health;
+        let retry_delay = health
+            .refresh_debounce_seconds
+            .max(health.probe_interval_seconds.max(1));
+        gate.last_source_generation = Some(source_generation.clone());
+        gate.last_overrides_generation = Some(overrides_generation);
+        gate.last_health_effective_signature = Some(next_signature);
+        gate.next_error_retry_after_unix = now_unix().map(|now| now.saturating_add(retry_delay));
         return Err(err);
     }
+    gate.last_source_generation = Some(source_generation.clone());
+    gate.last_overrides_generation = Some(overrides_generation);
+    gate.last_health_effective_signature = Some(next_signature);
+    gate.publish_completed = true;
+    gate.next_error_retry_after_unix = None;
 
     for node in &artifacts.effective.nodes {
         let next = node.effective_attachment_id.clone();
@@ -394,9 +497,12 @@ async fn run_round(
 pub async fn start_topology() {
     let mut health_state = load_starting_health();
     let mut last_effective = HashMap::<String, Option<String>>::new();
+    let mut build_gate = RuntimeBuildGate::default();
 
     loop {
-        let round_hints = match run_round(&mut health_state, &mut last_effective).await {
+        let round_hints = match run_round(&mut health_state, &mut last_effective, &mut build_gate)
+            .await
+        {
             Ok(hints) => hints,
             Err(err) => {
                 if let Ok(config) = load_config()
@@ -432,5 +538,104 @@ pub async fn start_topology() {
             })
             .unwrap_or(1);
         tokio::time::sleep(Duration::from_secs(sleep_seconds)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TopologyAttachmentHealthEntry, health_effective_signature, topology_overrides_generation,
+    };
+    use lqos_config::{Config, TopologyAttachmentHealthStateFile, TopologyAttachmentHealthStatus};
+    use lqos_overrides::TopologyOverridesFile;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{}-{unique}", std::process::id()))
+    }
+
+    fn health_entry() -> TopologyAttachmentHealthEntry {
+        TopologyAttachmentHealthEntry {
+            attachment_pair_id: "pair-1".to_string(),
+            attachment_id: Some("attachment-1".to_string()),
+            child_node_id: Some("child-1".to_string()),
+            parent_node_id: Some("parent-1".to_string()),
+            local_probe_ip: Some("192.0.2.1".to_string()),
+            remote_probe_ip: Some("192.0.2.2".to_string()),
+            status: TopologyAttachmentHealthStatus::Healthy,
+            probeable: true,
+            enabled: true,
+            consecutive_misses: 1,
+            consecutive_successes: 2,
+            last_success_unix: Some(10),
+            endpoint_status: vec![],
+            ..TopologyAttachmentHealthEntry::default()
+        }
+    }
+
+    #[test]
+    fn health_effective_signature_ignores_probe_counters_and_timestamps() {
+        let first = TopologyAttachmentHealthStateFile {
+            generated_unix: Some(1),
+            attachments: vec![health_entry()],
+            ..TopologyAttachmentHealthStateFile::default()
+        };
+        let mut second_entry = health_entry();
+        second_entry.consecutive_misses = 4;
+        second_entry.consecutive_successes = 5;
+        second_entry.last_success_unix = Some(20);
+        second_entry.last_failure_unix = Some(21);
+        let second = TopologyAttachmentHealthStateFile {
+            generated_unix: Some(2),
+            attachments: vec![second_entry],
+            ..TopologyAttachmentHealthStateFile::default()
+        };
+
+        assert_eq!(
+            health_effective_signature(&first),
+            health_effective_signature(&second)
+        );
+    }
+
+    #[test]
+    fn health_effective_signature_tracks_suppression_status() {
+        let first = TopologyAttachmentHealthStateFile {
+            attachments: vec![health_entry()],
+            ..TopologyAttachmentHealthStateFile::default()
+        };
+        let mut suppressed = health_entry();
+        suppressed.status = TopologyAttachmentHealthStatus::Suppressed;
+        suppressed.suppressed_until_unix = Some(123);
+        let second = TopologyAttachmentHealthStateFile {
+            attachments: vec![suppressed],
+            ..TopologyAttachmentHealthStateFile::default()
+        };
+
+        assert_ne!(
+            health_effective_signature(&first),
+            health_effective_signature(&second)
+        );
+    }
+
+    #[test]
+    fn topology_overrides_generation_tracks_manual_override_file_changes() {
+        let lqos_directory = unique_temp_dir("lqos-topology-runtime-overrides");
+        fs::create_dir_all(&lqos_directory).expect("temp lqos directory should exist");
+        let config = Config {
+            lqos_directory: lqos_directory.to_string_lossy().to_string(),
+            ..Config::default()
+        };
+        let path = TopologyOverridesFile::path_for_config(&config);
+
+        let before = topology_overrides_generation(&config);
+        fs::write(&path, "{\"schemaVersion\":1}\n").expect("override file should write");
+        let after = topology_overrides_generation(&config);
+
+        assert_ne!(before, after);
     }
 }

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -383,7 +383,7 @@ fn main() -> Result<()> {
                                 let _ = throughput_tracker::flow_data::setup_flow_analysis();
                                 start_heimdall()?;
                                 spawn_queue_structure_monitor()?;
-                                shaped_devices_tracker::shaping_inputs_watcher()?;
+                                shaped_devices_tracker::topology_runtime_status_watcher()?;
                                 throughput_tracker::spawn_throughput_monitor(
                                     flow_tx,
                                     system_usage_tx.clone(),

--- a/src/rust/lqosd/src/node_manager/local_api/config.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/config.rs
@@ -785,6 +785,7 @@ fn persist_shaped_devices(mut devices: Vec<ShapedDevice>) -> Result<(), String> 
     lqos_network_devices::apply_shaped_devices_snapshot(
         "node_manager:persist_shaped_devices",
         copied,
+        lqos_network_devices::ShapedDevicesSnapshotProvenance::ExternalSnapshot,
     )
     .map_err(|e| format!("Unable to publish ShapedDevices.csv snapshot: {e}"))?;
 

--- a/src/rust/lqosd/src/shaped_devices_tracker/mod.rs
+++ b/src/rust/lqosd/src/shaped_devices_tracker/mod.rs
@@ -5,11 +5,13 @@ use arc_swap::ArcSwap;
 use fxhash::{FxHashMap, FxHashSet};
 use lqos_bus::{BusResponse, Circuit};
 use lqos_config::{
-    NetworkJsonNode, NetworkJsonTransport, TopologyShapingInputsFile, load_config,
+    NetworkJsonNode, NetworkJsonTransport, TopologyRuntimeShapingPayloadIdentity,
+    TopologyRuntimeStatusFile, TopologyShapingInputsFile,
+    load_active_runtime_shaping_inputs_from_status, load_config,
     topology_runtime_status_path,
 };
 #[cfg(test)]
-use lqos_config::{TopologyRuntimeStatusFile, topology_shaping_inputs_path};
+use lqos_config::load_active_runtime_shaping_inputs;
 use lqos_queue_tracker::EFFECTIVE_NODE_RATES;
 use lqos_utils::file_watcher::FileWatcher;
 use lqos_utils::hash_to_i64;
@@ -18,8 +20,6 @@ use lqos_utils::units::{DownUpOrder, down_up_retransmit_sample};
 use lqos_utils::unix_time::time_since_boot;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
-#[cfg(test)]
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
@@ -42,6 +42,8 @@ pub static CIRCUIT_LIVE_LAST_REFRESH_SECS: AtomicU64 = AtomicU64::new(0);
 pub static CIRCUIT_LIVE_REFRESH_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 pub static EFFECTIVE_CIRCUIT_PARENTS: Lazy<ArcSwap<FxHashMap<String, RuntimeCircuitParent>>> =
     Lazy::new(|| ArcSwap::new(Arc::new(FxHashMap::default())));
+static LAST_TOPOLOGY_STATUS_IDENTITY: Lazy<Mutex<Option<TopologyRuntimeShapingPayloadIdentity>>> =
+    Lazy::new(|| Mutex::new(None));
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RuntimeCircuitParent {
@@ -104,38 +106,16 @@ fn publish_shaping_inputs(shaping_inputs: TopologyShapingInputsFile) {
     invalidate_executive_cache_snapshot();
 }
 
-#[cfg(test)]
-fn active_runtime_shaping_inputs_path(config: &lqos_config::Config) -> Result<Option<PathBuf>> {
-    let status = TopologyRuntimeStatusFile::load(config)?;
-    if !status.ready {
-        return Ok(None);
-    }
-    let path = status.shaping_inputs_path.trim();
-    if path.is_empty() {
-        return Ok(None);
-    }
-    Ok(Some(PathBuf::from(path)))
+fn topology_status_identity(status: &TopologyRuntimeStatusFile) -> TopologyRuntimeShapingPayloadIdentity {
+    status.shaping_payload_identity()
 }
 
-#[cfg(test)]
-fn load_active_runtime_shaping_inputs(
-    config: &lqos_config::Config,
-) -> Result<Option<TopologyShapingInputsFile>> {
-    if let Some(active_path) = active_runtime_shaping_inputs_path(config)?
-        && active_path.exists()
-    {
-        let raw = std::fs::read_to_string(&active_path)?;
-        let shaping_inputs = serde_json::from_str(&raw)?;
-        return Ok(Some(shaping_inputs));
-    }
+fn topology_status_identity_changed(identity: &TopologyRuntimeShapingPayloadIdentity) -> bool {
+    LAST_TOPOLOGY_STATUS_IDENTITY.lock().as_ref() != Some(identity)
+}
 
-    let fallback_path = topology_shaping_inputs_path(config);
-    if !fallback_path.exists() {
-        return Ok(None);
-    }
-    let raw = std::fs::read_to_string(&fallback_path)?;
-    let shaping_inputs = serde_json::from_str(&raw)?;
-    Ok(Some(shaping_inputs))
+fn remember_topology_status_identity(identity: TopologyRuntimeShapingPayloadIdentity) {
+    *LAST_TOPOLOGY_STATUS_IDENTITY.lock() = Some(identity);
 }
 
 #[cfg(test)]
@@ -257,21 +237,8 @@ fn integration_ingress_enabled(config: &lqos_config::Config) -> bool {
 fn load_ready_runtime_shaping_inputs(
     config: &lqos_config::Config,
 ) -> Result<Option<TopologyShapingInputsFile>> {
-    let Some(active_path) = active_runtime_shaping_inputs_path(config)? else {
-        return Ok(None);
-    };
-    if !active_path.exists() {
-        return Ok(None);
-    }
-    let raw = std::fs::read_to_string(&active_path)
-        .with_context(|| format!("Unable to read shaping inputs at {}", active_path.display()))?;
-    let shaping_inputs = serde_json::from_str(&raw).with_context(|| {
-        format!(
-            "Unable to decode shaping inputs JSON at {}",
-            active_path.display()
-        )
-    })?;
-    Ok(Some(shaping_inputs))
+    load_active_runtime_shaping_inputs(config)
+        .context("Unable to load active runtime shaping inputs")
 }
 
 #[cfg(test)]
@@ -311,16 +278,28 @@ fn load_shaped_devices_from_preferred_source(
         ConfigShapedDevices::load_for_config(config).context("Unable to load ShapedDevices.csv")?;
     Ok((shaped_devices, ShapedDevicesLoadSource::ShapedDevicesCsv))
 }
-fn load_shaping_inputs() {
+fn load_topology_runtime_status_payload() {
     let Ok(config) = load_config() else {
-        warn!("Unable to load LibreQoS config while loading shaping_inputs.json");
-        publish_shaping_inputs(TopologyShapingInputsFile::default());
+        warn!("Unable to load LibreQoS config while loading topology runtime status");
         return;
     };
-    match lqos_network_devices::load_runtime_shaping_inputs_for_config(config.as_ref()) {
+    let status = match TopologyRuntimeStatusFile::load(config.as_ref()) {
+        Ok(status) => status,
+        Err(err) => {
+            warn!("Unable to load topology_runtime_status.json: {err}; keeping last-known-good effective parent cache");
+            return;
+        }
+    };
+    let identity = topology_status_identity(&status);
+    if !topology_status_identity_changed(&identity) {
+        debug!("Topology runtime status changed without shaping payload identity change");
+        return;
+    }
+    match load_active_runtime_shaping_inputs_from_status(config.as_ref(), &status) {
         Ok(Some(shaping_inputs)) => {
             debug!("Loaded shaping inputs from active runtime status");
             publish_shaping_inputs(shaping_inputs);
+            remember_topology_status_identity(identity);
         }
         Ok(None) => {
             if lqos_config::integration_ingress_enabled(config.as_ref()) {
@@ -329,9 +308,11 @@ fn load_shaping_inputs() {
                 debug!(
                     "No active runtime shaping inputs published; keeping last-known-good effective parent cache"
                 );
+                remember_topology_status_identity(identity);
             } else {
                 debug!("Integration ingress disabled; clearing effective parent cache");
                 publish_shaping_inputs(TopologyShapingInputsFile::default());
+                remember_topology_status_identity(identity);
             }
         }
         Err(err) => {
@@ -342,31 +323,31 @@ fn load_shaping_inputs() {
     }
 }
 
-pub fn shaping_inputs_watcher() -> Result<()> {
+pub fn topology_runtime_status_watcher() -> Result<()> {
     std::thread::Builder::new()
-        .name("Shaping Inputs Watcher".to_string())
+        .name("Topology Runtime Status Watcher".to_string())
         .spawn(|| {
-            debug!("Watching for shaping_inputs.json changes");
-            if let Err(e) = watch_for_shaping_inputs_changing() {
-                error!("Error watching for shaping_inputs.json changes: {:?}", e);
+            debug!("Watching for topology_runtime_status.json changes");
+            if let Err(e) = watch_for_topology_runtime_status_changing() {
+                error!("Error watching topology_runtime_status.json: {:?}", e);
             }
         })?;
     Ok(())
 }
 
-fn watch_for_shaping_inputs_changing() -> Result<()> {
+fn watch_for_topology_runtime_status_changing() -> Result<()> {
     let Ok(config) = load_config() else {
-        error!("Unable to load LibreQoS config to watch shaping_inputs.json");
+        error!("Unable to load LibreQoS config to watch topology_runtime_status.json");
         return Err(anyhow::Error::msg(
-            "Unable to load LibreQoS config for shaping_inputs.json",
+            "Unable to load LibreQoS config for topology_runtime_status.json",
         ));
     };
     let watch_path = topology_runtime_status_path(config.as_ref());
 
     let mut watcher = FileWatcher::new("topology_runtime_status.json", watch_path);
-    watcher.set_file_exists_callback(load_shaping_inputs);
-    watcher.set_file_created_callback(load_shaping_inputs);
-    watcher.set_file_changed_callback(load_shaping_inputs);
+    watcher.set_file_exists_callback(load_topology_runtime_status_payload);
+    watcher.set_file_created_callback(load_topology_runtime_status_payload);
+    watcher.set_file_changed_callback(load_topology_runtime_status_payload);
     loop {
         let result = watcher.watch();
         info!("topology_runtime_status.json watcher returned: {result:?}");


### PR DESCRIPTION
This branch reduces repeated topology reload work when runtime probe output does not change the effective topology, and fixes the Rust CI failure seen in lqos_topology tests.

Changes:

  - Treat topology_runtime_status.json as readiness metadata, not a shaped-device reload trigger.
  - Keep topology runtime probe specs cached until source topology inputs or override file contents change.
  - Avoid rebuilding/publishing runtime artifacts when only probe counters or generated_unix changed.
  - Skip shaped-device publishes when the effective payload fingerprint is unchanged, including row-order and per-device address-order differences.
  - Preserve lqosd’s last known-good effective parent cache across transient runtime read failures.
  - Fix OverrideStore::load_effective_for_config so tests and config-snapshot reads do not require write access to /run/lqos/lqos_overrides.lock.
  - Correct override lock chmod modes from decimal 666/777 to octal 0o666/0o777.
