### PR TITLE
Import Sonar uninventoried MAC addresses as devices

### DIFF
--- a/src/integrationSonar.py
+++ b/src/integrationSonar.py
@@ -70,6 +70,10 @@ def sonarAccountIpAssignmentDeviceNodeId(account_id):
   return f"sonar:account-ip-assignments:{account_id}"
 
 
+def sonarUninventoriedMacAddressDeviceNodeId(uninventoried_mac_address_id):
+  return f"sonar:uninventoried-mac-address:{uninventoried_mac_address_id}"
+
+
 def sonarSession():
   global _SONAR_SESSION
   if _SONAR_SESSION is None:
@@ -480,6 +484,25 @@ def buildAccountDevices(account):
       'source': 'account_ip_assignments',
     })
 
+  for uninventoried_mac_address in account.get('uninventoried_mac_addresses', {}).get('entities', []):
+    mac_address = (uninventoried_mac_address.get('mac_address') or '').strip()
+    uninventoried_mac_address_ips = [
+      ip['subnet']
+      for ip in uninventoried_mac_address.get('ip_assignments', {}).get('entities', [])
+      if ip.get('subnet') and ip['subnet'] not in known_ip_subnets
+    ]
+    if not uninventoried_mac_address_ips:
+      continue
+    known_ip_subnets.update(uninventoried_mac_address_ips)
+    devices.append({
+      'id': sonarUninventoriedMacAddressDeviceNodeId(uninventoried_mac_address['id']),
+      'raw_id': uninventoried_mac_address['id'],
+      'name': f"Uninventoried MAC Address: {mac_address}" if mac_address else "Uninventoried MAC Address",
+      'ips': uninventoried_mac_address_ips,
+      'mac': mac_address,
+      'source': 'uninventoried_mac_addresses',
+    })
+
   return devices
 
 
@@ -629,6 +652,17 @@ def getAccounts(sonar_active_status_ids):
                         }
                       }
                     }
