### PR TITLE
Fix/dynamic treeguard

### DIFF
--- a/docs-es/v2.0/treeguard-es.md
+++ b/docs-es/v2.0/treeguard-es.md
@@ -124,6 +124,8 @@ anterior.
 
 Las decisiones SQM por circuito de TreeGuard también son overrides de tiempo de ejecución. El scheduler no materializa los cambios SQM propiedad de TreeGuard de vuelta en el `ShapedDevices.csv` base, por lo que limpiar TreeGuard no reescribe permanentemente la política SQM definida por el operador.
 
+TreeGuard solo gestiona circuitos estáticos de `ShapedDevices.csv`. Los circuitos dinámicos, incluidos los overlays de promoción de IPs desconocidas, permanecen bajo el ciclo de vida de circuitos dinámicos y overlays de Bakery, y no se enrolan en la conmutación SQM de TreeGuard.
+
 TreeGuard también se niega a gestionar nodos que ya estén marcados con `"virtual": true` en el `network.json` base. Si existen overrides legados de TreeGuard para esos nodos, TreeGuard limpia ese estado legado y vuelve a respetar la definición base de la topología.
 
 Para la gestión SQM por circuito, TreeGuard trata los valores duplicados de `device_id` como colisiones de identidad inseguras. Si el mismo `device_id` aparece en más de un circuito dentro de `ShapedDevices.csv`, TreeGuard omite esos circuitos afectados y limpia cualquier override SQM de TreeGuard asociado a esos `device_id` duplicados.

--- a/docs/v2.0/configuration-advanced.md
+++ b/docs/v2.0/configuration-advanced.md
@@ -193,6 +193,7 @@ attach_to = "" # optional network.json node name
 Notes:
 - `ip_range` must be a CIDR. `0.0.0.0` (and `::`) are allowed shorthands for the match-all `/0` networks.
 - `attach_to` is a `network.json` node name (optional; empty is allowed).
+- Unknown-IP promotions are applied to Bakery asynchronously. Repeated observations for the same promoted circuit are deduplicated while the live overlay is queued or waiting for Bakery.
 
 #### CRM/NMS Integrations
 

--- a/docs/v2.0/treeguard.md
+++ b/docs/v2.0/treeguard.md
@@ -123,6 +123,8 @@ circuits per successful case instead of the earlier smaller smoke-test default.
 
 TreeGuard circuit SQM decisions are also runtime overrides. The scheduler does not materialize TreeGuard-owned SQM changes back into the base `ShapedDevices.csv`, so clearing TreeGuard does not permanently rewrite operator-authored circuit SQM policy.
 
+TreeGuard only manages static circuits from `ShapedDevices.csv`. Dynamic circuits, including unknown-IP promotion overlays, remain under the dynamic-circuit and Bakery overlay lifecycle and are not enrolled in TreeGuard SQM switching.
+
 TreeGuard also refuses to manage nodes that are already marked `"virtual": true` in the base `network.json`. If stale legacy TreeGuard-owned node-virtualization overrides exist for those nodes, TreeGuard clears that legacy override state and falls back to the base topology definition.
 
 For circuit SQM management, TreeGuard treats duplicate `device_id` values as unsafe identity collisions. If the same `device_id` appears in more than one circuit in `ShapedDevices.csv`, TreeGuard skips those affected circuits and clears any TreeGuard-owned SQM overrides for those duplicate device IDs.

--- a/src/rust/lqosd/src/network_devices_hooks.rs
+++ b/src/rust/lqosd/src/network_devices_hooks.rs
@@ -2,11 +2,174 @@ use crate::shaped_devices_tracker;
 use crate::throughput_tracker::THROUGHPUT_TRACKER;
 use lqos_bus::TcHandle;
 use lqos_config::ShapedDevice;
+use std::collections::HashSet;
 use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use tracing::warn;
 
 pub(crate) struct LqosdNetworkDevicesHooks;
