### PR TITLE
Fix NetFlow v9 IPv4 byte order

### DIFF
--- a/src/rust/lqosd/src/throughput_tracker/flow_data/netflow9/protocol/field_encoder.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/netflow9/protocol/field_encoder.rs
@@ -52,12 +52,10 @@ fn encode_ipv4(direction: usize, key: &FlowbeeKey, target: &mut Vec<u8>) -> anyh
     let local = key.local_ip.as_ip();
     let remote = key.remote_ip.as_ip();
     if let (IpAddr::V4(local), IpAddr::V4(remote)) = (local, remote) {
-        let src_ip = u32::from_ne_bytes(local.octets());
-        let dst_ip = u32::from_ne_bytes(remote.octets());
         if direction == 0 {
-            target.extend_from_slice(&src_ip.to_be_bytes());
+            target.extend_from_slice(&local.octets());
         } else {
-            target.extend_from_slice(&dst_ip.to_be_bytes());
+            target.extend_from_slice(&remote.octets());
         }
     } else {
         anyhow::bail!("Expected IPv4 addresses, got {:?}", (local, remote));


### PR DESCRIPTION
## Summary
- Write IPv4 octets directly in the NetFlow v9 encoder.
- Avoid native-endian `u32` conversion before serializing address fields.

## Why
LibreQoS was exporting NetFlow v9 IPv4 addresses byte-reversed on little-endian systems. In a production UISP test, v9 packets were received but parsed as incorrect endpoint addresses. For example, an address with octets `A.B.C.D` was decoded by the collector as `D.C.B.A`, so UISP did not create usable customer traffic rows.

## Validation
- Decoded live NetFlow v9 payload from LibreQoS and confirmed reversed IPv4 address bytes before this patch.
- Confirmed UISP started importing rows when production was temporarily switched to NetFlow v5 as a workaround.
- Attempted `cargo check --package lqosd` on macOS, but it could not complete because `libbpf-sys` requires Linux/libelf headers such as `byteswap.h`, `asm/unistd.h`, and `linux/stddef.h`.
