### PR TITLE
Balance Queue Auto virtualization across high-capacity AP branches

### DIFF
--- a/docs-es/v2.0/configuration-advanced-es.md
+++ b/docs-es/v2.0/configuration-advanced-es.md
@@ -178,6 +178,7 @@ Notas:
 - Durante el shaping, los nodos virtuales se eliminan y sus hijos se promueven al ancestro no virtual más cercano (revisa `queuingStructure.json` para el plan físico activo).
 - `ShapedDevices.csv` aún puede usar un nodo virtual como `Parent Node` para mostrar/agrupar; LibreQoS adjuntará esos circuitos para shaping al ancestro no virtual más cercano (si el nodo virtual está en el nivel superior y no tiene ancestro no virtual, se tratará como sin nodo padre para el shaping).
 - Evita colisiones de nombres después de la promoción (dos nodos con el mismo nombre terminando al mismo nivel).
+- Queue Auto también puede virtualizar ramas de alta capacidad de agregación, uplink o AP representadas como nodos `Site` o `AP` cuando superan `queue_auto_virtualize_threshold_mbps` y tienen ramas de cola hijas. Esto evita que una rama lógica grande se convierta en un cuello de botella de una sola cola de CPU.
 
 #### Consideraciones de CPU
 

--- a/docs-es/v2.0/integrations-splynx-es.md
+++ b/docs-es/v2.0/integrations-splynx-es.md
@@ -27,7 +27,7 @@ Después, ejecute una sincronización manual y valide salidas antes de aumentar 
 - Use la WebUI para confirmar que la importación y la profundidad del árbol son las esperadas.
 - Use WebUI para ajustes operativos diarios.
 - Cuando Splynx no puede inferir el padre de un circuito desde `access_device` o los metadatos del router, LibreQoS deja ese circuito sin padre para shaping en lugar de adjuntarlo a un sitio o AP sintético. Corrija el padre en Splynx o Topology Manager si debe aparecer bajo un sitio o AP real.
-- En modo `ap_site`, LibreQoS trata los Network Sites de Splynx como contenedores de sitio y las filas de monitoreo con `access_device = 1` como AP o nodos de acceso. Los contenedores de sitio grandes pueden virtualizarse automáticamente cuando superan `queue_auto_virtualize_threshold_mbps`, tienen ramas de cola hijas y no tienen circuitos conectados directamente al ID del sitio. Defina una anulación virtual del nodo en `false` cuando un sitio específico deba permanecer como cola física.
+- En modo `ap_site`, LibreQoS trata los Network Sites de Splynx como contenedores de sitio y las filas de monitoreo con `access_device = 1` como AP o nodos de acceso. Las ramas grandes de sitios y APs, incluidas ramas de uplink o agregación representadas como nodos `Site` o `AP`, pueden virtualizarse automáticamente cuando superan `queue_auto_virtualize_threshold_mbps`, tienen ramas de cola hijas y no tienen circuitos conectados directamente al ID del nodo. Defina una anulación virtual del nodo en `false` cuando un nodo específico deba permanecer como cola física.
 
 ## Validación en 5 minutos después de cambios Splynx
 

--- a/docs/v2.0/configuration-advanced.md
+++ b/docs/v2.0/configuration-advanced.md
@@ -119,8 +119,8 @@ In the WebUI, this lives at `Configuration -> Integration - Common` as `Queue Au
 How it works:
 
 - `queue_auto_virtualize_threshold_mbps` is the static queue-policy threshold used by `lqos_topology`.
-- `QueueAuto` only hides a node when it is a `Site`, has child branches, and its final effective node rate is at or above the threshold.
-- That same threshold rule applies to top-level `QueueAuto` sites and non-top-level `QueueAuto` sites.
+- Queue Auto can hide a `Site` or `AP` node when it has child branches and its final effective node rate is at or above the threshold.
+- That same threshold rule applies to top-level and non-top-level eligible nodes.
 - Nodes with directly attached circuits stay queue-visible by default.
 
 This static queue policy is now the primary way to avoid wasting HTB depth or creating artificial aggregate choke points. TreeGuard runtime link virtualization remains available, but is disabled by default.
@@ -131,7 +131,7 @@ This static queue policy is now the primary way to avoid wasting HTB depth or cr
 
 ```{mermaid}
 flowchart TD
-    A[Node queue policy = QueueAuto] --> B{Is this a Site node?}
+    A[Node queue policy allows auto visibility] --> B{Is this a Site or AP node?}
     B -->|No| C[Keep queue-visible]
     B -->|Yes| D{Does it have child branches?}
     D -->|No| E[Keep queue-visible]
@@ -142,9 +142,9 @@ flowchart TD
 
 Current rule summary:
 