+
+const UNKNOWN_IP_PROMOTION_REPLY_TIMEOUT: Duration = Duration::from_secs(60);
+
+static UNKNOWN_IP_PROMOTION_SENDER: OnceLock<mpsc::Sender<ShapedDevice>> = OnceLock::new();
+static UNKNOWN_IP_PROMOTIONS_PENDING: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn pending_unknown_ip_promotions() -> &'static Mutex<HashSet<String>> {
+    UNKNOWN_IP_PROMOTIONS_PENDING.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn with_pending_unknown_ip_promotions<R>(f: impl FnOnce(&mut HashSet<String>) -> R) -> R {
+    match pending_unknown_ip_promotions().lock() {
+        Ok(mut pending) => f(&mut pending),
+        Err(poisoned) => {
+            let mut pending = poisoned.into_inner();
+            f(&mut pending)
+        }
+    }
+}
+
+fn mark_unknown_ip_promotion_pending(circuit_id: &str) -> bool {
+    with_pending_unknown_ip_promotions(|pending| pending.insert(circuit_id.to_string()))
+}
+
+fn clear_unknown_ip_promotion_pending(circuit_id: &str) {
+    with_pending_unknown_ip_promotions(|pending| {
+        pending.remove(circuit_id);
+    });
+}
+
+fn unknown_ip_promotion_sender() -> Result<mpsc::Sender<ShapedDevice>, String> {
+    if let Some(sender) = UNKNOWN_IP_PROMOTION_SENDER.get() {
+        return Ok(sender.clone());
+    }
+
+    let (tx, rx) = mpsc::channel::<ShapedDevice>();
+    std::thread::Builder::new()
+        .name("dyn-circuit-promoter".to_string())
+        .spawn(move || unknown_ip_promotion_worker(rx))
+        .map_err(|err| err.to_string())?;
+
+    if UNKNOWN_IP_PROMOTION_SENDER.set(tx.clone()).is_err() {
+        return UNKNOWN_IP_PROMOTION_SENDER
+            .get()
+            .cloned()
+            .ok_or_else(|| "unknown IP promotion worker initialized without sender".to_string());
+    }
+
+    Ok(tx)
+}
+
+fn unknown_ip_promotion_worker(rx: mpsc::Receiver<ShapedDevice>) {
+    while let Ok(shaped_device) = rx.recv() {
+        let circuit_id = shaped_device.circuit_id.clone();
+        apply_unknown_ip_promotion(shaped_device);
+        clear_unknown_ip_promotion_pending(&circuit_id);
+    }
+}
+
+fn apply_unknown_ip_promotion(shaped_device: ShapedDevice) {
+    let Some(sender) = lqos_bakery::BAKERY_SENDER.get() else {
+        return;
+    };
+
+    let (tx, rx) = mpsc::channel::<Result<Option<TcHandle>, String>>();
+    if let Err(err) = sender.send(lqos_bakery::BakeryCommands::UpsertDynamicCircuitOverlay {
+        shaped_device: Box::new(shaped_device.clone()),
+        reply: Some(tx),
+    }) {
+        warn!(
+            "Unable to enqueue dynamic circuit overlay for unknown IP promotion '{}': {err}",
+            shaped_device.circuit_id
+        );
+        return;
+    }
+
+    let handle = match rx.recv_timeout(UNKNOWN_IP_PROMOTION_REPLY_TIMEOUT) {
+        Ok(Ok(Some(handle))) => handle,
+        Ok(Ok(None)) => {
+            // Bakery accepted the overlay but could not yet allocate a concrete class handle
+            // (e.g., baseline not ready). We'll retry on future observations.
+            return;
+        }
+        Ok(Err(err)) => {
+            warn!(
+                "Bakery rejected dynamic circuit overlay for unknown IP promotion '{}': {err}",
+                shaped_device.circuit_id
+            );
+            return;
+        }
+        Err(err) => {
+            warn!(
+                "Timeout waiting for Bakery reply while promoting unknown IP '{}': {err}",
+                shaped_device.circuit_id
+            );
+            return;
+        }
+    };
+
+    let circuit_hash = if shaped_device.circuit_hash != 0 {
+        shaped_device.circuit_hash
+    } else {
+        lqos_utils::hash_to_i64(&shaped_device.circuit_id)
+    };
+    let device_hash = if shaped_device.device_hash != 0 {
+        shaped_device.device_hash
+    } else {
+        lqos_utils::hash_to_i64(&shaped_device.device_id)
+    };
+
+    let cpu_count = lqos_sys::num_possible_cpus().map(|n| n.max(1)).unwrap_or(1);
+    let cpu = ((circuit_hash as u64) % (cpu_count as u64)) as u32;
+
+    for (ip, prefix) in shaped_device.ipv4.iter() {
+        let addr = if *prefix == 32 {
+            ip.to_string()
+        } else {
+            format!("{ip}/{prefix}")
+        };
+        if let Err(err) = lqos_sys::add_ip_to_tc(
+            &addr,
+            handle,
+            cpu,
+            false,
+            circuit_hash as u64,
+            device_hash as u64,
+        ) {
+            warn!(
+                "Unable to map unknown IP dynamic circuit '{}' for {addr}: {err:?}",
+                shaped_device.circuit_id
+            );
+        }
+    }
+    for (ip, prefix) in shaped_device.ipv6.iter() {
+        let addr = if *prefix == 128 {
+            ip.to_string()
+        } else {
+            format!("{ip}/{prefix}")
+        };
+        if let Err(err) = lqos_sys::add_ip_to_tc(
+            &addr,
+            handle,
+            cpu,
+            false,
+            circuit_hash as u64,
+            device_hash as u64,
+        ) {
+            warn!(
+                "Unable to map unknown IP dynamic circuit '{}' for {addr}: {err:?}",
+                shaped_device.circuit_id
+            );
+        }
+    }
+
+    if let Err(err) = lqos_sys::clear_hot_cache() {
+        warn!(
+            "Unable to clear hot cache after mapping unknown IP dynamic circuit '{}': {err:?}",
+            shaped_device.circuit_id
+        );
+    }
+}
 
 impl lqos_network_devices::DaemonHooks for LqosdNetworkDevicesHooks {
     fn on_shaped_devices_updated(&self) {
@@ -47,120 +210,41 @@ impl lqos_network_devices::DaemonHooks for LqosdNetworkDevicesHooks {
         let shaped_device = shaped_device.clone();
         let circuit_id = shaped_device.circuit_id.clone();
 
-        let result = std::thread::Builder::new()
-            .name("dyn-circuit-unknown-ip".to_string())
-            .spawn(move || {
-                let Some(sender) = lqos_bakery::BAKERY_SENDER.get() else {
-                    return;
-                };
-
-                let (tx, rx) = mpsc::channel::<Result<Option<TcHandle>, String>>();
-                if let Err(err) =
-                    sender.send(lqos_bakery::BakeryCommands::UpsertDynamicCircuitOverlay {
-                        shaped_device: Box::new(shaped_device.clone()),
-                        reply: Some(tx),
-                    })
-                {
-                    warn!(
-                        "Unable to enqueue dynamic circuit overlay for unknown IP promotion '{}': {err}",
-                        shaped_device.circuit_id
-                    );
-                    return;
-                }
-
-                let handle = match rx.recv_timeout(Duration::from_secs(10)) {
-                    Ok(Ok(Some(handle))) => handle,
-                    Ok(Ok(None)) => {
-                        // Bakery accepted the overlay but could not yet allocate a concrete class
-                        // handle (e.g., baseline not ready). We'll retry on future observations.
-                        return;
-                    }
-                    Ok(Err(err)) => {
-                        warn!(
-                            "Bakery rejected dynamic circuit overlay for unknown IP promotion '{}': {err}",
-                            shaped_device.circuit_id
-                        );
-                        return;
-                    }
-                    Err(err) => {
-                        warn!(
-                            "Timeout waiting for Bakery reply while promoting unknown IP '{}': {err}",
-                            shaped_device.circuit_id
-                        );
-                        return;
-                    }
-                };
-
-                let circuit_hash = if shaped_device.circuit_hash != 0 {
-                    shaped_device.circuit_hash
-                } else {
-                    lqos_utils::hash_to_i64(&shaped_device.circuit_id)
-                };
-                let device_hash = if shaped_device.device_hash != 0 {
-                    shaped_device.device_hash
-                } else {
-                    lqos_utils::hash_to_i64(&shaped_device.device_id)
-                };
-
-                let cpu_count = lqos_sys::num_possible_cpus()
-                    .map(|n| n.max(1))
-                    .unwrap_or(1);
-                let cpu = ((circuit_hash as u64) % (cpu_count as u64)) as u32;
-
-                for (ip, prefix) in shaped_device.ipv4.iter() {
-                    let addr = if *prefix == 32 {
-                        ip.to_string()
-                    } else {
-                        format!("{ip}/{prefix}")
-                    };
-                    if let Err(err) = lqos_sys::add_ip_to_tc(
-                        &addr,
-                        handle,
-                        cpu,
-                        false,
-                        circuit_hash as u64,
-                        device_hash as u64,
-                    ) {
-                        warn!(
-                            "Unable to map unknown IP dynamic circuit '{}' for {addr}: {err:?}",
-                            shaped_device.circuit_id
-                        );
-                    }
-                }
-                for (ip, prefix) in shaped_device.ipv6.iter() {
-                    let addr = if *prefix == 128 {
-                        ip.to_string()
-                    } else {
-                        format!("{ip}/{prefix}")
-                    };
-                    if let Err(err) = lqos_sys::add_ip_to_tc(
-                        &addr,
-                        handle,
-                        cpu,
-                        false,
-                        circuit_hash as u64,
-                        device_hash as u64,
-                    ) {
-                        warn!(
-                            "Unable to map unknown IP dynamic circuit '{}' for {addr}: {err:?}",
-                            shaped_device.circuit_id
-                        );
-                    }
-                }
-
-                if let Err(err) = lqos_sys::clear_hot_cache() {
-                    warn!(
-                        "Unable to clear hot cache after mapping unknown IP dynamic circuit '{}': {err:?}",
-                        shaped_device.circuit_id
-                    );
-                }
-            });
-
-        if let Err(err) = result {
-            warn!(
-                "Unable to spawn unknown IP promotion helper thread for '{}': {err}",
-                circuit_id
-            );
+        if !mark_unknown_ip_promotion_pending(&circuit_id) {
+            return;
         }
+
+        let sender = match unknown_ip_promotion_sender() {
+            Ok(sender) => sender,
+            Err(err) => {
+                clear_unknown_ip_promotion_pending(&circuit_id);
+                warn!("Unable to start unknown IP promotion worker for '{circuit_id}': {err}");
+                return;
+            }
+        };
+
+        if let Err(err) = sender.send(shaped_device) {
+            clear_unknown_ip_promotion_pending(&circuit_id);
+            warn!("Unable to enqueue unknown IP promotion for '{circuit_id}': {err}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clear_unknown_ip_promotion_pending, mark_unknown_ip_promotion_pending};
+
+    #[test]
+    fn unknown_ip_promotion_pending_set_deduplicates_until_cleared() {
+        let circuit_id = "[dyn] test pending dedupe";
+        clear_unknown_ip_promotion_pending(circuit_id);
+
+        assert!(mark_unknown_ip_promotion_pending(circuit_id));
+        assert!(!mark_unknown_ip_promotion_pending(circuit_id));
+
+        clear_unknown_ip_promotion_pending(circuit_id);
+        assert!(mark_unknown_ip_promotion_pending(circuit_id));
+
+        clear_unknown_ip_promotion_pending(circuit_id);
     }
 }

--- a/src/rust/lqosd/src/treeguard/actor.rs
+++ b/src/rust/lqosd/src/treeguard/actor.rs
@@ -279,7 +279,7 @@ fn current_topology_totals() -> (usize, usize) {
 
     let catalog = lqos_network_devices::network_devices_catalog();
     let mut circuit_ids: FxHashSet<&str> = FxHashSet::default();
-    for device in catalog.iter_all_devices() {
+    for device in catalog.iter_static_devices() {
         let circuit_id = device.circuit_id.trim();
         if circuit_id.is_empty() {
             continue;
@@ -307,7 +307,7 @@ fn direct_circuit_counts_by_node(
     shaped_devices: &lqos_network_devices::NetworkDevicesCatalog,
 ) -> FxHashMap<String, usize> {
     let mut circuits_by_node: FxHashMap<String, FxHashSet<&str>> = FxHashMap::default();
-    for device in shaped_devices.iter_all_devices() {
+    for device in shaped_devices.iter_static_devices() {
         let node_name = device.parent_node.trim();
         let circuit_id = device.circuit_id.trim();
         if node_name.is_empty() || circuit_id.is_empty() {
@@ -454,7 +454,6 @@ struct CircuitInventoryEntry {
 #[derive(Clone, Debug, Default)]
 struct CircuitInventory {
     shaped_devices_generation: u64,
-    dynamic_signature: u64,
     circuit_ids: Vec<String>,
     entries: FxHashMap<String, CircuitInventoryEntry>,
     all_device_ids: FxHashSet<String>,
@@ -610,54 +609,21 @@ fn ensure_circuit_inventory(
     runtime_state: &mut TreeguardRuntimeState,
     shaped: &lqos_network_devices::NetworkDevicesCatalog,
 ) {
-    use std::hash::{Hash, Hasher};
-
-    fn dynamic_overlay_signature(dynamic: &[lqos_network_devices::DynamicCircuit]) -> u64 {
-        use fxhash::FxHasher;
-
-        let mut entry_sigs: Vec<u64> = Vec::with_capacity(dynamic.len());
-        for circuit in dynamic {
-            let dev = &circuit.shaped;
-            let mut h = FxHasher::default();
-            dev.circuit_id.trim().hash(&mut h);
-            dev.device_id.trim().hash(&mut h);
-            dev.parent_node.trim().hash(&mut h);
-            dev.download_max_mbps.to_bits().hash(&mut h);
-            dev.upload_max_mbps.to_bits().hash(&mut h);
-            dev.sqm_override
-                .as_deref()
-                .unwrap_or("")
-                .trim()
-                .hash(&mut h);
-            entry_sigs.push(h.finish());
-        }
-        entry_sigs.sort_unstable();
-
-        let mut outer = FxHasher::default();
-        entry_sigs.hash(&mut outer);
-        outer.finish()
-    }
-
     let generation = shaped.shaped_devices().generation();
-    let dynamic_signature = dynamic_overlay_signature(shaped.dynamic_circuits());
-    if runtime_state.circuit_inventory.shaped_devices_generation == generation
-        && runtime_state.circuit_inventory.dynamic_signature == dynamic_signature
-    {
+    if runtime_state.circuit_inventory.shaped_devices_generation == generation {
         return;
     }
 
-    runtime_state.circuit_inventory = build_circuit_inventory(shaped, dynamic_signature);
+    runtime_state.circuit_inventory = build_circuit_inventory(shaped);
     runtime_state.circuit_batch_cursor = 0;
 }
 
 fn build_circuit_inventory(
     shaped: &lqos_network_devices::NetworkDevicesCatalog,
-    dynamic_signature: u64,
 ) -> CircuitInventory {
     let mut circuits_by_device_id: FxHashMap<String, FxHashSet<String>> = FxHashMap::default();
-    circuits_by_device_id
-        .reserve(shaped.shaped_devices().devices_len() + shaped.dynamic_circuits().len());
-    for device in shaped.iter_all_devices() {
+    circuits_by_device_id.reserve(shaped.shaped_devices().devices_len());
+    for device in shaped.iter_static_devices() {
         let device_id = device.device_id.trim();
         let circuit_id = device.circuit_id.trim();
         if device_id.is_empty() || circuit_id.is_empty() {
@@ -682,10 +648,10 @@ fn build_circuit_inventory(
         .collect();
 
     let mut by_circuit_id: FxHashMap<String, Vec<lqos_config::ShapedDevice>> = FxHashMap::default();
-    by_circuit_id.reserve(shaped.shaped_devices().devices_len() + shaped.dynamic_circuits().len());
+    by_circuit_id.reserve(shaped.shaped_devices().devices_len());
     let mut all_device_ids = FxHashSet::default();
-    all_device_ids.reserve(shaped.shaped_devices().devices_len() + shaped.dynamic_circuits().len());
-    for device in shaped.iter_all_devices() {
+    all_device_ids.reserve(shaped.shaped_devices().devices_len());
+    for device in shaped.iter_static_devices() {
         if device.circuit_id.trim().is_empty() {
             continue;
         }
@@ -762,7 +728,6 @@ fn build_circuit_inventory(
 
     CircuitInventory {
         shaped_devices_generation: shaped.shaped_devices().generation(),
-        dynamic_signature,
         circuit_ids,
         entries,
         all_device_ids,
@@ -779,6 +744,25 @@ fn circuit_evaluation_batch_size(managed_circuits: usize, all_circuits: bool) ->
 
     let target = managed_circuits.div_ceil(TREEGUARD_CIRCUIT_TARGET_SWEEP_SECONDS);
     managed_circuits.min(target.max(TREEGUARD_CIRCUIT_MIN_BATCH_SIZE))
+}
+
+fn enrolled_treeguard_circuits(
+    circuit_inventory: &CircuitInventory,
+    configured_circuits: &[String],
+    all_circuits: bool,
+) -> Vec<String> {
+    if all_circuits {
+        return circuit_inventory.circuit_ids.clone();
+    }
+
+    let mut enrolled: Vec<String> = configured_circuits
+        .iter()
+        .filter(|circuit_id| circuit_inventory.entries.contains_key(circuit_id.as_str()))
+        .cloned()
+        .collect();
+    enrolled.sort();
+    enrolled.dedup();
+    enrolled
 }
 
 fn collect_circuit_batch<'a>(
@@ -807,6 +791,25 @@ fn collect_circuit_batch<'a>(
 
     *cursor = index;
     batch
+}
+
+fn out_of_scope_treeguard_sqm_device_ids(
+    treeguard_device_ids_with_overrides: &FxHashSet<String>,
+    circuit_inventory: &CircuitInventory,
+    desired_device_ids: &FxHashSet<String>,
+    all_circuits: bool,
+) -> Vec<String> {
+    treeguard_device_ids_with_overrides
+        .iter()
+        .filter(|device_id| {
+            if all_circuits {
+                !circuit_inventory.all_device_ids.contains(*device_id)
+            } else {
+                !desired_device_ids.contains(*device_id)
+            }
+        })
+        .cloned()
+        .collect()
 }
 
 /// Executes a single TreeGuard tick.
@@ -1614,14 +1617,11 @@ fn run_tick(
     let manage_circuits = tg.enabled && tg.circuits.enabled;
     let circuit_inventory = &runtime_state.circuit_inventory;
 
-    let enrolled_circuits: Vec<String> = if tg.circuits.all_circuits {
-        circuit_inventory.circuit_ids.clone()
-    } else {
-        let mut v = tg.circuits.circuits.clone();
-        v.sort();
-        v.dedup();
-        v
-    };
+    let enrolled_circuits = enrolled_treeguard_circuits(
+        circuit_inventory,
+        &tg.circuits.circuits,
+        tg.circuits.all_circuits,
+    );
     status.managed_circuits = enrolled_circuits.len();
 
     let allowlisted_circuits: FxHashSet<String> = if tg.circuits.all_circuits {
@@ -1692,17 +1692,12 @@ fn run_tick(
             .as_ref()
             .map(overrides_sqm_device_ids)
             .unwrap_or_default();
-        let removed: Vec<String> = treeguard_device_ids_with_overrides
-            .iter()
-            .filter(|device_id| {
-                if tg.circuits.all_circuits {
-                    !circuit_inventory.all_device_ids.contains(*device_id)
-                } else {
-                    !desired_device_ids.contains(*device_id)
-                }
-            })
-            .cloned()
-            .collect();
+        let removed: Vec<String> = out_of_scope_treeguard_sqm_device_ids(
+            &treeguard_device_ids_with_overrides,
+            circuit_inventory,
+            &desired_device_ids,
+            tg.circuits.all_circuits,
+        );
         if !removed.is_empty() {
             match overrides::clear_device_overrides(&removed) {
                 Ok(changed) => {
@@ -3307,12 +3302,14 @@ mod tests {
     use super::{
         CircuitSqmApplyContext, CircuitSqmTransition, CircuitTickContext, LinkVirtualState,
         PendingLinkVirtualizationDecision, TreeguardRuntimeState, apply_circuit_sqm_change,
-        apply_link_virtualization_decision, base_circuit_sqm_state, circuit_evaluation_batch_size,
-        circuit_sqm_transition_from_decision, clear_structural_ineligible_if_topology_changed,
-        collect_circuit_batch, empty_status_snapshot, latched_structural_ineligible_reason,
-        pause_for_bakery_reload_with_flag, process_circuit_tick, run_tick,
-        select_link_virtualization_candidates, treeguard_manages_circuit_direction,
-        try_consume_circuit_change_budget,
+        apply_link_virtualization_decision, base_circuit_sqm_state, build_circuit_inventory,
+        circuit_evaluation_batch_size, circuit_sqm_transition_from_decision,
+        clear_structural_ineligible_if_topology_changed, collect_circuit_batch,
+        direct_circuit_counts_by_node, empty_status_snapshot, enrolled_treeguard_circuits,
+        ensure_circuit_inventory, latched_structural_ineligible_reason,
+        out_of_scope_treeguard_sqm_device_ids, pause_for_bakery_reload_with_flag,
+        process_circuit_tick, run_tick, select_link_virtualization_candidates,
+        treeguard_manages_circuit_direction, try_consume_circuit_change_budget,
     };
     use crate::node_manager::ws::messages::TreeguardActivityEntry;
     use crate::system_stats::SystemStats;
@@ -3331,6 +3328,7 @@ mod tests {
     use lqos_bus::TcHandle;
     use lqos_config::ConfigShapedDevices;
     use lqos_config::ShapedDevice;
+    use lqos_network_devices::{DynamicCircuit, NetworkDevicesCatalog, ShapedDevicesCatalog};
     use lqos_queue_tracker::{QUEUE_STRUCTURE, QueueNode, QueueStructure};
     use lqos_utils::rtt::RttBuffer;
     use lqos_utils::units::DownUpOrder;
@@ -3363,6 +3361,168 @@ mod tests {
             is_top_level,
             value_score,
         }
+    }
+
+    fn treeguard_test_catalog(
+        static_devices: Vec<ShapedDevice>,
+        dynamic_devices: Vec<ShapedDevice>,
+    ) -> NetworkDevicesCatalog {
+        let mut shaped = ConfigShapedDevices::default();
+        shaped.replace_with_new_data(static_devices);
+        let shaped_catalog = ShapedDevicesCatalog::from_shaped_devices(Arc::new(shaped));
+        let dynamic = dynamic_devices
+            .into_iter()
+            .map(|shaped| DynamicCircuit {
+                shaped,
+                last_seen_unix: 1,
+            })
+            .collect();
+        NetworkDevicesCatalog::from_snapshots(shaped_catalog, Arc::new(dynamic))
+    }
+
+    fn treeguard_test_device(circuit_id: &str, device_id: &str, parent_node: &str) -> ShapedDevice {
+        ShapedDevice {
+            circuit_id: circuit_id.to_string(),
+            circuit_name: circuit_id.to_string(),
+            device_id: device_id.to_string(),
+            device_name: device_id.to_string(),
+            parent_node: parent_node.to_string(),
+            download_max_mbps: 100.0,
+            upload_max_mbps: 20.0,
+            ..ShapedDevice::default()
+        }
+    }
+
+    #[test]
+    fn treeguard_circuit_inventory_excludes_dynamic_circuits() {
+        let static_device = treeguard_test_device("static-circuit", "static-device", "Tower A");
+        let dynamic_device = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.42",
+            "[dyn] (Default) 192.0.2.42",
+            "Tower A",
+        );
+        let catalog = treeguard_test_catalog(vec![static_device], vec![dynamic_device]);
+
+        let inventory = build_circuit_inventory(&catalog);
+
+        assert_eq!(inventory.circuit_ids, vec!["static-circuit".to_string()]);
+        assert!(inventory.entries.contains_key("static-circuit"));
+        assert!(!inventory.entries.contains_key("[dyn] (Default) 192.0.2.42"));
+        assert!(inventory.all_device_ids.contains("static-device"));
+        assert!(
+            !inventory
+                .all_device_ids
+                .contains("[dyn] (Default) 192.0.2.42")
+        );
+    }
+
+    #[test]
+    fn treeguard_dynamic_overlay_changes_do_not_reset_circuit_batch_cursor() {
+        let static_device = treeguard_test_device("static-circuit", "static-device", "Tower A");
+        let first_dynamic = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.42",
+            "[dyn] (Default) 192.0.2.42",
+            "Tower A",
+        );
+        let second_dynamic = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.43",
+            "[dyn] (Default) 192.0.2.43",
+            "Tower A",
+        );
+        let first_catalog =
+            treeguard_test_catalog(vec![static_device.clone()], vec![first_dynamic]);
+        let second_catalog = treeguard_test_catalog(vec![static_device], vec![second_dynamic]);
+        let mut runtime_state = TreeguardRuntimeState {
+            circuit_inventory: build_circuit_inventory(&first_catalog),
+            circuit_batch_cursor: 1,
+            ..TreeguardRuntimeState::default()
+        };
+
+        ensure_circuit_inventory(&mut runtime_state, &second_catalog);
+
+        assert_eq!(runtime_state.circuit_batch_cursor, 1);
+        assert_eq!(
+            runtime_state.circuit_inventory.circuit_ids,
+            vec!["static-circuit".to_string()]
+        );
+    }
+
+    #[test]
+    fn treeguard_cleans_dynamic_sqm_overrides_as_out_of_scope() {
+        let static_device = treeguard_test_device("static-circuit", "static-device", "Tower A");
+        let dynamic_device = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.42",
+            "[dyn] (Default) 192.0.2.42",
+            "Tower A",
+        );
+        let catalog = treeguard_test_catalog(vec![static_device], vec![dynamic_device]);
+        let inventory = build_circuit_inventory(&catalog);
+        let desired_device_ids = FxHashSet::default();
+        let treeguard_device_ids_with_overrides = FxHashSet::from_iter([
+            "static-device".to_string(),
+            "[dyn] (Default) 192.0.2.42".to_string(),
+        ]);
+
+        let mut removed = out_of_scope_treeguard_sqm_device_ids(
+            &treeguard_device_ids_with_overrides,
+            &inventory,
+            &desired_device_ids,
+            true,
+        );
+        removed.sort();
+
+        assert_eq!(removed, vec!["[dyn] (Default) 192.0.2.42".to_string()]);
+    }
+
+    #[test]
+    fn treeguard_explicit_enrollment_excludes_dynamic_circuits() {
+        let static_device = treeguard_test_device("static-circuit", "static-device", "Tower A");
+        let dynamic_device = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.42",
+            "[dyn] (Default) 192.0.2.42",
+            "Tower A",
+        );
+        let catalog = treeguard_test_catalog(vec![static_device], vec![dynamic_device]);
+        let inventory = build_circuit_inventory(&catalog);
+        let configured = vec![
+            "[dyn] (Default) 192.0.2.42".to_string(),
+            "static-circuit".to_string(),
+        ];
+
+        let enrolled = enrolled_treeguard_circuits(&inventory, &configured, false);
+
+        assert_eq!(enrolled, vec!["static-circuit".to_string()]);
+    }
+
+    #[test]
+    fn treeguard_all_circuits_enrollment_uses_static_inventory() {
+        let static_device = treeguard_test_device("static-circuit", "static-device", "Tower A");
+        let dynamic_device = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.42",
+            "[dyn] (Default) 192.0.2.42",
+            "Tower A",
+        );
+        let catalog = treeguard_test_catalog(vec![static_device], vec![dynamic_device]);
+        let inventory = build_circuit_inventory(&catalog);
+
+        let enrolled = enrolled_treeguard_circuits(&inventory, &[], true);
+
+        assert_eq!(enrolled, vec!["static-circuit".to_string()]);
+    }
+
+    #[test]
+    fn treeguard_link_circuit_counts_ignore_dynamic_circuits() {
+        let static_device = treeguard_test_device("static-circuit", "static-device", "Tower A");
+        let dynamic_device = treeguard_test_device(
+            "[dyn] (Default) 192.0.2.42",
+            "[dyn] (Default) 192.0.2.42",
+            "Tower A",
+        );
+        let catalog = treeguard_test_catalog(vec![static_device], vec![dynamic_device]);
+
+        let counts = direct_circuit_counts_by_node(&catalog);
+
+        assert_eq!(counts.get("Tower A"), Some(&1));
     }
 
     #[test]


### PR DESCRIPTION
This PR:
- Separates out TreeGuard and Dynamic Circuits, so they won't stomp on one another
- Fixes a slightly stupid resource spawn that slipped in when setting up dynamic circuits

<img width="1886" height="935" alt="image" src="https://github.com/user-attachments/assets/3d985e9f-7605-4aeb-8325-de103b554ef3" />

Working quite well in production.