+                    uninventoried_mac_addresses {
+                      entities {
+                        id
+                        mac_address
+                        ip_assignments {
+                          entities {
+                            subnet
+                          }
+                        }
+                      }
+                    }
                     child_accounts {
                       entities {
                         id
@@ -687,6 +721,17 @@ def getAccounts(sonar_active_status_ids):
                         radius_accounts {
                           entities {
                             id
+                            ip_assignments {
+                              entities {
+                                subnet
+                              }
+                            }
+                          }
+                        }
+                        uninventoried_mac_addresses {
+                          entities {
+                            id
+                            mac_address
                             ip_assignments {
                               entities {
                                 subnet

--- a/src/test_integration_sonar.py
+++ b/src/test_integration_sonar.py
@@ -62,8 +62,8 @@ def inventory_item(item_id, name, ips=None, mac=""):
     }
 
 
-def sonar_account(address_items=None, radius_accounts=None, account_ips=None):
-    return {
+def sonar_account(address_items=None, radius_accounts=None, account_ips=None, uninventoried_mac_addresses=None):
+    account = {
         "id": 1,
         "name": "Account 1",
         "ip_assignments": {
@@ -82,7 +82,9 @@ def sonar_account(address_items=None, radius_accounts=None, account_ips=None):
         },
         "radius_accounts": {"entities": radius_accounts or []},
         "all_account_services": {"entities": []},
+        "uninventoried_mac_addresses": {"entities": uninventoried_mac_addresses or []},
     }
+    return account
 
 
 def radius_account(radius_id, ips):
@@ -90,6 +92,16 @@ def radius_account(radius_id, ips):
         "id": radius_id,
         "ip_assignments": {
             "entities": [{"subnet": subnet} for subnet in ips]
+        },
+    }
+
+
+def uninventoried_mac_address(mac_id, mac_address, ips=None):
+    return {
+        "id": mac_id,
+        "mac_address": mac_address,
+        "ip_assignments": {
+            "entities": [{"subnet": subnet} for subnet in (ips or [])]
         },
     }
 
@@ -212,6 +224,113 @@ class TestIntegrationSonarDevices(unittest.TestCase):
         self.assertEqual(len(devices), 3)
         self.assertEqual(devices[2]["id"], "sonar:account-ip-assignments:1")
         self.assertEqual(devices[2]["ips"], ["100.64.9.92"])
+
+    def test_uninventoried_mac_device_emits_with_stable_id_and_label(self):
+        devices = integrationSonar.buildAccountDevices(
+            sonar_account(
+                uninventoried_mac_addresses=[
+                    uninventoried_mac_address(555, "AA:BB:CC:DD:EE:55", ips=["100.64.12.12/32"]),
+                ]
+            )
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0]["id"], "sonar:uninventoried-mac-address:555")
+        self.assertEqual(devices[0]["raw_id"], 555)
+        self.assertEqual(devices[0]["name"], "Uninventoried MAC Address: AA:BB:CC:DD:EE:55")
+        self.assertEqual(devices[0]["ips"], ["100.64.12.12/32"])
+        self.assertEqual(devices[0]["mac"], "AA:BB:CC:DD:EE:55")
+        self.assertEqual(devices[0]["source"], "uninventoried_mac_addresses")
+
+    def test_uninventoried_mac_ips_are_deduped_against_inventory_radius_and_account_ips(self):
+        devices = integrationSonar.buildAccountDevices(
+            sonar_account(
+                address_items=[
+                    inventory_item(42, "ONU", ips=["100.64.13.13/32"], mac="AA:BB:CC:DD:EE:42"),
+                ],
+                radius_accounts=[
+                    radius_account(43, ["100.64.13.14/32"]),
+                ],
+                account_ips=["100.64.13.15"],
+                uninventoried_mac_addresses=[
+                    uninventoried_mac_address(444, "AA:BB:CC:DD:EE:44", ips=[
+                        "100.64.13.13/32",
+                        "100.64.13.14/32",
+                        "100.64.13.15",
+                        "100.64.13.16",
+                    ]),
+                ],
+            )
+        )
+
+        self.assertEqual([d["id"] for d in devices], [
+            "sonar:device:42",
+            "sonar:radius-account:43",
+            "sonar:account-ip-assignments:1",
+            "sonar:uninventoried-mac-address:444",
+        ])
+        self.assertEqual(devices[3]["ips"], ["100.64.13.16"])
+
+    def test_uninventoried_mac_device_is_skipped_when_all_ips_are_duplicates(self):
+        devices = integrationSonar.buildAccountDevices(
+            sonar_account(
+                address_items=[
+                    inventory_item(42, "ONU", ips=["100.64.14.14/32"], mac="AA:BB:CC:DD:EE:42"),
+                ],
+                uninventoried_mac_addresses=[
+                    uninventoried_mac_address(666, "AA:BB:CC:DD:EE:66", ips=["100.64.14.14/32"]),
+                ],
+            )
+        )
+
+        self.assertEqual([d["id"] for d in devices], ["sonar:device:42"])
+
+    def test_uninventoried_mac_device_is_skipped_when_it_has_no_ip_assignments(self):
+        devices = integrationSonar.buildAccountDevices(
+            sonar_account(
+                address_items=[
+                    inventory_item(42, "ONU", ips=["100.64.15.15/32"], mac="AA:BB:CC:DD:EE:42"),
+                ],
+                uninventoried_mac_addresses=[
+                    uninventoried_mac_address(777, "AA:BB:CC:DD:EE:77", ips=[]),
+                ],
+            )
+        )
+
+        self.assertEqual([d["id"] for d in devices], ["sonar:device:42"])
+
+    def test_uninventoried_mac_devices_emit_after_account_level_ip_devices(self):
+        devices = integrationSonar.buildAccountDevices(
+            sonar_account(
+                account_ips=["100.64.16.16"],
+                uninventoried_mac_addresses=[
+                    uninventoried_mac_address(888, "AA:BB:CC:DD:EE:88", ips=["100.64.16.17"]),
+                ],
+            )
+        )
+
+        self.assertEqual([d["id"] for d in devices], [
+            "sonar:account-ip-assignments:1",
+            "sonar:uninventoried-mac-address:888",
+        ])
+
+    def test_uninventoried_mac_label_falls_back_when_mac_is_blank(self):
+        devices = integrationSonar.buildAccountDevices(
+            sonar_account(
+                uninventoried_mac_addresses=[
+                    uninventoried_mac_address(999, "   ", ips=["100.64.17.17"]),
+                ]
+            )
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0]["name"], "Uninventoried MAC Address")
+        self.assertEqual(devices[0]["mac"], "")
+
+    def test_account_with_no_uninventoried_mac_addresses_emits_no_extra_device(self):
+        devices = integrationSonar.buildAccountDevices(sonar_account())
+
+        self.assertEqual(devices, [])
 
     def test_inventory_mac_devices_are_preserved_when_radius_supplies_ips(self):
         devices = integrationSonar.buildAccountDevices(


### PR DESCRIPTION
This PR allows the sonar integration to create devices from IP assignments on uninventoried mac addresses. In our environment, we use uninventoried mac addresses when a subscriber brings their own CPE but we still want to authenticate based on mac address.

The changes mostly consist of tweaks to the graphql query in `getAccounts` and the addition of some response parsing logic in `buildAccountDevices`. I also added some new unit tests to `src/test_integration_sonar.py`

This is my first time contributing to LibreQoS. My organization just started using it. So I'm new to the codebase and haven't solidified my dev environment. However, I did verify that all python unit tests pass.