-- Non-`Site` nodes stay queue-visible under `QueueAuto`.
-- A `Site` with no child branches stays queue-visible.
-- A top-level or non-top-level `Site` with child branches only becomes static virtual when its final effective node rate is at or above `queue_auto_virtualize_threshold_mbps`.
+- Node kinds other than `Site` and `AP` stay queue-visible under Queue Auto.
+- An eligible node with no child branches stays queue-visible.
+- A top-level or non-top-level eligible node with child branches only becomes static virtual when its final effective node rate is at or above `queue_auto_virtualize_threshold_mbps`.
 - The rate used for this decision is the recompiled runtime-effective rate, not an earlier raw attachment max.
 
 When a node becomes static virtual:
@@ -334,6 +334,7 @@ Notes:
 - During shaping, virtual nodes are removed and their children are promoted to the nearest non-virtual ancestor (see `queuingStructure.json` for the active physical plan).
 - `ShapedDevices.csv` can still use a virtual node as a `Parent Node` for display/grouping; LibreQoS will attach those circuits for shaping to the nearest non-virtual ancestor (top-level virtual nodes will be treated as unparented for shaping).
 - Avoid name collisions after promotion (two nodes with the same name ending up at the same level).
+- Queue Auto can also virtualize high-capacity aggregation, uplink, or AP branches represented as `Site` or `AP` nodes when they exceed `queue_auto_virtualize_threshold_mbps` and have child queue branches. This keeps one large logical branch from becoming a single CPU queue bottleneck.
 
 #### CPU Considerations
 

--- a/docs/v2.0/integrations-splynx.md
+++ b/docs/v2.0/integrations-splynx.md
@@ -26,7 +26,7 @@ LibreQoS supports multiple topology strategies for Splynx integration to balance
 
 When Splynx cannot infer a circuit parent from `access_device` or router metadata, LibreQoS leaves the circuit unparented for shaping instead of attaching it to a synthetic site or AP. Fix the parent in Splynx or Topology Manager if the circuit should appear under a real site or AP.
 
-In `ap_site` mode, LibreQoS treats Splynx Network Sites as site containers and monitoring rows with `access_device = 1` as AP/access nodes. Large site containers can be virtualized automatically when they exceed `queue_auto_virtualize_threshold_mbps`, have child queue branches, and have no circuits directly attached to the site node ID. Set a node virtual override to `false` when a specific site must remain as a physical queue.
+In `ap_site` mode, LibreQoS treats Splynx Network Sites as site containers and monitoring rows with `access_device = 1` as AP/access nodes. Large site and AP branches, including uplink or aggregation branches represented as `Site` or `AP` nodes, can be virtualized automatically when they exceed `queue_auto_virtualize_threshold_mbps`, have child queue branches, and have no circuits directly attached to the node ID. Set a node virtual override to `false` when a specific node must remain as a physical queue.
 
 Configure the shared topology mode in `/etc/lqos.conf` under the `[topology]` section:
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -3288,36 +3288,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3325,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3337,13 +3333,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -4741,12 +4736,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -79,7 +79,7 @@ sysinfo = { version = "0", default-features = false, features = [ "system" ] }
 default-net = "0"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls-no-provider", "charset", "http2", "system-proxy"] }
 rustls = "0.23"
-pyo3 = "0.25.1"
+pyo3 = "0.29.0"
 colored = "2"
 miniz_oxide = "0.8"
 byteorder = "1"

--- a/src/rust/lqos_config/src/etc/v15/topology.rs
+++ b/src/rust/lqos_config/src/etc/v15/topology.rs
@@ -16,8 +16,9 @@ pub struct TopologyConfig {
 
     /// Practical per-node queue budget used by `queue_auto` visibility policy.
     ///
-    /// Site-like aggregation nodes at or above this threshold may be hidden from the
-    /// queue-visible runtime tree when LibreQoS can safely promote their children.
+    /// Eligible high-capacity `Site` and `AP` branches at or above this threshold may
+    /// be hidden from the queue-visible runtime tree when LibreQoS can safely promote
+    /// their children.
     #[serde(default = "default_queue_auto_virtualize_threshold_mbps")]
     pub queue_auto_virtualize_threshold_mbps: u64,
 }

--- a/src/rust/lqos_config/src/topology_editor_state.rs
+++ b/src/rust/lqos_config/src/topology_editor_state.rs
@@ -70,7 +70,7 @@ pub enum TopologyAttachmentRole {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TopologyQueueVisibilityPolicy {
-    /// The node remains visible in the baseline queue topology.
+    /// The node remains visible unless automatic high-capacity branch rules hide it.
     #[default]
     QueueVisible,
     /// The node remains logical-only for queueing and its children are promoted one level.

--- a/src/rust/lqos_python/src/device_weights.rs
+++ b/src/rust/lqos_python/src/device_weights.rs
@@ -37,7 +37,7 @@ pub struct DeviceWeightRequest {
 /// This struct is used to receive a response from the Long Term Stats API
 /// It contains the circuit_id and the weight of the device
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct DeviceWeightResponse {
     #[pyo3(get)]
     pub circuit_id: String,

--- a/src/rust/lqos_python/src/lib.rs
+++ b/src/rust/lqos_python/src/lib.rs
@@ -36,6 +36,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+type PyObject = Py<PyAny>;
+
 // ===== Planner CBOR I/O =====
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
@@ -166,11 +168,11 @@ fn plan_top_level_cpu_bins(
     hysteresis_threshold: Option<f64>,
 ) -> PyResult<PyObject> {
     let items_any = items.bind(py);
-    let items_list = items_any.downcast::<PyList>()?;
+    let items_list = items_any.cast::<PyList>()?;
     let planner_items: Vec<lqos_config::TopLevelPlannerItem> = items_list
         .iter()
         .map(|item| -> PyResult<lqos_config::TopLevelPlannerItem> {
-            let dict = item.downcast::<PyDict>()?;
+            let dict = item.cast::<PyDict>()?;
             let id = get_string(dict, "id", String::new());
             let weight = get_f64(dict, "weight", 1.0);
             Ok(lqos_config::TopLevelPlannerItem { id, weight })
@@ -180,7 +182,7 @@ fn plan_top_level_cpu_bins(
     let prev_assign_map = match prev_assign {
         Some(obj) => {
             let any = obj.bind(py);
-            let dict = any.downcast::<PyDict>()?;
+            let dict = any.cast::<PyDict>()?;
             dict.iter()
                 .filter_map(|(k, v)| {
                     Some((k.extract::<String>().ok()?, v.extract::<String>().ok()?))
@@ -192,7 +194,7 @@ fn plan_top_level_cpu_bins(
     let last_change_map = match last_change_ts {
         Some(obj) => {
             let any = obj.bind(py);
-            let dict = any.downcast::<PyDict>()?;
+            let dict = any.cast::<PyDict>()?;
             dict.iter()
                 .filter_map(|(k, v)| Some((k.extract::<String>().ok()?, v.extract::<f64>().ok()?)))
                 .collect::<BTreeMap<_, _>>()
@@ -258,11 +260,11 @@ fn plan_class_identities(
     stick_offset: u16,
     circuit_padding: u32,
 ) -> PyResult<PyObject> {
-    let sites_list = sites.bind(py).downcast::<PyList>()?;
+    let sites_list = sites.bind(py).cast::<PyList>()?;
     let site_inputs: Vec<lqos_config::SiteIdentityInput> = sites_list
         .iter()
         .map(|item| -> PyResult<lqos_config::SiteIdentityInput> {
-            let dict = item.downcast::<PyDict>()?;
+            let dict = item.cast::<PyDict>()?;
             Ok(lqos_config::SiteIdentityInput {
                 site_key: get_string(dict, "site_key", String::new()),
                 parent_path: get_string(dict, "parent_path", String::new()),
@@ -272,14 +274,14 @@ fn plan_class_identities(
         })
         .collect::<PyResult<Vec<_>>>()?;
 
-    let groups_list = circuit_groups.bind(py).downcast::<PyList>()?;
+    let groups_list = circuit_groups.bind(py).cast::<PyList>()?;
     let circuit_group_inputs: Vec<lqos_config::CircuitIdentityGroupInput> = groups_list
         .iter()
         .map(|item| -> PyResult<lqos_config::CircuitIdentityGroupInput> {
-            let dict = item.downcast::<PyDict>()?;
+            let dict = item.cast::<PyDict>()?;
             let ids = match dict.get_item("circuit_ids")? {
                 Some(value) => value
-                    .downcast::<PyList>()?
+                    .cast::<PyList>()?
                     .iter()
                     .filter_map(|entry| entry.extract::<String>().ok())
                     .collect::<Vec<_>>(),
@@ -295,11 +297,11 @@ fn plan_class_identities(
 
     let previous_sites = match site_state {
         Some(obj) => {
-            let dict = obj.bind(py).downcast::<PyDict>()?;
+            let dict = obj.bind(py).cast::<PyDict>()?;
             dict.iter()
                 .filter_map(|(k, v)| {
                     let key = k.extract::<String>().ok()?;
-                    let entry = v.downcast::<PyDict>().ok()?;
+                    let entry = v.cast::<PyDict>().ok()?;
                     Some((
                         key,
                         lqos_config::PlannerSiteIdentityState {
@@ -318,11 +320,11 @@ fn plan_class_identities(
 
     let previous_circuits = match circuit_state {
         Some(obj) => {
-            let dict = obj.bind(py).downcast::<PyDict>()?;
+            let dict = obj.bind(py).cast::<PyDict>()?;
             dict.iter()
                 .filter_map(|(k, v)| {
                     let key = k.extract::<String>().ok()?;
-                    let entry = v.downcast::<PyDict>().ok()?;
+                    let entry = v.cast::<PyDict>().ok()?;
                     Some((
                         key,
                         lqos_config::PlannerCircuitIdentityState {
@@ -411,7 +413,7 @@ fn plan_class_identities(
 fn write_planner_cbor(py: Python, path: String, state: PyObject) -> PyResult<bool> {
     use std::fs;
     use std::io::Write;
-    let dict = state.downcast_bound::<pyo3::types::PyDict>(py)?;
+    let dict = state.cast_bound::<pyo3::types::PyDict>(py)?;
     // Build strongly typed struct, preserving integer keys
     let algo_version = get_string(dict, "algo_version", default_algo_version());
     let updated_at = get_f64(dict, "updated_at", 0.0);
@@ -420,7 +422,7 @@ fn write_planner_cbor(py: Python, path: String, state: PyObject) -> PyResult<boo
     let site_count = get_i64(dict, "site_count", 0);
     let mut site_names: Vec<i64> = Vec::new();
     if let Ok(Some(sn)) = dict.get_item("site_names")
-        && let Ok(list) = sn.downcast::<pyo3::types::PyList>()
+        && let Ok(list) = sn.cast::<pyo3::types::PyList>()
     {
         for item in list.iter() {
             if let Some(n) = to_i64_any(&item) {
@@ -431,11 +433,11 @@ fn write_planner_cbor(py: Python, path: String, state: PyObject) -> PyResult<boo
     // site_map
     let mut site_map: BTreeMap<i64, PlannerSiteEntry> = BTreeMap::new();
     if let Ok(Some(sm_any)) = dict.get_item("site_map")
-        && let Ok(sm_dict) = sm_any.downcast::<pyo3::types::PyDict>()
+        && let Ok(sm_dict) = sm_any.cast::<pyo3::types::PyDict>()
     {
         for (k, v) in sm_dict.iter() {
             if let Some(key) = to_i64_any(&k)
-                && let Ok(entry) = v.downcast::<pyo3::types::PyDict>()
+                && let Ok(entry) = v.cast::<pyo3::types::PyDict>()
             {
                 let cpu = get_i64(entry, "cpu", 0);
                 let major = get_i64(entry, "major", 0);
@@ -459,11 +461,11 @@ fn write_planner_cbor(py: Python, path: String, state: PyObject) -> PyResult<boo
     // circuit_map
     let mut circuit_map: BTreeMap<i64, PlannerCircuitEntry> = BTreeMap::new();
     if let Ok(Some(cm_any)) = dict.get_item("circuit_map")
-        && let Ok(cm_dict) = cm_any.downcast::<pyo3::types::PyDict>()
+        && let Ok(cm_dict) = cm_any.cast::<pyo3::types::PyDict>()
     {
         for (k, v) in cm_dict.iter() {
             if let Some(key) = to_i64_any(&k)
-                && let Ok(entry) = v.downcast::<pyo3::types::PyDict>()
+                && let Ok(entry) = v.cast::<pyo3::types::PyDict>()
             {
                 let cpu = get_i64(entry, "cpu", 0);
                 let major = get_i64(entry, "major", 0);
@@ -740,7 +742,7 @@ fn fetch_planner_remote(
 #[pyfunction]
 fn store_planner_remote(py: Python, state: PyObject) -> PyResult<bool> {
     // Extract needed values and serialize as compressed CBOR
-    let dict = state.downcast_bound::<pyo3::types::PyDict>(py)?;
+    let dict = state.cast_bound::<pyo3::types::PyDict>(py)?;
     let algo_version = get_string(dict, "algo_version", default_algo_version());
     let updated_at = get_f64(dict, "updated_at", 0.0);
     let queues_available = get_i64(dict, "queuesAvailable", 0);
@@ -749,7 +751,7 @@ fn store_planner_remote(py: Python, state: PyObject) -> PyResult<bool> {
     // site_names
     let mut site_names: Vec<i64> = Vec::new();
     if let Ok(Some(sn)) = dict.get_item("site_names")
-        && let Ok(list) = sn.downcast::<pyo3::types::PyList>()
+        && let Ok(list) = sn.cast::<pyo3::types::PyList>()
     {
         for item in list.iter() {
             if let Some(n) = to_i64_any(&item) {
@@ -760,11 +762,11 @@ fn store_planner_remote(py: Python, state: PyObject) -> PyResult<bool> {
     // site_map
     let mut site_map: BTreeMap<i64, PlannerSiteEntry> = BTreeMap::new();
     if let Ok(Some(sm_any)) = dict.get_item("site_map")
-        && let Ok(sm_dict) = sm_any.downcast::<pyo3::types::PyDict>()
+        && let Ok(sm_dict) = sm_any.cast::<pyo3::types::PyDict>()
     {
         for (k, v) in sm_dict.iter() {
             if let Some(key) = to_i64_any(&k)
-                && let Ok(entry) = v.downcast::<pyo3::types::PyDict>()
+                && let Ok(entry) = v.cast::<pyo3::types::PyDict>()
             {
                 let cpu = get_i64(entry, "cpu", 0);
                 let major = get_i64(entry, "major", 0);
@@ -788,11 +790,11 @@ fn store_planner_remote(py: Python, state: PyObject) -> PyResult<bool> {
     // circuit_map
     let mut circuit_map: BTreeMap<i64, PlannerCircuitEntry> = BTreeMap::new();
     if let Ok(Some(cm_any)) = dict.get_item("circuit_map")
-        && let Ok(cm_dict) = cm_any.downcast::<pyo3::types::PyDict>()
+        && let Ok(cm_dict) = cm_any.cast::<pyo3::types::PyDict>()
     {
         for (k, v) in cm_dict.iter() {
             if let Some(key) = to_i64_any(&k)
-                && let Ok(entry) = v.downcast::<pyo3::types::PyDict>()
+                && let Ok(entry) = v.cast::<pyo3::types::PyDict>()
             {
                 let cpu = get_i64(entry, "cpu", 0);
                 let major = get_i64(entry, "major", 0);

--- a/src/rust/lqos_topology/src/lib.rs
+++ b/src/rust/lqos_topology/src/lib.rs
@@ -2757,12 +2757,16 @@ fn resolved_auto_queue_visibility_policy(
     if !queue_auto_node_kind_can_hide(tree_node) {
         return TopologyQueueVisibilityPolicy::QueueVisible;
     }
-    if child_branch_counts
+    let logical_child_count = child_branch_counts
         .get(ui_node.node_id.as_str())
         .copied()
-        .unwrap_or_default()
-        == 0
-    {
+        .unwrap_or_default();
+    let effective_child_count = tree_node
+        .get("children")
+        .and_then(Value::as_object)
+        .map(Map::len)
+        .unwrap_or_default();
+    if logical_child_count == 0 && effective_child_count == 0 {
         return TopologyQueueVisibilityPolicy::QueueVisible;
     }
     let threshold = config.topology.queue_auto_virtualize_threshold_mbps;
@@ -7034,6 +7038,36 @@ mod tests {
             .as_object()
             .expect("Aggregation Switch should retain its logical children");
         assert!(aggregation_children.get("Access AP").is_some());
+    }
+
+    #[test]
+    fn queue_auto_marks_large_ap_branch_virtual_with_effective_tree_children() {
+        let (config, canonical, mut editor_state, effective) = ap_branch_fixture();
+        let access_ap = editor_state
+            .nodes
+            .iter_mut()
+            .find(|node| node.node_id == "ap-child")
+            .expect("fixture should include Access AP");
+        access_ap.current_parent_node_id = Some("site-root".to_string());
+        access_ap.current_parent_node_name = Some("Core".to_string());
+
+        let effective_network = apply_effective_topology_to_network_json(
+            &config,
+            &canonical,
+            &editor_state,
+            &effective,
+        );
+        let root = effective_network
+            .as_object()
+            .expect("effective export should remain an object tree");
+        let aggregation = root["Core"]["children"]["Aggregation Switch"]
+            .as_object()
+            .expect("Aggregation Switch should remain visible as a virtual node");
+
+        assert_eq!(
+            aggregation.get("virtual").and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[test]

--- a/src/rust/lqos_topology/src/lib.rs
+++ b/src/rust/lqos_topology/src/lib.rs
@@ -2754,11 +2754,7 @@ fn resolved_auto_queue_visibility_policy(
     let Some(tree_node) = tree_node.and_then(Value::as_object) else {
         return TopologyQueueVisibilityPolicy::QueueVisible;
     };
-    let is_site = tree_node
-        .get("type")
-        .and_then(Value::as_str)
-        .is_some_and(|kind| kind.eq_ignore_ascii_case("site"));
-    if !is_site {
+    if !queue_auto_node_kind_can_hide(tree_node) {
         return TopologyQueueVisibilityPolicy::QueueVisible;
     }
     if child_branch_counts
@@ -2778,6 +2774,13 @@ fn resolved_auto_queue_visibility_policy(
     } else {
         TopologyQueueVisibilityPolicy::QueueVisible
     }
+}
+
+fn queue_auto_node_kind_can_hide(tree_node: &Map<String, Value>) -> bool {
+    tree_node
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| matches!(kind.to_ascii_lowercase().as_str(), "site" | "ap"))
 }
 
 fn apply_effective_topology_reparenting_only(
@@ -6867,6 +6870,201 @@ mod tests {
             .as_object()
             .expect("Aggregation should retain its logical children");
         assert!(aggregation_children.get("Edge POP").is_some());
+    }
+
+    fn ap_branch_fixture() -> (
+        Config,
+        Value,
+        TopologyEditorStateFile,
+        TopologyEffectiveStateFile,
+    ) {
+        let mut config = Config::default();
+        config.uisp_integration.enable_uisp = true;
+        config.topology.queue_auto_virtualize_threshold_mbps = 5_000;
+
+        let editor_state = TopologyEditorStateFile {
+            schema_version: 1,
+            source: "uisp/full2".to_string(),
+            generated_unix: None,
+            ingress_identity: None,
+            nodes: vec![
+                TopologyEditorNode {
+                    node_id: "site-root".to_string(),
+                    node_name: "Core".to_string(),
+                    latitude: None,
+                    longitude: None,
+                    current_parent_node_id: None,
+                    current_parent_node_name: None,
+                    current_attachment_id: None,
+                    current_attachment_name: None,
+                    can_move: false,
+                    allowed_parents: Vec::new(),
+                    queue_visibility_policy: TopologyQueueVisibilityPolicy::QueueVisible,
+                    preferred_attachment_id: None,
+                    preferred_attachment_name: None,
+                    effective_attachment_id: None,
+                    effective_attachment_name: None,
+                },
+                TopologyEditorNode {
+                    node_id: "ap-agg".to_string(),
+                    node_name: "Aggregation Switch".to_string(),
+                    latitude: None,
+                    longitude: None,
+                    current_parent_node_id: Some("site-root".to_string()),
+                    current_parent_node_name: Some("Core".to_string()),
+                    current_attachment_id: None,
+                    current_attachment_name: None,
+                    can_move: false,
+                    allowed_parents: Vec::new(),
+                    queue_visibility_policy: TopologyQueueVisibilityPolicy::QueueVisible,
+                    preferred_attachment_id: None,
+                    preferred_attachment_name: None,
+                    effective_attachment_id: None,
+                    effective_attachment_name: None,
+                },
+                TopologyEditorNode {
+                    node_id: "ap-child".to_string(),
+                    node_name: "Access AP".to_string(),
+                    latitude: None,
+                    longitude: None,
+                    current_parent_node_id: Some("ap-agg".to_string()),
+                    current_parent_node_name: Some("Aggregation Switch".to_string()),
+                    current_attachment_id: None,
+                    current_attachment_name: None,
+                    can_move: false,
+                    allowed_parents: Vec::new(),
+                    queue_visibility_policy: TopologyQueueVisibilityPolicy::QueueVisible,
+                    preferred_attachment_id: None,
+                    preferred_attachment_name: None,
+                    effective_attachment_id: None,
+                    effective_attachment_name: None,
+                },
+            ],
+        };
+
+        let canonical = json!({
+            "Core": {
+                "children": {
+                    "Aggregation Switch": {
+                        "children": {
+                            "Access AP": {
+                                "children": {},
+                                "downloadBandwidthMbps": 1000,
+                                "id": "ap-child",
+                                "name": "Access AP",
+                                "type": "AP",
+                                "uploadBandwidthMbps": 1000
+                            }
+                        },
+                        "downloadBandwidthMbps": 10000,
+                        "id": "ap-agg",
+                        "name": "Aggregation Switch",
+                        "type": "AP",
+                        "uploadBandwidthMbps": 10000
+                    }
+                },
+                "downloadBandwidthMbps": 20000,
+                "id": "site-root",
+                "name": "Core",
+                "type": "Site",
+                "uploadBandwidthMbps": 20000
+            }
+        });
+
+        let effective = TopologyEffectiveStateFile {
+            schema_version: 1,
+            generated_unix: None,
+            canonical_generated_unix: None,
+            health_generated_unix: None,
+            nodes: vec![
+                TopologyEffectiveNodeState {
+                    node_id: "site-root".to_string(),
+                    logical_parent_node_id: String::new(),
+                    preferred_attachment_id: None,
+                    effective_attachment_id: None,
+                    fallback_reason: None,
+                    all_attachments_suppressed: false,
+                    attachments: vec![],
+                },
+                TopologyEffectiveNodeState {
+                    node_id: "ap-agg".to_string(),
+                    logical_parent_node_id: "site-root".to_string(),
+                    preferred_attachment_id: None,
+                    effective_attachment_id: None,
+                    fallback_reason: None,
+                    all_attachments_suppressed: false,
+                    attachments: vec![],
+                },
+                TopologyEffectiveNodeState {
+                    node_id: "ap-child".to_string(),
+                    logical_parent_node_id: "ap-agg".to_string(),
+                    preferred_attachment_id: None,
+                    effective_attachment_id: None,
+                    fallback_reason: None,
+                    all_attachments_suppressed: false,
+                    attachments: vec![],
+                },
+            ],
+        };
+
+        (config, canonical, editor_state, effective)
+    }
+
+    #[test]
+    fn queue_auto_marks_large_ap_branch_virtual_without_treeguard() {
+        let (config, canonical, editor_state, effective) = ap_branch_fixture();
+
+        let effective_network = apply_effective_topology_to_network_json(
+            &config,
+            &canonical,
+            &editor_state,
+            &effective,
+        );
+        let root = effective_network
+            .as_object()
+            .expect("effective export should remain an object tree");
+        let aggregation = root["Core"]["children"]["Aggregation Switch"]
+            .as_object()
+            .expect("Aggregation Switch should remain visible as a virtual node");
+        assert_eq!(
+            aggregation.get("virtual").and_then(Value::as_bool),
+            Some(true)
+        );
+        let aggregation_children = aggregation["children"]
+            .as_object()
+            .expect("Aggregation Switch should retain its logical children");
+        assert!(aggregation_children.get("Access AP").is_some());
+    }
+
+    #[test]
+    fn queue_auto_keeps_large_ap_branch_visible_with_direct_circuit() {
+        let (config, canonical, editor_state, effective) = ap_branch_fixture();
+        let virtualization = QueueVirtualizationContext {
+            direct_circuit_node_ids: HashSet::from(["ap-agg".to_string()]),
+            forced_visible_node_names: HashSet::new(),
+        };
+        let canonical_state = TopologyCanonicalStateFile::from_editor_and_network(
+            &editor_state,
+            &canonical,
+            TopologyCanonicalIngressKind::NativeIntegration,
+        );
+
+        let effective_network = apply_effective_topology_to_network_json_from_canonical(
+            &config,
+            &canonical,
+            &canonical_state,
+            &editor_state,
+            &effective,
+            &virtualization,
+        );
+        let root = effective_network
+            .as_object()
+            .expect("effective export should remain an object tree");
+        let aggregation = root["Core"]["children"]["Aggregation Switch"]
+            .as_object()
+            .expect("Aggregation Switch should remain exported");
+
+        assert_eq!(aggregation.get("virtual").and_then(Value::as_bool), None);
     }
 
     #[test]

--- a/src/systemd_hotfix.sh
+++ b/src/systemd_hotfix.sh
@@ -175,6 +175,15 @@ apt_candidate_has_hotfix_repo() {
         -v version="$version" \
         -v repo_url="$repo_url" \
         -v dist_component="${HOTFIX_REPO_DIST}/${HOTFIX_REPO_COMPONENT}" '
+        function normalized_url(url) {
+            sub(/\/+$/, "", url)
+            return url
+        }
+
+        BEGIN {
+            repo_url = normalized_url(repo_url)
+        }
+
         ($1 == "***" && $2 == version) || ($1 == version && $2 ~ /^[0-9]+$/) {
             in_version = 1
             next
@@ -184,9 +193,50 @@ apt_candidate_has_hotfix_repo() {
             in_version = 0
         }
 
-        in_version && $1 ~ /^[0-9]+$/ && $2 == repo_url && $3 == dist_component {
+        in_version && $1 ~ /^[0-9]+$/ && normalized_url($2) == repo_url && $3 == dist_component {
             found = 1
             exit
+        }
+
+        END { if (!found) exit 1 }
+    '
+}
+
+apt_madison_has_hotfix_repo() {
+    local package="$1"
+    local version="$2"
+    local repo_url="${HOTFIX_REPO_URL%/}"
+
+    LC_ALL=C apt-cache madison "$package" | awk \
+        -F '|' \
+        -v version="$version" \
+        -v repo_url="$repo_url" \
+        -v dist_component="${HOTFIX_REPO_DIST}/${HOTFIX_REPO_COMPONENT}" '
+        function trim(text) {
+            gsub(/^[ \t]+|[ \t]+$/, "", text)
+            return text
+        }
+
+        function normalized_url(url) {
+            sub(/\/+$/, "", url)
+            return url
+        }
+
+        BEGIN {
+            repo_url = normalized_url(repo_url)
+        }
+
+        {
+            candidate_version = trim($2)
+            source = trim($3)
+            split(source, source_parts, /[ \t]+/)
+
+            if (candidate_version == version &&
+                normalized_url(source_parts[1]) == repo_url &&
+                source_parts[2] == dist_component) {
+                found = 1
+                exit
+            }
         }
 
         END { if (!found) exit 1 }
@@ -211,7 +261,9 @@ resolve_hotfix_package_version() {
         [[ "$priority" =~ ^[0-9]+$ ]] || fail "Unable to verify LibreQoS APT pin priority for $package=$version."
         (( priority >= 1001 )) || fail "APT candidate for $package=$version is not pinned from the LibreQoS hotfix repo."
         # apt-cache reports the pin on the version line; the matching source line can remain at archive priority 500.
-        apt_candidate_has_hotfix_repo "$package" "$version" || fail "APT candidate for $package=$version is not from $HOTFIX_REPO_URL $HOTFIX_REPO_DIST/$HOTFIX_REPO_COMPONENT."
+        apt_candidate_has_hotfix_repo "$package" "$version" || \
+            apt_madison_has_hotfix_repo "$package" "$version" || \
+            fail "APT candidate for $package=$version is not from $HOTFIX_REPO_URL $HOTFIX_REPO_DIST/$HOTFIX_REPO_COMPONENT."
 
         if [[ -z "${resolved_version:-}" ]]; then
             resolved_version="$version"

--- a/src/test_systemd_hotfix.py
+++ b/src/test_systemd_hotfix.py
@@ -77,10 +77,13 @@ class SystemdHotfixScriptTest(unittest.TestCase):
                 #!/bin/sh
                 [ "${HOTFIX_TEST_APT_CACHE_FAIL:-0}" = "1" ] && exit 12
 
+                command="$1"
                 package="$2"
                 version="${HOTFIX_TEST_CANDIDATE_VERSION:-255.4-1ubuntu9999+libreqos1}"
                 priority="${HOTFIX_TEST_CANDIDATE_PRIORITY:-1001}"
                 repo_line="${HOTFIX_TEST_REPO_LINE:-        500 https://repo.libreqos.com noble/main amd64 Packages}"
+                madison_repo_url="${HOTFIX_TEST_MADISON_REPO_URL:-https://repo.libreqos.com}"
+                madison_dist_component="${HOTFIX_TEST_MADISON_DIST_COMPONENT:-noble/main}"
 
                 case ",${HOTFIX_TEST_INCONSISTENT_PACKAGES:-}," in
                   *,"$package",*) version="${HOTFIX_TEST_OTHER_VERSION:-255.4-1ubuntu9999+libreqos2}" ;;
@@ -88,6 +91,11 @@ class SystemdHotfixScriptTest(unittest.TestCase):
 
                 if [ "${HOTFIX_TEST_NO_CANDIDATE_FOR:-}" = "$package" ]; then
                   version="(none)"
+                fi
+
+                if [ "$command" = "madison" ]; then
+                  printf '   %s | %s | %s %s amd64 Packages\\n' "$package" "$version" "$madison_repo_url" "$madison_dist_component"
+                  exit 0
                 fi
 
                 cat <<POLICY
@@ -161,6 +169,29 @@ class SystemdHotfixScriptTest(unittest.TestCase):
         self.assertNotIn("libnss-resolve=", apt_log)
         self.assertIn("package_version=255.4-1ubuntu9999+libreqos1", marker)
 
+    def test_auto_accepts_policy_repo_url_with_trailing_slash(self):
+        result, apt_log, marker = self.run_install(
+            {
+                "HOTFIX_TEST_REPO_LINE": (
+                    "        500 https://repo.libreqos.com/ noble/main amd64 Packages"
+                ),
+                "HOTFIX_TEST_MADISON_REPO_URL": "https://example.invalid",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("systemd=255.4-1ubuntu9999+libreqos1", apt_log)
+        self.assertIn("package_version=255.4-1ubuntu9999+libreqos1", marker)
+
+    def test_auto_uses_madison_when_policy_source_line_is_unrecognized(self):
+        result, apt_log, marker = self.run_install(
+            {"HOTFIX_TEST_REPO_LINE": "        release o=LibreQoS,l=LibreQoS,n=noble"}
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("systemd=255.4-1ubuntu9999+libreqos1", apt_log)
+        self.assertIn("package_version=255.4-1ubuntu9999+libreqos1", marker)
+
     def test_auto_rejects_ubuntu_candidate(self):
         result, _, _ = self.run_install(
             {"HOTFIX_TEST_CANDIDATE_VERSION": "255.4-1ubuntu8.16"}
@@ -198,7 +229,8 @@ class SystemdHotfixScriptTest(unittest.TestCase):
             {
                 "HOTFIX_TEST_REPO_LINE": (
                     "        500 https://example.invalid noble/main amd64 Packages"
-                )
+                ),
+                "HOTFIX_TEST_MADISON_REPO_URL": "https://example.invalid",
             }
         )
 
@@ -210,7 +242,8 @@ class SystemdHotfixScriptTest(unittest.TestCase):
             {
                 "HOTFIX_TEST_REPO_LINE": (
                     "        500 https://repo.libreqos.com.evil noble/main amd64 Packages"
-                )
+                ),
+                "HOTFIX_TEST_MADISON_REPO_URL": "https://repo.libreqos.com.evil",
             }
         )
 


### PR DESCRIPTION
## Summary

This PR improves Queue Auto topology virtualization so large high-capacity `Site` and `AP` branches can be hidden from the physical HTB queue tree and have their children promoted for CPU placement.

The motivating case is a large imported topology where auto-virtualization was working for high-capacity site containers, but large AP/uplink/aggregation branches below those sites remained physical queue nodes. That left most circuits under one CPU queue even though the logical topology had enough child branches to distribute load.

Queue Auto now applies the same threshold rule to eligible `AP` branches as it already did for eligible `Site` branches:

- node kind must be `Site` or `AP`
- node must have child queue branches
- final effective node rate must be at or above `queue_auto_virtualize_threshold_mbps`
- nodes with directly attached circuits remain queue-visible
- forced-visible overrides remain respected

This keeps the change focused on known topology node kinds and avoids auto-hiding arbitrary custom node types.

## What Changed

### Queue Auto eligibility

- Added an explicit Queue Auto eligibility predicate for `Site` and `AP` node kinds.
- Removed the previous Site-only restriction that kept high-capacity AP/uplink/aggregation branches physical even when they were safe to promote.
- Preserved the existing child-branch, capacity-threshold, direct-circuit, and forced-visible safeguards.
- Clarified `QueueVisible` RustDoc to reflect current baseline behavior: visible nodes can still be hidden by automatic high-capacity branch rules.
- Updated the topology threshold RustDoc to describe eligible high-capacity `Site` and `AP` branches.

### Regression coverage

- Added a synthetic AP aggregation branch fixture.
- Added a positive regression proving a high-capacity AP branch with children becomes virtual under Queue Auto.
- Added a negative regression proving a high-capacity AP branch with a directly attached circuit remains physical.