### PR TITLE
Reduce ALL_FLOWS lock contention

### DIFF
--- a/src/rust/lqosd/src/lts2_sys/control_channel.rs
+++ b/src/rust/lqosd/src/lts2_sys/control_channel.rs
@@ -16,7 +16,9 @@ use crate::lts2_sys::lts2_client::{LicenseStatus, set_license_status};
 use lqos_probe::ProbeClass;
 
 mod messages;
-use crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection;
+use crate::throughput_tracker::{
+    flow_data::for_each_active_flow_for_circuit, retire_check, THROUGHPUT_TRACKER,
+};
 pub use messages::{
     RemoteInsightRequest, SupportTicket, SupportTicketComment, SupportTicketStatus,
     SupportTicketSummary, WsMessage,
@@ -26,6 +28,7 @@ const SHAPER_VERSION_STRING: &str = include_str!("../../../../VERSION_STRING");
 const CONTROL_CHANNEL_QUEUE_DEPTH: usize = 256;
 const CONNECTION_COMMAND_QUEUE_DEPTH: usize = 1024;
 const SOCKET_SENDER_QUEUE_DEPTH: usize = 32;
+const STREAMING_CIRCUIT_FLOW_WINDOW: Duration = Duration::from_secs(300);
 
 type ControlSocketWriter = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 
@@ -1412,45 +1415,76 @@ async fn shaper_snapshot_streaming(
     Ok(())
 }
 
+#[derive(Serialize, Deserialize)]
+struct DeviceSnapshot {
+    device_id: String,
+    device_name: String,
+    addresses: Vec<(std::net::IpAddr, u8)>,
+    last_ping_ms: Option<f32>,
+    bits_per_second: (u64, u64),
+    median_tcp_rtt_ms: Option<f32>,
+    tcp_retransmit_pct: (f64, f64),
+}
+
+#[derive(Serialize, Deserialize)]
+struct FlowSnapshot {
+    remote_ip: std::net::IpAddr,
+    local_ip: std::net::IpAddr,
+    src_port: u16,
+    dst_port: u16,
+    ip_protocol: u8,
+    // Legacy Insight field name; payload value is the flow age at snapshot time.
+    #[serde(rename = "last_seen_nanos")]
+    age_nanos_wire: u64,
+    rate_bps: (u32, u32),
+    bytes_sent: (u64, u64),
+    packets_sent: (u64, u64),
+    tcp_retransmits: (u16, u16),
+    rtt_ms: (f32, f32),
+}
+
+#[derive(Serialize, Deserialize)]
+struct StreamingCircuitPayload {
+    devices: Vec<DeviceSnapshot>,
+    flows: Vec<FlowSnapshot>,
+}
+
+fn streaming_circuit_flow_snapshots(
+    circuit_hash: i64,
+    now_nanos: u64,
+) -> Vec<FlowSnapshot> {
+    let five_minutes_ago =
+        now_nanos.saturating_sub(STREAMING_CIRCUIT_FLOW_WINDOW.as_nanos() as u64);
+    let mut flows_out = Vec::new();
+
+    for_each_active_flow_for_circuit(circuit_hash, five_minutes_ago, |flow| {
+        let rtt_ms = (
+            flow.rtt_nanos.down as f32 / 1_000_000.0,
+            flow.rtt_nanos.up as f32 / 1_000_000.0,
+        );
+        flows_out.push(FlowSnapshot {
+            remote_ip: flow.key.remote_ip.as_ip(),
+            local_ip: flow.key.local_ip.as_ip(),
+            src_port: flow.key.src_port,
+            dst_port: flow.key.dst_port,
+            ip_protocol: flow.key.ip_protocol,
+            age_nanos_wire: flow.age_nanos(now_nanos),
+            rate_bps: (flow.rate_estimate_bps.down, flow.rate_estimate_bps.up),
+            bytes_sent: (flow.bytes_sent.down, flow.bytes_sent.up),
+            packets_sent: (flow.packets_sent.down, flow.packets_sent.up),
+            tcp_retransmits: (flow.tcp_retransmits.down, flow.tcp_retransmits.up),
+            rtt_ms,
+        });
+    });
+
+    flows_out
+}
+
 async fn circuit_snapshot_streaming(
     request_id: u64,
     circuit_hash: i64,
     reply: tokio::sync::mpsc::Sender<Message>,
 ) -> anyhow::Result<()> {
-    #[derive(Serialize, Deserialize)]
-    struct DeviceSnapshot {
-        device_id: String,
-        device_name: String,
-        addresses: Vec<(std::net::IpAddr, u8)>,
-        last_ping_ms: Option<f32>,
-        // down, up bits per second
-        bits_per_second: (u64, u64),
-        median_tcp_rtt_ms: Option<f32>,
-        // down, up retransmit percentage
-        tcp_retransmit_pct: (f64, f64),
-    }
-
-    #[derive(Serialize, Deserialize)]
-    struct FlowSnapshot {
-        remote_ip: std::net::IpAddr,
-        local_ip: std::net::IpAddr,
-        src_port: u16,
-        dst_port: u16,
-        ip_protocol: u8,
-        last_seen_nanos: u64,
-        // Down/Up tuples for compact transport
-        rate_bps: (u32, u32),
-        bytes_sent: (u64, u64),
-        packets_sent: (u64, u64),
-        tcp_retransmits: (u16, u16),
-        rtt_ms: (f32, f32),
-    }
-
-    #[derive(Serialize, Deserialize)]
-    struct StreamingCircuitPayload {
-        devices: Vec<DeviceSnapshot>,
-        flows: Vec<FlowSnapshot>,
-    }
 
     // Helper: choose a host IP for ping (only /32 or /128)
     fn choose_host_ip(
@@ -1496,20 +1530,26 @@ async fn circuit_snapshot_streaming(
 
     // Aggregation holders per device hash
     use lqos_utils::units::{DownUpOrder, down_up_divide};
-    struct Agg {
+    #[derive(Default)]
+    struct DeviceTrafficAggregate {
         bps_bytes: DownUpOrder<u64>,
         tcp_packets: DownUpOrder<u64>,
         tcp_retries: DownUpOrder<u64>,
         rtts: Vec<f32>,
     }
-    let mut aggregates: std::collections::HashMap<i64, Agg> = std::collections::HashMap::new();
+    let mut aggregates: std::collections::HashMap<i64, DeviceTrafficAggregate> =
+        std::collections::HashMap::new();
 
     // Walk raw throughput data and fold into devices of this circuit
     {
-        let raw = crate::throughput_tracker::THROUGHPUT_TRACKER
-            .raw_data
-            .lock();
+        let raw_cycle = THROUGHPUT_TRACKER
+            .cycle
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let raw = THROUGHPUT_TRACKER.raw_data.lock();
         for (xdp_ip, te) in raw.iter() {
+            if !retire_check(raw_cycle, te.most_recent_cycle) {
+                continue;
+            }
             let device = catalog
                 .device_by_hashes(te.device_hash, te.circuit_hash)
                 .or_else(|| {
@@ -1522,17 +1562,10 @@ async fn circuit_snapshot_streaming(
             if !matches_desired {
                 continue;
             }
-            // retire_check is local; use the same heuristic: require most_recent_cycle >= tp_cycle - RETIRE_AFTER_SECONDS
-            // We don't have RETIRE_AFTER_SECONDS here; accept all entries for snapshot.
             let Some(device_hash) = device.map(|device| device.device_hash) else {
                 continue;
             };
-            let agg = aggregates.entry(device_hash).or_insert_with(|| Agg {
-                bps_bytes: DownUpOrder::zeroed(),
-                tcp_packets: DownUpOrder::zeroed(),
-                tcp_retries: DownUpOrder::zeroed(),
-                rtts: Vec::new(),
-            });
+            let agg = aggregates.entry(device_hash).or_default();
             // bytes_per_second -> later convert to bits
             agg.bps_bytes += te.bytes_per_second;
             agg.tcp_packets += te.tcp_packets;
@@ -1547,12 +1580,7 @@ async fn circuit_snapshot_streaming(
     // Build device snapshots
     let mut devices_out: Vec<DeviceSnapshot> = Vec::new();
     for dev in circuit_devices {
-        let agg = aggregates.remove(&dev.device_hash).unwrap_or(Agg {
-            bps_bytes: DownUpOrder::zeroed(),
-            tcp_packets: DownUpOrder::zeroed(),
-            tcp_retries: DownUpOrder::zeroed(),
-            rtts: Vec::new(),
-        });
+        let agg = aggregates.remove(&dev.device_hash).unwrap_or_default();
         // Compact addresses into a single list
         let mut addresses: Vec<(std::net::IpAddr, u8)> = Vec::new();
         addresses.extend(
@@ -1606,51 +1634,12 @@ async fn circuit_snapshot_streaming(
         });
     }
 
-    // Build flow snapshots for this circuit (recent, last 5 minutes)
-    let mut flows_out: Vec<FlowSnapshot> = Vec::new();
-    if let Ok(now_ts) = lqos_utils::unix_time::time_since_boot() {
-        let now_nanos = std::time::Duration::from(now_ts).as_nanos() as u64;
-        let five_minutes_ago = now_nanos.saturating_sub(300 * 1_000_000_000);
-        let all_flows = crate::throughput_tracker::flow_data::ALL_FLOWS.lock();
-        for (key, (local, ..)) in all_flows.flow_data.iter() {
-            if local.last_seen < five_minutes_ago {
-                continue;
-            }
-            let device = catalog
-                .device_by_hashes(local.device_hash, local.circuit_hash)
-                .or_else(|| {
-                    catalog
-                        .device_longest_match_for_ip(&key.local_ip)
-                        .map(|(_, device)| device)
-                });
-            let matches_desired = local.circuit_hash == Some(circuit_hash)
-                || device.is_some_and(|device| device.circuit_hash == circuit_hash);
-            if !matches_desired {
-                continue;
-            }
-
-            let local_ip_addr = key.local_ip.as_ip();
-            let remote_ip_addr = key.remote_ip.as_ip();
-
-            let rtt_ms = (
-                local.get_summary_rtt_as_millis(FlowbeeEffectiveDirection::Download) as f32,
-                local.get_summary_rtt_as_millis(FlowbeeEffectiveDirection::Upload) as f32,
-            );
-            flows_out.push(FlowSnapshot {
-                remote_ip: remote_ip_addr,
-                local_ip: local_ip_addr,
-                src_port: key.src_port,
-                dst_port: key.dst_port,
-                ip_protocol: key.ip_protocol,
-                last_seen_nanos: now_nanos.saturating_sub(local.last_seen),
-                rate_bps: (local.rate_estimate_bps.down, local.rate_estimate_bps.up),
-                bytes_sent: (local.bytes_sent.down, local.bytes_sent.up),
-                packets_sent: (local.packets_sent.down, local.packets_sent.up),
-                tcp_retransmits: (local.tcp_retransmits.down, local.tcp_retransmits.up),
-                rtt_ms,
-            });
-        }
-    }
+    let flows_out = lqos_utils::unix_time::time_since_boot()
+        .map(|now_ts| {
+            let now_nanos = std::time::Duration::from(now_ts).as_nanos() as u64;
+            streaming_circuit_flow_snapshots(circuit_hash, now_nanos)
+        })
+        .unwrap_or_default();
 
     let payload = StreamingCircuitPayload {
         devices: devices_out,
@@ -1761,6 +1750,16 @@ async fn tree_snapshot_streaming(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{ActiveFlowSnapshotTestContext, active_flow_entry};
+    use crate::throughput_tracker::{replace_raw_throughput_for_test, RawThroughputTestEntry};
+    use crate::throughput_tracker::flow_data::{
+        FlowbeeEffectiveDirection, RttBuffer, RttData, replace_active_flows_for_test,
+        replace_active_flows_live_for_test,
+    };
+    use lqos_config::ShapedDevice;
+    use lqos_utils::units::DownUpOrder;
+    use lqos_utils::hash_to_i64;
+    use std::net::Ipv4Addr;
 
     #[test]
     fn encode_ws_binary_round_trips_begin_ingest() {
@@ -1787,5 +1786,255 @@ mod tests {
             }
             other => panic!("unexpected decoded message: {other:?}"),
         }
+    }
+
+    #[test]
+    fn streaming_circuit_flow_snapshots_filter_snapshot_by_age_and_circuit() {
+        let _ctx = ActiveFlowSnapshotTestContext::with_shaped_devices(
+            "streaming-circuit-test",
+            vec![ShapedDevice {
+                circuit_id: "insight-circuit".to_string(),
+                circuit_name: "Insight Circuit".to_string(),
+                device_id: "insight-device".to_string(),
+                device_name: "Insight Device".to_string(),
+                parent_node: "Parent".to_string(),
+                ipv4: vec![(Ipv4Addr::new(192, 0, 2, 52), 32)],
+                ..Default::default()
+            }],
+        );
+        let circuit_hash = hash_to_i64("insight-circuit");
+        let now_nanos = 1_000_000_000_000;
+        let mut hash_matched = active_flow_entry(
+            [192, 0, 2, 99],
+            [198, 51, 100, 62],
+            50_002,
+            now_nanos - 10_000_000_000,
+            DownUpOrder::new(30_000, 40_000),
+            DownUpOrder::new(1_000, 2_000),
+            DownUpOrder::new(10, 20),
+        );
+        hash_matched.1.0.circuit_hash = Some(circuit_hash);
+        let mut ip_matched = active_flow_entry(
+            [192, 0, 2, 52],
+            [198, 51, 100, 60],
+            50_000,
+            now_nanos - 1_000_000_000,
+            DownUpOrder::new(30_000, 40_000),
+            DownUpOrder::new(1_000, 2_000),
+            DownUpOrder::new(10, 20),
+        );
+        let mut rtt = RttBuffer::new(
+            RttData::from_nanos(12_000_000),
+            FlowbeeEffectiveDirection::Download,
+            now_nanos,
+        );
+        rtt.push(
+            RttData::from_nanos(12_000_000),
+            FlowbeeEffectiveDirection::Download,
+            now_nanos,
+        );
+        rtt.push(
+            RttData::from_nanos(34_000_000),
+            FlowbeeEffectiveDirection::Upload,
+            now_nanos,
+        );
+        rtt.push(
+            RttData::from_nanos(34_000_000),
+            FlowbeeEffectiveDirection::Upload,
+            now_nanos,
+        );
+        ip_matched.1.0.set_rtt_buffer(rtt);
+
+        replace_active_flows_for_test(vec![
+            ip_matched,
+            active_flow_entry(
+                [192, 0, 2, 52],
+                [198, 51, 100, 61],
+                50_001,
+                now_nanos - 301_000_000_000,
+                DownUpOrder::new(30_000, 40_000),
+                DownUpOrder::new(1_000, 2_000),
+                DownUpOrder::new(10, 20),
+            ),
+            active_flow_entry(
+                [192, 0, 2, 52],
+                [198, 51, 100, 64],
+                50_004,
+                now_nanos - STREAMING_CIRCUIT_FLOW_WINDOW.as_nanos() as u64,
+                DownUpOrder::new(30_000, 40_000),
+                DownUpOrder::new(1_000, 2_000),
+                DownUpOrder::new(10, 20),
+            ),
+            hash_matched,
+            active_flow_entry(
+                [192, 0, 2, 53],
+                [198, 51, 100, 63],
+                50_003,
+                now_nanos - 1_000_000_000,
+                DownUpOrder::new(30_000, 40_000),
+                DownUpOrder::new(1_000, 2_000),
+                DownUpOrder::new(10, 20),
+            ),
+        ]);
+
+        let flows = streaming_circuit_flow_snapshots(circuit_hash, now_nanos);
+
+        assert_eq!(flows.len(), 3);
+        let mut remote_ips = flows
+            .iter()
+            .map(|flow| flow.remote_ip.to_string())
+            .collect::<Vec<_>>();
+        remote_ips.sort();
+        assert_eq!(
+            remote_ips,
+            vec!["198.51.100.60", "198.51.100.62", "198.51.100.64"]
+        );
+        let ip_matched = flows
+            .iter()
+            .find(|flow| flow.remote_ip.to_string() == "198.51.100.60")
+            .expect("IP-matched flow should be included");
+        assert_eq!(ip_matched.age_nanos_wire, 1_000_000_000);
+        let wire_flow = serde_json::to_value(ip_matched).expect("flow should serialize");
+        assert_eq!(wire_flow["last_seen_nanos"], 1_000_000_000);
+        assert!(wire_flow.get("age_nanos").is_none());
+        assert_eq!(ip_matched.rate_bps, (30_000, 40_000));
+        assert_eq!(ip_matched.bytes_sent, (1_000, 2_000));
+        assert_eq!(ip_matched.packets_sent, (10, 20));
+        assert_eq!(ip_matched.tcp_retransmits, (1, 2));
+        assert_eq!(ip_matched.rtt_ms, (14.0, 35.0));
+
+        replace_active_flows_live_for_test(Vec::new());
+        assert_eq!(
+            streaming_circuit_flow_snapshots(circuit_hash, now_nanos).len(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn circuit_snapshot_streaming_aggregates_only_fresh_raw_device_rows() {
+        let _ctx = ActiveFlowSnapshotTestContext::with_shaped_devices(
+            "streaming-circuit-raw-test",
+            vec![ShapedDevice {
+                circuit_id: "raw-circuit".to_string(),
+                circuit_name: "Raw Circuit".to_string(),
+                device_id: "raw-device".to_string(),
+                device_name: "Raw Device".to_string(),
+                parent_node: "Parent".to_string(),
+                ipv4: vec![(Ipv4Addr::new(192, 0, 2, 0), 24)],
+                ..Default::default()
+            }],
+        );
+        let circuit_hash = hash_to_i64("raw-circuit");
+        let device_hash = hash_to_i64("raw-device");
+        let _raw_guard = replace_raw_throughput_for_test(
+            100,
+            vec![
+                RawThroughputTestEntry {
+                    ip: lqos_utils::XdpIpAddress::from_ip(Ipv4Addr::new(192, 0, 2, 10).into()),
+                    circuit_hash: Some(circuit_hash),
+                    device_hash: Some(device_hash),
+                    most_recent_cycle: 99,
+                    bytes_per_second: DownUpOrder::new(1_000, 2_000),
+                    tcp_packets: DownUpOrder::new(100, 200),
+                    tcp_retransmits: DownUpOrder::new(10, 20),
+                },
+                RawThroughputTestEntry {
+                    ip: lqos_utils::XdpIpAddress::from_ip(Ipv4Addr::new(192, 0, 2, 11).into()),
+                    circuit_hash: Some(circuit_hash),
+                    device_hash: Some(device_hash),
+                    most_recent_cycle: 60,
+                    bytes_per_second: DownUpOrder::new(9_000, 9_000),
+                    tcp_packets: DownUpOrder::new(900, 900),
+                    tcp_retransmits: DownUpOrder::new(90, 90),
+                },
+                RawThroughputTestEntry {
+                    ip: lqos_utils::XdpIpAddress::from_ip(Ipv4Addr::new(192, 0, 2, 12).into()),
+                    circuit_hash: Some(circuit_hash),
+                    device_hash: Some(device_hash),
+                    most_recent_cycle: 70,
+                    bytes_per_second: DownUpOrder::new(100, 200),
+                    tcp_packets: DownUpOrder::new(10, 20),
+                    tcp_retransmits: DownUpOrder::new(1, 2),
+                },
+            ],
+        );
+        let now_nanos = std::time::Duration::from(
+            lqos_utils::unix_time::time_since_boot()
+                .expect("test system clock should report time since boot"),
+        )
+        .as_nanos() as u64;
+        replace_active_flows_for_test(vec![
+            active_flow_entry(
+                [192, 0, 2, 10],
+                [198, 51, 100, 70],
+                50_010,
+                now_nanos.saturating_sub(1_000_000_000),
+                DownUpOrder::new(30_000, 40_000),
+                DownUpOrder::new(1_000, 2_000),
+                DownUpOrder::new(10, 20),
+            ),
+            active_flow_entry(
+                [192, 0, 2, 12],
+                [198, 51, 100, 72],
+                50_012,
+                now_nanos.saturating_sub(1_000_000_000),
+                DownUpOrder::new(30_000, 40_000),
+                DownUpOrder::new(1_000, 2_000),
+                DownUpOrder::new(10, 20),
+            ),
+        ]);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        circuit_snapshot_streaming(77, circuit_hash, tx)
+            .await
+            .expect("streaming circuit snapshot should send");
+
+        let Some(Message::Binary(bytes)) = rx.recv().await else {
+            panic!("streaming circuit should emit one binary frame");
+        };
+        let messages::WsMessage::StreamingCircuit {
+            request_id,
+            circuit_hash: payload_circuit_hash,
+            data,
+        } = messages::WsMessage::from_bytes(&bytes).expect("streaming circuit should decode")
+        else {
+            panic!("unexpected websocket message");
+        };
+        assert_eq!(request_id, 77);
+        assert_eq!(payload_circuit_hash, circuit_hash);
+        let payload: StreamingCircuitPayload =
+            serde_cbor::from_slice(&data).expect("streaming circuit payload should decode");
+
+        assert_eq!(payload.devices.len(), 1);
+        assert_eq!(payload.devices[0].device_id, "raw-device");
+        assert_eq!(payload.devices[0].bits_per_second, (8_000, 16_000));
+        assert_eq!(payload.devices[0].tcp_retransmit_pct, (0.1, 0.1));
+        let mut flow_ips = payload
+            .flows
+            .iter()
+            .map(|flow| flow.remote_ip.to_string())
+            .collect::<Vec<_>>();
+        flow_ips.sort();
+        assert_eq!(flow_ips, vec!["198.51.100.70", "198.51.100.72"]);
+    }
+
+    #[test]
+    fn streaming_flow_snapshot_decodes_legacy_last_seen_nanos_wire_field() {
+        let decoded: FlowSnapshot = serde_json::from_value(serde_json::json!({
+            "remote_ip": "198.51.100.62",
+            "local_ip": "192.0.2.99",
+            "src_port": 443,
+            "dst_port": 50002,
+            "ip_protocol": 6,
+            "last_seen_nanos": 1_000_000_000_u64,
+            "rate_bps": [30_000, 40_000],
+            "bytes_sent": [1_000, 2_000],
+            "packets_sent": [10, 20],
+            "tcp_retransmits": [1, 2],
+            "rtt_ms": [12.0, 34.0]
+        }))
+        .expect("legacy flow snapshot should deserialize");
+
+        assert_eq!(decoded.age_nanos_wire, 1_000_000_000);
     }
 }

--- a/src/rust/lqosd/src/main.rs
+++ b/src/rust/lqosd/src/main.rs
@@ -42,7 +42,9 @@ use crate::ip_mapping::clear_hot_cache;
 use crate::{
     file_lock::FileLock,
     ip_mapping::{clear_ip_flows, del_ip_flow, list_mapped_ips, map_ip_to_flow},
-    throughput_tracker::flow_data::{FlowActor, flowbee_handle_events, setup_netflow_tracker},
+    throughput_tracker::flow_data::{
+        FlowActor, flowbee_handle_events, live_active_flow_count, setup_netflow_tracker,
+    },
 };
 use anyhow::Result;
 use lqos_bus::{
@@ -60,7 +62,7 @@ use signal_hook::{
     consts::{SIGHUP, SIGINT, SIGTERM},
     iterator::Signals,
 };
-use stats::{BUS_REQUESTS, FLOWS_TRACKED, HIGH_WATERMARK, TIME_TO_POLL_HOSTS};
+use stats::{BUS_REQUESTS, HIGH_WATERMARK, TIME_TO_POLL_HOSTS};
 use std::{thread, time::Duration};
 use throughput_tracker::flow_data::get_rtt_events_per_second;
 use tracing::{error, info, warn};
@@ -490,7 +492,6 @@ fn memory_debug() {
             let mut fb = allocative::FlameGraphBuilder::default();
             fb.visit_global_roots();
             // fb.visit_root(&*THROUGHPUT_TRACKER);
-            // fb.visit_root(&*ALL_FLOWS);
             // fb.visit_root(&*RECENT_FLOWS);
             // lqos_network_devices::with_network_json_read(|net_json| fb.visit_root(net_json));
             let flamegraph_src = fb.finish();
@@ -653,7 +654,7 @@ fn handle_bus_requests(requests: &[BusRequest], responses: &mut Vec<BusResponse>
                 bus_requests: BUS_REQUESTS.load(std::sync::atomic::Ordering::Relaxed),
                 time_to_poll_hosts: TIME_TO_POLL_HOSTS.load(std::sync::atomic::Ordering::Relaxed),
                 high_watermark: HIGH_WATERMARK.as_down_up(),
-                tracked_flows: FLOWS_TRACKED.load(std::sync::atomic::Ordering::Relaxed),
+                tracked_flows: live_active_flow_count(),
                 rtt_events_per_second: get_rtt_events_per_second(),
             },
             BusRequest::GetPacketHeaderDump(id) => {

--- a/src/rust/lqosd/src/memory_watchdog.rs
+++ b/src/rust/lqosd/src/memory_watchdog.rs
@@ -5,7 +5,8 @@
 //! diagnostic context while leaving restart decisions to system policy and
 //! operators.
 
-use crate::stats::{BUS_REQUESTS, FLOWS_TRACKED, HIGH_WATERMARK, TIME_TO_POLL_HOSTS};
+use crate::stats::{BUS_REQUESTS, HIGH_WATERMARK, TIME_TO_POLL_HOSTS};
+use crate::throughput_tracker::flow_data::live_active_flow_count;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -151,7 +152,7 @@ struct MemoryDiagnostics {
 impl MemoryDiagnostics {
     fn read() -> Self {
         Self {
-            flows_tracked: FLOWS_TRACKED.load(Ordering::Relaxed),
+            flows_tracked: live_active_flow_count(),
             bus_requests: BUS_REQUESTS.load(Ordering::Relaxed),
             time_to_poll_hosts_us: TIME_TO_POLL_HOSTS.load(Ordering::Relaxed),
             high_watermark_down: HIGH_WATERMARK.get_down(),

--- a/src/rust/lqosd/src/node_manager/local_api/circuit_activity.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/circuit_activity.rs
@@ -1,4 +1,6 @@
-use crate::throughput_tracker::flow_data::{ALL_FLOWS, FlowbeeLocalData, get_asn_name_and_country};
+use crate::throughput_tracker::flow_data::{
+    ActiveFlowDisplayFields, ActiveFlowSnapshot, for_each_active_flow_for_circuit,
+};
 use lqos_utils::hash_to_i64;
 use lqos_utils::units::{DownUpOrder, TcpRetransmitSample};
 use lqos_utils::unix_time::time_since_boot;
@@ -114,7 +116,9 @@ pub struct CircuitFlowSankeyRow {
     pub remote_ip: String,
     pub down_bps: u32,
     pub up_bps: u32,
-    pub last_seen_nanos: u64,
+    /// Legacy UI field name; payload value is the flow age at snapshot time.
+    #[serde(rename = "last_seen_nanos")]
+    pub age_nanos_wire: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -139,7 +143,7 @@ struct CircuitFlowSnapshotRow {
     rtt_up_nanos: u64,
     qoo_down: Option<f32>,
     qoo_up: Option<f32>,
-    last_seen_nanos: u64,
+    age_nanos: u64,
     opacity: f64,
     sort_rate_bps: f64,
 }
@@ -188,122 +192,108 @@ fn circuit_display_rate_ceiling_bps(
 }
 
 fn display_rate_bps(
-    local: &FlowbeeLocalData,
+    flow: &ActiveFlowSnapshot,
     ceiling_bps: Option<DownUpOrder<u32>>,
 ) -> DownUpOrder<u32> {
     let Some(ceiling_bps) = ceiling_bps else {
-        return local.rate_estimate_bps;
+        return flow.rate_estimate_bps;
     };
 
     DownUpOrder {
-        down: local.rate_estimate_bps.down.min(ceiling_bps.down),
-        up: local.rate_estimate_bps.up.min(ceiling_bps.up),
+        down: flow.rate_estimate_bps.down.min(ceiling_bps.down),
+        up: flow.rate_estimate_bps.up.min(ceiling_bps.up),
     }
 }
 
-fn flow_rtt_nanos(local: &FlowbeeLocalData) -> DownUpOrder<u64> {
-    let rtt = local.get_rtt_array();
-    DownUpOrder {
-        down: rtt[0].as_nanos(),
-        up: rtt[1].as_nanos(),
+fn circuit_flow_snapshot_row_from_flow(
+    flow: &ActiveFlowSnapshot,
+    device_name: String,
+    display: &ActiveFlowDisplayFields,
+    display_rate_ceiling: Option<DownUpOrder<u32>>,
+    now_as_nanos: u64,
+) -> CircuitFlowSnapshotRow {
+    let display_rate = display_rate_bps(flow, display_rate_ceiling);
+    let current_rate = display_rate.down as u64 + display_rate.up as u64;
+    let packets_sent_down = flow.packets_sent.down;
+    let packets_sent_up = flow.packets_sent.up;
+    let tcp_retransmits_down = flow.tcp_retransmits.down;
+    let tcp_retransmits_up = flow.tcp_retransmits.up;
+    let retransmit_down_pct = if tcp_retransmits_down > 0 && packets_sent_down > 0 {
+        tcp_retransmits_down as f64 / packets_sent_down as f64
+    } else {
+        0.0
+    };
+    let retransmit_up_pct = if tcp_retransmits_up > 0 && packets_sent_up > 0 {
+        tcp_retransmits_up as f64 / packets_sent_up as f64
+    } else {
+        0.0
+    };
+    let age_nanos = flow.age_nanos(now_as_nanos);
+
+    CircuitFlowSnapshotRow {
+        device_name,
+        asn_id: display.remote_asn,
+        asn_name: display.remote_asn_name.clone(),
+        asn_country: display.remote_asn_country.clone(),
+        protocol_name: display.analysis.clone(),
+        remote_ip: display.remote_ip.clone(),
+        down_bps: display_rate.down,
+        up_bps: display_rate.up,
+        bytes_sent_down: flow.bytes_sent.down,
+        bytes_sent_up: flow.bytes_sent.up,
+        packets_sent_down,
+        packets_sent_up,
+        tcp_retransmits_down,
+        tcp_retransmits_up,
+        retransmit_down_pct,
+        retransmit_up_pct,
+        rtt_down_nanos: flow.rtt_nanos.down,
+        rtt_up_nanos: flow.rtt_nanos.up,
+        qoo_down: flow.qoo.down,
+        qoo_up: flow.qoo.up,
+        age_nanos,
+        opacity: 1.0
+            - f64::min(
+                1.0,
+                age_nanos as f64 / RECENT_CIRCUIT_FLOWS_WINDOW_NANOS as f64,
+            ),
+        sort_rate_bps: current_rate as f64,
     }
 }
 
-fn flow_qoo(local: &FlowbeeLocalData) -> DownUpOrder<Option<f32>> {
-    let qoq = local.get_qoq_scores();
-    DownUpOrder {
-        down: qoq.download_total_f32(),
-        up: qoq.upload_total_f32(),
-    }
+fn current_and_recent_cutoff_nanos() -> Option<(u64, u64)> {
+    let now = time_since_boot().ok()?;
+    let now_as_nanos = Duration::from(now).as_nanos() as u64;
+    let recent_cutoff = now_as_nanos.saturating_sub(RECENT_CIRCUIT_FLOWS_WINDOW_NANOS);
+    Some((now_as_nanos, recent_cutoff))
 }
 
 fn flow_snapshot_rows(circuit_id: &str) -> Vec<CircuitFlowSnapshotRow> {
     let circuit_hash = hash_to_i64(circuit_id);
     let catalog = lqos_network_devices::network_devices_catalog();
     let display_rate_ceiling = circuit_display_rate_ceiling_bps(&catalog, circuit_hash);
-    let Ok(now) = time_since_boot() else {
+    let Some((now_as_nanos, recent_cutoff)) = current_and_recent_cutoff_nanos() else {
         return Vec::new();
     };
-    let now_as_nanos = Duration::from(now).as_nanos() as u64;
-    let recent_cutoff = now_as_nanos.saturating_sub(RECENT_CIRCUIT_FLOWS_WINDOW_NANOS);
 
-    let all_flows = ALL_FLOWS.lock();
-    all_flows
-        .flow_data
-        .iter()
-        .filter_map(|(key, (local, analysis))| {
-            if local.last_seen < recent_cutoff {
-                return None;
-            }
-            let device = catalog
-                .device_by_hashes(local.device_hash, local.circuit_hash)
-                .or_else(|| {
-                    catalog
-                        .device_longest_match_for_ip(&key.local_ip)
-                        .map(|(_, device)| device)
-                });
-            let matches_desired = local.circuit_hash == Some(circuit_hash)
-                || device.is_some_and(|device| device.circuit_id == circuit_id);
-            if !matches_desired {
-                return None;
-            }
+    let mut rows = Vec::new();
+    for_each_active_flow_for_circuit(circuit_hash, recent_cutoff, |flow| {
+        let device_name = if flow.device_name.is_empty() {
+            "Unknown".to_string()
+        } else {
+            flow.device_name.clone()
+        };
 
-            let device_name = device
-                .map(|d| d.device_name.clone())
-                .unwrap_or_else(|| "Unknown".to_string());
-
-            let geo = get_asn_name_and_country(key.remote_ip.as_ip());
-            let display_rate = display_rate_bps(local, display_rate_ceiling);
-            let current_rate = display_rate.down as u64 + display_rate.up as u64;
-            let packets_sent_down = local.packets_sent.down;
-            let packets_sent_up = local.packets_sent.up;
-            let tcp_retransmits_down = local.tcp_retransmits.down;
-            let tcp_retransmits_up = local.tcp_retransmits.up;
-            let retransmit_down_pct = if tcp_retransmits_down > 0 && packets_sent_down > 0 {
-                tcp_retransmits_down as f64 / packets_sent_down as f64
-            } else {
-                0.0
-            };
-            let retransmit_up_pct = if tcp_retransmits_up > 0 && packets_sent_up > 0 {
-                tcp_retransmits_up as f64 / packets_sent_up as f64
-            } else {
-                0.0
-            };
-            let rtt = flow_rtt_nanos(local);
-            let qoo = flow_qoo(local);
-            let last_seen_nanos = now_as_nanos.saturating_sub(local.last_seen);
-
-            Some(CircuitFlowSnapshotRow {
-                device_name,
-                asn_id: analysis.asn_id.0,
-                asn_name: geo.name,
-                asn_country: geo.country,
-                protocol_name: analysis.protocol_analysis.to_string(),
-                remote_ip: key.remote_ip.to_string(),
-                down_bps: display_rate.down,
-                up_bps: display_rate.up,
-                bytes_sent_down: local.bytes_sent.down,
-                bytes_sent_up: local.bytes_sent.up,
-                packets_sent_down,
-                packets_sent_up,
-                tcp_retransmits_down,
-                tcp_retransmits_up,
-                retransmit_down_pct,
-                retransmit_up_pct,
-                rtt_down_nanos: rtt.down,
-                rtt_up_nanos: rtt.up,
-                qoo_down: qoo.down,
-                qoo_up: qoo.up,
-                last_seen_nanos,
-                opacity: 1.0
-                    - f64::min(
-                        1.0,
-                        last_seen_nanos as f64 / RECENT_CIRCUIT_FLOWS_WINDOW_NANOS as f64,
-                    ),
-                sort_rate_bps: current_rate as f64,
-            })
-        })
-        .collect()
+        let row = circuit_flow_snapshot_row_from_flow(
+            flow,
+            device_name,
+            &flow.display,
+            display_rate_ceiling,
+            now_as_nanos,
+        );
+        rows.push(row);
+    });
+    rows
 }
 
 fn sort_direction_is_asc(sort_direction: &str) -> bool {
@@ -403,13 +393,19 @@ fn sort_traffic_rows(rows: &mut [CircuitFlowSnapshotRow], sort_column: &str, sor
 }
 
 pub fn circuit_flow_counts(circuit_id: &str) -> (usize, usize) {
-    let rows = flow_snapshot_rows(circuit_id);
-    let asn_count = rows
-        .iter()
-        .map(|row| (row.asn_name.clone(), row.asn_country.clone()))
-        .collect::<std::collections::HashSet<_>>()
-        .len();
-    (rows.len(), asn_count)
+    let circuit_hash = hash_to_i64(circuit_id);
+    let Some((_, recent_cutoff)) = current_and_recent_cutoff_nanos() else {
+        return (0, 0);
+    };
+
+    let mut flow_count = 0;
+    let mut asns = std::collections::HashSet::new();
+    for_each_active_flow_for_circuit(circuit_hash, recent_cutoff, |flow| {
+        flow_count += 1;
+        asns.insert(flow.display.remote_asn);
+    });
+
+    (flow_count, asns.len())
 }
 
 pub fn circuit_traffic_flows_page(query: &CircuitTrafficFlowsQuery) -> CircuitTrafficFlowsPage {
@@ -579,7 +575,7 @@ pub fn circuit_top_asns_data(query: &CircuitTopAsnsQuery) -> CircuitTopAsnsData 
 
 pub fn circuit_flow_sankey_rows(circuit_id: &str) -> Vec<CircuitFlowSankeyRow> {
     let mut rows = flow_snapshot_rows(circuit_id);
-    rows.retain(|row| row.last_seen_nanos <= SANKEY_RECENT_FLOW_WINDOW_NANOS);
+    rows.retain(|row| row.age_nanos <= SANKEY_RECENT_FLOW_WINDOW_NANOS);
     rows.sort_by(|a, b| compare_f64(a.sort_rate_bps, b.sort_rate_bps, false));
     rows.into_iter()
         .take(SANKEY_TOP_FLOW_LIMIT)
@@ -591,14 +587,29 @@ pub fn circuit_flow_sankey_rows(circuit_id: &str) -> Vec<CircuitFlowSankeyRow> {
             remote_ip: row.remote_ip,
             down_bps: row.down_bps,
             up_bps: row.up_bps,
-            last_seen_nanos: row.last_seen_nanos,
+            age_nanos_wire: row.age_nanos,
         })
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{median_f32, median_u64};
+    use super::{
+        CircuitFlowSankeyRow, CircuitTopAsnsQuery, CircuitTrafficFlowsQuery,
+        circuit_flow_counts, circuit_flow_sankey_rows, circuit_flow_snapshot_row_from_flow,
+        circuit_top_asns_data, circuit_traffic_flows_page, flow_snapshot_rows, median_f32,
+        median_u64,
+    };
+    use crate::test_support::{ActiveFlowSnapshotTestContext, active_flow_entry};
+    use crate::throughput_tracker::flow_data::{
+        ActiveFlowDisplayFields, ActiveFlowSnapshot, AsnId, replace_active_flows_for_test,
+        replace_active_flows_live_for_test,
+    };
+    use lqos_config::ShapedDevice;
+    use lqos_sys::flowbee_data::FlowbeeKey;
+    use lqos_utils::units::DownUpOrder;
+    use lqos_utils::{XdpIpAddress, hash_to_i64};
+    use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn median_u64_handles_even_and_odd_lengths() {
@@ -616,5 +627,304 @@ mod tests {
 
         let mut even = vec![40.0_f32, 10.0, 30.0, 20.0];
         assert_eq!(median_f32(&mut even), Some(25.0));
+    }
+
+    #[test]
+    fn circuit_flow_sankey_row_decodes_legacy_last_seen_nanos_wire_field() {
+        let row: CircuitFlowSankeyRow = serde_json::from_value(serde_json::json!({
+            "device_name": "Device Public",
+            "asn_id": 64512,
+            "asn_name": "Example ASN",
+            "protocol_name": "HTTPS",
+            "remote_ip": "198.51.100.10",
+            "down_bps": 70_000_000,
+            "up_bps": 2_000_000,
+            "last_seen_nanos": 2_000_000_000_u64
+        }))
+        .expect("legacy circuit flow row should deserialize");
+
+        assert_eq!(row.age_nanos_wire, 2_000_000_000);
+    }
+
+    #[test]
+    fn public_circuit_flow_readers_use_published_snapshot_and_catalog_matching() {
+        let _ctx = ActiveFlowSnapshotTestContext::with_shaped_devices(
+            "circuit-activity-test",
+            vec![ShapedDevice {
+                circuit_id: "circuit-public".to_string(),
+                circuit_name: "Circuit Public".to_string(),
+                device_id: "device-public".to_string(),
+                device_name: "Device Public".to_string(),
+                parent_node: "Parent".to_string(),
+                ipv4: vec![(Ipv4Addr::new(192, 0, 2, 42), 32)],
+                download_max_mbps: 100.0,
+                upload_max_mbps: 50.0,
+                ..Default::default()
+            }],
+        );
+        let now_nanos =
+            std::time::Duration::from(lqos_utils::unix_time::time_since_boot().unwrap())
+                .as_nanos() as u64;
+        let fresh = now_nanos.saturating_sub(2 * 1_000_000_000);
+        let fresh_small = now_nanos.saturating_sub(4 * 1_000_000_000);
+        let stale = now_nanos.saturating_sub(40 * 1_000_000_000);
+        let circuit_hash = hash_to_i64("circuit-public");
+
+        let ip_matched = active_flow_entry(
+            [192, 0, 2, 42],
+            [198, 51, 100, 10],
+            50_000,
+            fresh,
+            DownUpOrder::new(70_000_000, 2_000_000),
+            DownUpOrder::new(5_000, 1_000),
+            DownUpOrder::new(50, 10),
+        );
+        let small = active_flow_entry(
+            [192, 0, 2, 42],
+            [198, 51, 100, 11],
+            50_001,
+            fresh_small,
+            DownUpOrder::new(1_000, 1_000),
+            DownUpOrder::new(12_000, 1_000),
+            DownUpOrder::new(120, 10),
+        );
+        let mut hash_matched = active_flow_entry(
+            [192, 0, 2, 99],
+            [198, 51, 100, 14],
+            50_004,
+            fresh,
+            DownUpOrder::new(30_000_000, 1_000_000),
+            DownUpOrder::new(8_000, 1_000),
+            DownUpOrder::new(80, 10),
+        );
+        hash_matched.1.0.circuit_hash = Some(circuit_hash);
+        let stale_flow = active_flow_entry(
+            [192, 0, 2, 42],
+            [198, 51, 100, 12],
+            50_002,
+            stale,
+            DownUpOrder::new(90_000_000, 1_000_000),
+            DownUpOrder::new(90_000, 1_000),
+            DownUpOrder::new(900, 10),
+        );
+        let other_circuit = active_flow_entry(
+            [192, 0, 2, 43],
+            [198, 51, 100, 13],
+            50_003,
+            fresh,
+            DownUpOrder::new(80_000_000, 1_000_000),
+            DownUpOrder::new(80_000, 1_000),
+            DownUpOrder::new(800, 10),
+        );
+        replace_active_flows_for_test(vec![
+            ip_matched,
+            small,
+            hash_matched,
+            stale_flow,
+            other_circuit,
+        ]);
+
+        let page = circuit_traffic_flows_page(&CircuitTrafficFlowsQuery {
+            circuit: "circuit-public".to_string(),
+            page: 1,
+            page_size: 10,
+            hide_small: false,
+            sort_column: "bytes".to_string(),
+            sort_direction: "desc".to_string(),
+        });
+        assert_eq!(page.total_rows, 3);
+        assert_eq!(
+            page.rows
+                .iter()
+                .map(|row| row.remote_ip.as_str())
+                .collect::<Vec<_>>(),
+            vec!["198.51.100.11", "198.51.100.14", "198.51.100.10"]
+        );
+
+        let hidden_small = circuit_traffic_flows_page(&CircuitTrafficFlowsQuery {
+            circuit: "circuit-public".to_string(),
+            page: 1,
+            page_size: 10,
+            hide_small: true,
+            sort_column: "rate".to_string(),
+            sort_direction: "desc".to_string(),
+        });
+        assert_eq!(hidden_small.total_rows, 2);
+        assert_eq!(hidden_small.rows[0].remote_ip, "198.51.100.10");
+        assert_eq!(hidden_small.rows[1].remote_ip, "198.51.100.14");
+
+        let top_asns = circuit_top_asns_data(&CircuitTopAsnsQuery {
+            circuit: "circuit-public".to_string(),
+            hide_small: true,
+        });
+        assert_eq!(top_asns.total_asns, 1);
+        assert_eq!(top_asns.rows[0].flow_count, 2);
+        assert_eq!(top_asns.rows[0].down_bps, 100_000_000);
+
+        let sankey_rows = circuit_flow_sankey_rows("circuit-public");
+        assert_eq!(sankey_rows[0].device_name, "Device Public");
+        let sankey_wire = serde_json::to_value(&sankey_rows[0]).expect("row should serialize");
+        assert!(sankey_wire.get("last_seen_nanos").is_some());
+        assert!(sankey_wire.get("age_nanos").is_none());
+        assert_eq!(
+            sankey_rows
+                .iter()
+                .map(|row| row.remote_ip.as_str())
+                .collect::<Vec<_>>(),
+            vec!["198.51.100.10", "198.51.100.14", "198.51.100.11"]
+        );
+
+        replace_active_flows_live_for_test(Vec::new());
+
+        let stale_page = circuit_traffic_flows_page(&CircuitTrafficFlowsQuery {
+            circuit: "circuit-public".to_string(),
+            page: 1,
+            page_size: 10,
+            hide_small: false,
+            sort_column: "bytes".to_string(),
+            sort_direction: "desc".to_string(),
+        });
+        assert_eq!(stale_page.total_rows, 3);
+        assert_eq!(circuit_flow_sankey_rows("circuit-public").len(), 3);
+    }
+
+    #[test]
+    fn circuit_flow_counts_uses_numeric_asn_identity() {
+        let _ctx = ActiveFlowSnapshotTestContext::with_shaped_devices(
+            "circuit-asn-count-test",
+            vec![ShapedDevice {
+                circuit_id: "circuit-asn-count".to_string(),
+                circuit_name: "Circuit ASN Count".to_string(),
+                device_id: "device-asn-count".to_string(),
+                device_name: "Device ASN Count".to_string(),
+                parent_node: "Parent".to_string(),
+                ipv4: vec![(Ipv4Addr::new(192, 0, 2, 0), 24)],
+                ..Default::default()
+            }],
+        );
+        let now_nanos =
+            std::time::Duration::from(lqos_utils::unix_time::time_since_boot().unwrap())
+                .as_nanos() as u64;
+        let fresh = now_nanos.saturating_sub(1_000_000_000);
+
+        let mut first = active_flow_entry(
+            [192, 0, 2, 42],
+            [198, 51, 100, 10],
+            50_000,
+            fresh,
+            DownUpOrder::new(70_000_000, 2_000_000),
+            DownUpOrder::new(5_000, 1_000),
+            DownUpOrder::new(50, 10),
+        );
+        first.1.1.asn_id = AsnId(64_512);
+        let mut second = active_flow_entry(
+            [192, 0, 2, 43],
+            [198, 51, 100, 11],
+            50_001,
+            fresh,
+            DownUpOrder::new(30_000_000, 1_000_000),
+            DownUpOrder::new(8_000, 1_000),
+            DownUpOrder::new(80, 10),
+        );
+        second.1.1.asn_id = AsnId(64_513);
+        replace_active_flows_for_test(vec![first, second]);
+
+        let rows = flow_snapshot_rows("circuit-asn-count");
+        let display_identities = rows
+            .iter()
+            .map(|row| (row.asn_name.as_str(), row.asn_country.as_str()))
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(display_identities.len(), 1);
+        assert_eq!(circuit_flow_counts("circuit-asn-count"), (2, 2));
+    }
+
+    #[test]
+    fn circuit_flow_snapshot_row_uses_cached_flow_fields_and_clamps_display_rate() {
+        let mut key = FlowbeeKey::default();
+        key.remote_ip = XdpIpAddress::from_ip(IpAddr::from([198, 51, 100, 20]));
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_000;
+        let flow = ActiveFlowSnapshot {
+            key,
+            display: ActiveFlowDisplayFields {
+                remote_ip: "198.51.100.20".to_string(),
+                local_ip: "192.0.2.10".to_string(),
+                src_port: 443,
+                dst_port: 50_000,
+                ip_protocol: lqos_bus::FlowbeeProtocol::TCP,
+                remote_asn: 0,
+                remote_asn_name: "Example ASN".to_string(),
+                remote_asn_country: "US".to_string(),
+                analysis: "HTTPS".to_string(),
+            },
+            bytes_sent: DownUpOrder::new(10_000, 20_000),
+            packets_sent: DownUpOrder::new(100, 200),
+            rate_estimate_bps: DownUpOrder::new(100_000_000, 15_000_000),
+            tcp_retransmits: DownUpOrder::new(5, 4),
+            end_status: 0,
+            tos: 0,
+            flags: 0x12,
+            circuit_hash: None,
+            device_hash: None,
+            circuit_id: String::new(),
+            circuit_name: String::new(),
+            device_name: "Device A".to_string(),
+            last_seen: 70_000_000_000,
+            start_time: 65_000_000_000,
+            rtt_nanos: DownUpOrder::new(12_000_000, 34_000_000),
+            qoo: DownUpOrder::new(Some(77.0), Some(66.0)),
+        };
+
+        let row = circuit_flow_snapshot_row_from_flow(
+            &flow,
+            "Device A".to_string(),
+            &flow.display,
+            Some(DownUpOrder::new(50_000_000, 25_000_000)),
+            75_000_000_000,
+        );
+
+        assert_eq!(row.device_name, "Device A");
+        assert_eq!(row.asn_id, 0);
+        assert_eq!(row.asn_name, "Example ASN");
+        assert_eq!(row.asn_country, "US");
+        assert_eq!(row.protocol_name, "HTTPS");
+        assert_eq!(row.remote_ip, "198.51.100.20");
+        assert_eq!(row.down_bps, 50_000_000);
+        assert_eq!(row.up_bps, 15_000_000);
+        assert_eq!(row.bytes_sent_down, 10_000);
+        assert_eq!(row.bytes_sent_up, 20_000);
+        assert_eq!(row.packets_sent_down, 100);
+        assert_eq!(row.packets_sent_up, 200);
+        assert_eq!(row.tcp_retransmits_down, 5);
+        assert_eq!(row.tcp_retransmits_up, 4);
+        assert_eq!(row.rtt_down_nanos, 12_000_000);
+        assert_eq!(row.rtt_up_nanos, 34_000_000);
+        assert_eq!(row.qoo_down, Some(77.0));
+        assert_eq!(row.qoo_up, Some(66.0));
+        assert_eq!(row.age_nanos, 5_000_000_000);
+        assert!((row.opacity - (5.0 / 6.0)).abs() < f64::EPSILON);
+        assert_eq!(row.sort_rate_bps, 65_000_000.0);
+        assert_eq!(row.retransmit_down_pct, 0.05);
+        assert_eq!(row.retransmit_up_pct, 0.02);
+
+        let mut flow_without_device = flow;
+        flow_without_device.device_name = String::new();
+        flow_without_device.packets_sent = DownUpOrder::new(0, 0);
+        flow_without_device.tcp_retransmits = DownUpOrder::new(0, 0);
+        let row = circuit_flow_snapshot_row_from_flow(
+            &flow_without_device,
+            if flow_without_device.device_name.is_empty() {
+                "Unknown".to_string()
+            } else {
+                flow_without_device.device_name.clone()
+            },
+            &flow_without_device.display,
+            None,
+            75_000_000_000,
+        );
+        assert_eq!(row.device_name, "Unknown");
+        assert_eq!(row.retransmit_down_pct, 0.0);
+        assert_eq!(row.retransmit_up_pct, 0.0);
     }
 }

--- a/src/rust/lqosd/src/node_manager/local_api/flow_explorer.rs
+++ b/src/rust/lqosd/src/node_manager/local_api/flow_explorer.rs
@@ -1,6 +1,6 @@
 use crate::throughput_tracker::flow_data::{
     AsnCountryListEntry, AsnListEntry, AsnProtocolListEntry, FlowAnalysis, FlowbeeLocalData,
-    RECENT_FLOWS, RttData,
+    RECENT_FLOWS, RttData, retry_times_to_unix_seconds,
 };
 use crate::throughput_tracker::resolve_circuit_metadata_for_ip;
 use lqos_sys::flowbee_data::FlowbeeKey;
@@ -74,20 +74,14 @@ fn all_flows_to_transport(
                 circuit_name = flow.0.local_ip.as_ip().to_string();
             }
 
-            let retransmit_times_down = flow
-                .1
-                .get_retry_times_down()
-                .iter()
-                .filter(|n| **n > 0)
-                .map(|t| boot_time + Duration::from_nanos(*t).as_secs())
-                .collect();
-            let retransmit_times_up = flow
-                .1
-                .get_retry_times_up()
-                .iter()
-                .filter(|n| **n > 0)
-                .map(|t| boot_time + Duration::from_nanos(*t).as_secs())
-                .collect();
+            let retransmit_times_down =
+                retry_times_to_unix_seconds(flow.1.get_retry_times_down(), |timestamp| {
+                    boot_time + Duration::from_nanos(timestamp).as_secs()
+                });
+            let retransmit_times_up =
+                retry_times_to_unix_seconds(flow.1.get_retry_times_up(), |timestamp| {
+                    boot_time + Duration::from_nanos(timestamp).as_secs()
+                });
 
             FlowTimeline {
                 start: boot_time + Duration::from_nanos(flow.1.start_time).as_secs(),
@@ -128,6 +122,9 @@ pub fn protocol_timeline_data(protocol_name: &str) -> Result<Vec<FlowTimeline>, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection;
+    use lqos_sys::flowbee_data::FlowbeeData;
+    use lqos_utils::{XdpIpAddress, units::DownUpOrder};
 
     #[test]
     fn boot_time_helper_propagates_clock_errors() {
@@ -142,5 +139,32 @@ mod tests {
             .expect("test clock values should build a boot time");
 
         assert_eq!(boot_time, 0);
+    }
+
+    #[test]
+    fn flow_timeline_transport_converts_retry_times_to_unix_seconds() {
+        let mut key = FlowbeeKey::default();
+        key.local_ip = XdpIpAddress::from_ip("192.0.2.10".parse().expect("test IP should parse"));
+        key.remote_ip =
+            XdpIpAddress::from_ip("198.51.100.10".parse().expect("test IP should parse"));
+        key.ip_protocol = 6;
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 1_000_000_000;
+        raw.last_seen = 5_000_000_000;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.tcp_retransmits = DownUpOrder::new(2, 1);
+
+        let mut local = FlowbeeLocalData::from_flow(&raw, &key);
+        local.record_tcp_retry_time(FlowbeeEffectiveDirection::Download, 0);
+        local.record_tcp_retry_time(FlowbeeEffectiveDirection::Download, 2_000_000_000);
+        local.record_tcp_retry_time(FlowbeeEffectiveDirection::Download, 3_000_000_000);
+        local.record_tcp_retry_time(FlowbeeEffectiveDirection::Upload, 4_000_000_000);
+        let analysis = FlowAnalysis::new(&key);
+
+        let rows = all_flows_to_transport(1_700_000_000, vec![(key, local, analysis)]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].retransmit_times_down, vec![1_700_000_002, 1_700_000_003]);
+        assert_eq!(rows[0].retransmit_times_up, vec![1_700_000_004]);
     }
 }

--- a/src/rust/lqosd/src/stats.rs
+++ b/src/rust/lqosd/src/stats.rs
@@ -4,4 +4,3 @@ use std::sync::atomic::AtomicU64;
 pub static BUS_REQUESTS: AtomicU64 = AtomicU64::new(0);
 pub static TIME_TO_POLL_HOSTS: AtomicU64 = AtomicU64::new(0);
 pub static HIGH_WATERMARK: AtomicDownUp = AtomicDownUp::zeroed();
-pub static FLOWS_TRACKED: AtomicU64 = AtomicU64::new(0);

--- a/src/rust/lqosd/src/test_support.rs
+++ b/src/rust/lqosd/src/test_support.rs
@@ -1,7 +1,116 @@
-use std::sync::{Mutex, OnceLock};
+use crate::throughput_tracker::flow_data::{
+    FlowAnalysis, FlowbeeLocalData, active_flow_test_lock, replace_active_flows_for_test,
+};
+use lqos_config::{ConfigShapedDevices, ShapedDevice};
+use lqos_sys::flowbee_data::{FlowbeeData, FlowbeeKey};
+use lqos_utils::XdpIpAddress;
+use lqos_utils::units::DownUpOrder;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 /// Serializes tests that mutate process-global runtime configuration state.
 pub(crate) fn runtime_config_test_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Holds global active-flow snapshot state for tests and restores replaced shaped-device state on drop.
+pub(crate) struct ActiveFlowSnapshotTestContext {
+    _runtime_guard: Option<MutexGuard<'static, ()>>,
+    _active_flow_guard: MutexGuard<'static, ()>,
+    old_shaped: Option<Arc<ConfigShapedDevices>>,
+}
+
+impl ActiveFlowSnapshotTestContext {
+    /// Creates an active-flow test context without changing shaped-device catalog state.
+    pub(crate) fn empty() -> Self {
+        let active_flow_guard = active_flow_test_lock();
+        replace_active_flows_for_test(Vec::new());
+        Self {
+            _runtime_guard: None,
+            _active_flow_guard: active_flow_guard,
+            old_shaped: None,
+        }
+    }
+
+    /// Creates an active-flow test context with a temporary shaped-device catalog.
+    pub(crate) fn with_shaped_devices(reason: &str, devices: Vec<ShapedDevice>) -> Self {
+        let runtime_guard = runtime_config_test_lock()
+            .lock()
+            .expect("runtime config test lock should not be poisoned");
+        let active_flow_guard = active_flow_test_lock();
+        let mut shaped = ConfigShapedDevices::default();
+        shaped.replace_with_new_data(devices);
+        let old_shaped = lqos_network_devices::swap_shaped_devices_snapshot(reason, Arc::new(shaped));
+        replace_active_flows_for_test(Vec::new());
+
+        Self {
+            _runtime_guard: Some(runtime_guard),
+            _active_flow_guard: active_flow_guard,
+            old_shaped: Some(old_shaped),
+        }
+    }
+
+    /// Replaces the shaped-device catalog while preserving the original catalog for restore.
+    pub(crate) fn replace_shaped_devices(&mut self, reason: &str, devices: Vec<ShapedDevice>) {
+        let mut shaped = ConfigShapedDevices::default();
+        shaped.replace_with_new_data(devices);
+        let replacement = Arc::new(shaped);
+        if let Some(original) = self.old_shaped.take() {
+            lqos_network_devices::swap_shaped_devices_snapshot(reason, replacement);
+            self.old_shaped = Some(original);
+        } else {
+            self.old_shaped = Some(lqos_network_devices::swap_shaped_devices_snapshot(
+                reason,
+                replacement,
+            ));
+        }
+    }
+}
+
+impl Drop for ActiveFlowSnapshotTestContext {
+    fn drop(&mut self) {
+        replace_active_flows_for_test(Vec::new());
+        if let Some(old_shaped) = self.old_shaped.take() {
+            lqos_network_devices::swap_shaped_devices_snapshot(
+                "active-flow-snapshot-test-restore",
+                old_shaped,
+            );
+        }
+    }
+}
+
+/// Builds a live active-flow map entry for tests that seed the published snapshot.
+pub(crate) fn active_flow_entry(
+    local_ip: [u8; 4],
+    remote_ip: [u8; 4],
+    dst_port: u16,
+    last_seen: u64,
+    rate: DownUpOrder<u32>,
+    bytes: DownUpOrder<u64>,
+    packets: DownUpOrder<u64>,
+) -> (FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)) {
+    let mut key = FlowbeeKey::default();
+    key.local_ip = XdpIpAddress::from_ip(IpAddr::from(local_ip));
+    key.remote_ip = XdpIpAddress::from_ip(IpAddr::from(remote_ip));
+    key.ip_protocol = 6;
+    key.src_port = 443;
+    key.dst_port = dst_port;
+
+    let mut raw = FlowbeeData::default();
+    raw.start_time = last_seen.saturating_sub(1_000_000_000);
+    raw.last_seen = last_seen;
+    raw.bytes_sent = bytes;
+    raw.packets_sent = packets;
+    raw.rate_estimate_bps = rate;
+    raw.tcp_retransmits = DownUpOrder::new(1, 2);
+    raw.flags = 0x12;
+
+    (
+        key,
+        (
+            FlowbeeLocalData::from_flow(&raw, &key),
+            FlowAnalysis::new(&key),
+        ),
+    )
 }

--- a/src/rust/lqosd/src/throughput_tracker/flow_data/flow_analysis/finished_flows.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/flow_analysis/finished_flows.rs
@@ -2,7 +2,7 @@ use super::{
     FlowAnalysis, FlowbeeEffectiveDirection, get_asn_lat_lon, get_asn_name_and_country,
     get_asn_name_by_id,
 };
-use crate::throughput_tracker::flow_data::FlowbeeLocalData;
+use crate::throughput_tracker::flow_data::{FlowbeeLocalData, retry_times_to_unix_seconds};
 use allocative_derive::Allocative;
 use crossbeam_channel::Sender;
 use fxhash::FxHashMap;
@@ -215,7 +215,6 @@ impl TimeBuffer {
                 // It's V4
                 v4_bytes_sent.checked_add(data.bytes_sent);
                 v4_packets_sent.checked_add(data.packets_sent);
-                // TODO: This is awful code, fix it.
                 if data.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download) > 0 {
                     v4_rtt[0]
                         .push(data.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download));
@@ -228,7 +227,6 @@ impl TimeBuffer {
                 // It's V6
                 v6_bytes_sent.checked_add(data.bytes_sent);
                 v6_packets_sent.checked_add(data.packets_sent);
-                // TODO: This is awful code, fix it.
                 if data.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download) > 0 {
                     v6_rtt[0]
                         .push(data.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download));
@@ -462,6 +460,44 @@ impl FinishedFlowAnalysis {
     }
 }
 
+fn finished_flow_retry_times_to_unix(times: &[u64]) -> Vec<i64> {
+    retry_times_to_unix_seconds(times, |timestamp| {
+        boot_time_nanos_to_unix_now(timestamp).unwrap_or(0)
+    })
+    .into_iter()
+    .map(|timestamp| timestamp as i64)
+    .collect()
+}
+
+fn build_two_way_flow(
+    key: &FlowbeeKey,
+    data: &FlowbeeLocalData,
+    start_time: u64,
+    last_seen: u64,
+    circuit_hash: i64,
+) -> crate::lts2_sys::shared_types::TwoWayFlow {
+    crate::lts2_sys::shared_types::TwoWayFlow {
+        start_time,
+        end_time: last_seen,
+        local_ip: key.local_ip.as_ip(),
+        remote_ip: key.remote_ip.as_ip(),
+        protocol: key.ip_protocol,
+        dst_port: key.dst_port,
+        src_port: key.src_port,
+        bytes_down: data.bytes_sent.down,
+        bytes_up: data.bytes_sent.up,
+        retransmit_times_down: finished_flow_retry_times_to_unix(data.get_retry_times_down()),
+        retransmit_times_up: finished_flow_retry_times_to_unix(data.get_retry_times_up()),
+        rtt: [
+            data.get_summary_rtt_as_micros(FlowbeeEffectiveDirection::Download) as f32,
+            data.get_summary_rtt_as_micros(FlowbeeEffectiveDirection::Upload) as f32,
+        ],
+        circuit_hash,
+        packets_down: Some(data.packets_sent.down as i64),
+        packets_up: Some(data.packets_sent.up as i64),
+    }
+}
+
 fn enqueue(key: FlowbeeKey, data: FlowbeeLocalData, analysis: FlowAnalysis) {
     debug!("Finished flow analysis");
     let start_time = boot_time_nanos_to_unix_now(data.start_time).unwrap_or(0);
@@ -480,43 +516,8 @@ fn enqueue(key: FlowbeeKey, data: FlowbeeLocalData, analysis: FlowAnalysis) {
     });
 
     if !one_way {
-        //data.trim(); // Remove the trailing 30 seconds of zeroes
-        //let tp_buf_dn = data.throughput_buffer.iter().map(|v| v.down).collect();
-        //let tp_buf_up = data.throughput_buffer.iter().map(|v| v.up).collect();
-
-        let retransmit_times_down = data
-            .get_retry_times_down()
-            .iter()
-            .filter(|n| **n > 0)
-            .map(|t| boot_time_nanos_to_unix_now(*t).unwrap_or(0) as i64)
-            .collect();
-        let retransmit_times_up = data
-            .get_retry_times_up()
-            .iter()
-            .filter(|n| **n > 0)
-            .map(|t| boot_time_nanos_to_unix_now(*t).unwrap_or(0) as i64)
-            .collect();
-
-        if let Err(e) = crate::lts2_sys::two_way_flow(crate::lts2_sys::shared_types::TwoWayFlow {
-            start_time,
-            end_time: last_seen,
-            local_ip: key.local_ip.as_ip(),
-            remote_ip: key.remote_ip.as_ip(),
-            protocol: key.ip_protocol,
-            dst_port: key.dst_port,
-            src_port: key.src_port,
-            bytes_down: data.bytes_sent.down,
-            bytes_up: data.bytes_sent.up,
-            retransmit_times_down,
-            retransmit_times_up,
-            rtt: [
-                data.get_summary_rtt_as_micros(FlowbeeEffectiveDirection::Download) as f32,
-                data.get_summary_rtt_as_micros(FlowbeeEffectiveDirection::Upload) as f32,
-            ],
-            circuit_hash: circuit_hash.unwrap_or(0),
-            packets_down: Some(data.packets_sent.down as i64),
-            packets_up: Some(data.packets_sent.up as i64),
-        }) {
+        let flow = build_two_way_flow(&key, &data, start_time, last_seen, circuit_hash.unwrap_or(0));
+        if let Err(e) = crate::lts2_sys::two_way_flow(flow) {
             debug!("Failed to send two-way flow to LTS2: {e:?}");
         }
         if let Ok(time) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
@@ -546,5 +547,71 @@ fn enqueue(key: FlowbeeKey, data: FlowbeeLocalData, analysis: FlowAnalysis) {
         }) {
             debug!("Failed to send one-way flow to LTS2: {e:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::throughput_tracker::flow_data::{RttBuffer, RttData};
+    use lqos_sys::flowbee_data::{FlowbeeData, FlowbeeKey};
+    use lqos_utils::XdpIpAddress;
+    use lqos_utils::units::DownUpOrder;
+
+    #[test]
+    fn two_way_finished_flow_exports_summary_rtt_in_microseconds() {
+        let mut key = FlowbeeKey::default();
+        key.local_ip = XdpIpAddress::from_ip("192.0.2.10".parse().expect("test IP should parse"));
+        key.remote_ip =
+            XdpIpAddress::from_ip("198.51.100.10".parse().expect("test IP should parse"));
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_000;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        let mut data = FlowbeeLocalData::from_flow(&raw, &key);
+        let mut rtt = RttBuffer::new(
+            RttData::from_nanos(12_000_000),
+            FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(12_000_000),
+            FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(34_000_000),
+            FlowbeeEffectiveDirection::Upload,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(34_000_000),
+            FlowbeeEffectiveDirection::Upload,
+            raw.last_seen,
+        );
+        data.set_rtt_buffer(rtt);
+        data.record_tcp_retry_time(FlowbeeEffectiveDirection::Download, 0);
+        data.record_tcp_retry_time(FlowbeeEffectiveDirection::Download, 2_000_000_000);
+        data.record_tcp_retry_time(FlowbeeEffectiveDirection::Upload, 3_000_000_000);
+
+        let flow = build_two_way_flow(&key, &data, 1, 2, 3);
+
+        let expected_down_retry = boot_time_nanos_to_unix_now(2_000_000_000)
+            .expect("boot timestamp should convert") as i64;
+        let expected_up_retry = boot_time_nanos_to_unix_now(3_000_000_000)
+            .expect("boot timestamp should convert") as i64;
+        assert_eq!(flow.rtt, [14_000.0, 35_000.0]);
+        assert_eq!(flow.retransmit_times_down, vec![expected_down_retry]);
+        assert_eq!(flow.retransmit_times_up, vec![expected_up_retry]);
+        assert_eq!(flow.bytes_down, 1_000);
+        assert_eq!(flow.bytes_up, 2_000);
+        assert_eq!(flow.packets_down, Some(10));
+        assert_eq!(flow.packets_up, Some(20));
+        assert_eq!(flow.circuit_hash, 3);
     }
 }

--- a/src/rust/lqosd/src/throughput_tracker/flow_data/flow_tracker.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/flow_tracker.rs
@@ -1,13 +1,18 @@
-//! Provides a globally accessible vector of all flows. This is used to store
-//! all flows for the purpose of tracking and data-services.
+//! Owns the live active-flow table and publishes lock-free snapshots for readers.
 
 use crate::throughput_tracker::tracking_data::MAX_RETRY_TIMES;
 
-use super::{RttBuffer, RttData, flow_analysis::FlowAnalysis};
+use super::{
+    RttBuffer, RttData,
+    flow_analysis::{FlowAnalysis, get_asn_name_and_country},
+};
 use crate::throughput_tracker::flow_data::flow_analysis::FlowbeeEffectiveDirection;
 use allocative_derive::Allocative;
+use arc_swap::ArcSwap;
 use fxhash::FxHashMap;
+use lqos_bus::FlowbeeProtocol;
 use lqos_sys::flowbee_data::{FlowbeeData, FlowbeeKey};
+use lqos_utils::hash_to_i64;
 use lqos_utils::qoo::QoqScores;
 use lqos_utils::rtt::RttBucket;
 use lqos_utils::units::DownUpOrder;
@@ -17,15 +22,281 @@ use serde::ser::SerializeStruct;
 use serde::ser::SerializeTuple;
 use serde::{Serialize, Serializer};
 use smallvec::SmallVec;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::{Mutex as StdMutex, MutexGuard, OnceLock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Allocative)]
 pub struct AsnId(pub u32);
 
-pub static ALL_FLOWS: Lazy<Mutex<FlowTracker>> = Lazy::new(|| Mutex::new(FlowTracker::default()));
+static ALL_FLOWS: Lazy<Mutex<FlowTracker>> = Lazy::new(|| Mutex::new(FlowTracker::default()));
+static ACTIVE_FLOW_SNAPSHOT: Lazy<ArcSwap<Vec<ActiveFlowSnapshot>>> =
+    Lazy::new(|| ArcSwap::new(Arc::new(Vec::new())));
+static ACTIVE_FLOW_LIVE_COUNT: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Default, Allocative)]
-pub struct FlowTracker {
-    pub flow_data: FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>,
+struct FlowTracker {
+    flow_data: FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>,
+}
+
+/// Shared display fields derived when active-flow snapshots are published.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ActiveFlowDisplayFields {
+    /// Remote endpoint address as display text.
+    pub(crate) remote_ip: String,
+    /// Local endpoint address as display text.
+    pub(crate) local_ip: String,
+    /// Source port from the original flow key.
+    pub(crate) src_port: u16,
+    /// Destination port from the original flow key.
+    pub(crate) dst_port: u16,
+    /// Protocol from the original flow key.
+    pub(crate) ip_protocol: FlowbeeProtocol,
+    /// Remote ASN identifier.
+    pub(crate) remote_asn: u32,
+    /// Remote ASN display name.
+    pub(crate) remote_asn_name: String,
+    /// Remote ASN country code.
+    pub(crate) remote_asn_country: String,
+    /// Flow protocol/application analysis label.
+    pub(crate) analysis: String,
+}
+
+/// Copied view of an active flow for read-heavy UI, bus, and Insight paths.
+///
+/// This type intentionally stores only owned data from the live flow table and common display
+/// fields derived during the scheduled snapshot refresh.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ActiveFlowSnapshot {
+    pub(crate) key: FlowbeeKey,
+    pub(crate) display: ActiveFlowDisplayFields,
+    pub(crate) bytes_sent: DownUpOrder<u64>,
+    pub(crate) packets_sent: DownUpOrder<u64>,
+    pub(crate) rate_estimate_bps: DownUpOrder<u32>,
+    pub(crate) tcp_retransmits: DownUpOrder<u16>,
+    pub(crate) end_status: u8,
+    pub(crate) tos: u8,
+    pub(crate) flags: u8,
+    pub(crate) circuit_hash: Option<i64>,
+    pub(crate) device_hash: Option<i64>,
+    pub(crate) circuit_id: String,
+    pub(crate) circuit_name: String,
+    pub(crate) device_name: String,
+    pub(crate) last_seen: u64,
+    pub(crate) start_time: u64,
+    pub(crate) rtt_nanos: DownUpOrder<u64>,
+    pub(crate) qoo: DownUpOrder<Option<f32>>,
+}
+
+impl ActiveFlowSnapshot {
+    /// Returns the flow age relative to the caller's timestamp.
+    pub(crate) fn age_nanos(&self, now_nanos: u64) -> u64 {
+        now_nanos.saturating_sub(self.last_seen)
+    }
+}
+
+impl ActiveFlowSnapshot {
+    fn from_entry(key: &FlowbeeKey, local: &FlowbeeLocalData, analysis: &FlowAnalysis) -> Self {
+        let key = *key;
+        Self {
+            key,
+            display: ActiveFlowDisplayFields {
+                remote_ip: key.remote_ip.as_ip().to_string(),
+                local_ip: key.local_ip.as_ip().to_string(),
+                src_port: key.src_port,
+                dst_port: key.dst_port,
+                ip_protocol: FlowbeeProtocol::from(key.ip_protocol),
+                remote_asn: analysis.asn_id.0,
+                remote_asn_name: String::new(),
+                remote_asn_country: String::new(),
+                analysis: analysis.protocol_analysis.to_string(),
+            },
+            bytes_sent: local.bytes_sent,
+            packets_sent: local.packets_sent,
+            rate_estimate_bps: local.rate_estimate_bps,
+            tcp_retransmits: local.tcp_retransmits,
+            end_status: local.end_status,
+            tos: local.tos,
+            flags: local.get_flags(),
+            circuit_hash: local.circuit_hash,
+            device_hash: local.device_hash,
+            last_seen: local.last_seen,
+            start_time: local.start_time,
+            rtt_nanos: DownUpOrder::new(
+                local.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download),
+                local.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Upload),
+            ),
+            qoo: {
+                let scores = local.get_qoq_scores();
+                DownUpOrder::new(scores.download_total_f32(), scores.upload_total_f32())
+            },
+            circuit_id: local.circuit_id_hint.clone().unwrap_or_default(),
+            circuit_name: String::new(),
+            device_name: String::new(),
+        }
+    }
+
+    fn enrich_display_fields(&mut self, catalog: &lqos_network_devices::NetworkDevicesCatalog) {
+        let geo = get_asn_name_and_country(self.key.remote_ip.as_ip());
+        let device = crate::throughput_tracker::resolve_flow_device(
+            catalog,
+            &self.key.local_ip,
+            self.device_hash,
+            self.circuit_hash,
+        );
+        let (circuit_id, circuit_name) =
+            crate::throughput_tracker::flow_circuit_metadata_from_device(
+                device,
+                (!self.circuit_id.is_empty()).then_some(self.circuit_id.as_str()),
+            );
+
+        self.display.remote_asn_name = geo.name;
+        self.display.remote_asn_country = geo.country;
+        self.circuit_hash = device
+            .map(|device| device.circuit_hash)
+            .or(self.circuit_hash)
+            .or_else(|| (!circuit_id.is_empty()).then(|| hash_to_i64(&circuit_id)));
+        self.device_hash = device.map(|device| device.device_hash).or(self.device_hash);
+        self.circuit_id = circuit_id;
+        self.circuit_name = circuit_name;
+        self.device_name = device
+            .map(|device| device.device_name.clone())
+            .unwrap_or_default();
+    }
+}
+
+fn copy_active_flow_snapshot(
+    flow_data: &FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>,
+) -> Vec<ActiveFlowSnapshot> {
+    flow_data
+        .iter()
+        .map(|(key, (local, analysis))| ActiveFlowSnapshot::from_entry(key, local, analysis))
+        .collect()
+}
+
+fn enrich_active_flow_snapshot(
+    snapshot: &mut [ActiveFlowSnapshot],
+    catalog: &lqos_network_devices::NetworkDevicesCatalog,
+) {
+    for flow in snapshot {
+        flow.enrich_display_fields(catalog);
+    }
+}
+
+fn publish_active_flow_snapshot(snapshot: Vec<ActiveFlowSnapshot>) {
+    ACTIVE_FLOW_SNAPSHOT.store(Arc::new(snapshot));
+}
+
+/// Refreshes the cached active-flow snapshot from the live flow table.
+///
+/// The throughput monitor calls this once per update cycle after live flow writes complete.
+pub(in crate::throughput_tracker) fn refresh_active_flow_snapshot() {
+    let mut snapshot = {
+        let all_flows = ALL_FLOWS.lock();
+        copy_active_flow_snapshot(&all_flows.flow_data)
+    };
+    let catalog = lqos_network_devices::network_devices_catalog();
+    enrich_active_flow_snapshot(&mut snapshot, &catalog);
+    publish_active_flow_snapshot(snapshot);
+}
+
+/// Returns the latest cached active-flow snapshot.
+///
+/// The snapshot is refreshed by the throughput monitor after the live flow table is updated.
+pub(crate) fn active_flow_snapshot() -> Arc<Vec<ActiveFlowSnapshot>> {
+    ACTIVE_FLOW_SNAPSHOT.load_full()
+}
+
+/// Returns the number of active flows in the latest published snapshot.
+#[cfg(test)]
+pub(crate) fn active_flow_snapshot_count() -> u64 {
+    ACTIVE_FLOW_SNAPSHOT.load().len() as u64
+}
+
+/// Returns the latest live active-flow count published by the write gateway.
+pub(crate) fn live_active_flow_count() -> u64 {
+    ACTIVE_FLOW_LIVE_COUNT.load(Ordering::Relaxed)
+}
+
+/// Visits active-flow snapshot rows for a circuit after a recent cutoff.
+pub(crate) fn for_each_active_flow_for_circuit(
+    circuit_hash: i64,
+    recent_cutoff_nanos: u64,
+    mut visit: impl FnMut(&ActiveFlowSnapshot),
+) {
+    let snapshot = active_flow_snapshot();
+    for flow in snapshot.iter().filter(|flow| {
+        flow.last_seen >= recent_cutoff_nanos
+            && (flow.circuit_hash == Some(circuit_hash)
+                || (flow.circuit_hash.is_none()
+                    && !flow.circuit_id.is_empty()
+                    && hash_to_i64(&flow.circuit_id) == circuit_hash))
+    }) {
+        visit(flow);
+    }
+}
+
+/// Mutates the live flow table.
+///
+/// This function is the only write gateway for the live active-flow table. The caller's closure
+/// must avoid blocking I/O, channel sends, DNS/network lookups, and other unrelated work while it
+/// has access to the live map. Cached reader snapshots are refreshed separately once per throughput
+/// update cycle.
+pub(in crate::throughput_tracker) fn mutate_all_flows<R>(
+    f: impl FnOnce(&mut FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>) -> R,
+) -> R {
+    let mut all_flows = ALL_FLOWS.lock();
+    let result = f(&mut all_flows.flow_data);
+    ACTIVE_FLOW_LIVE_COUNT.store(all_flows.flow_data.len() as u64, Ordering::Relaxed);
+    result
+}
+
+/// Converts non-zero retry timestamps with a caller-provided boot-time-to-Unix converter.
+pub(crate) fn retry_times_to_unix_seconds(
+    times: &[u64],
+    to_unix_seconds: impl Fn(u64) -> u64,
+) -> Vec<u64> {
+    times
+        .iter()
+        .copied()
+        .filter(|timestamp| *timestamp > 0)
+        .map(to_unix_seconds)
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) fn active_flow_test_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| StdMutex::new(())).lock().unwrap()
+}
+
+#[cfg(test)]
+fn replace_active_flows_for_test_inner(
+    flows: impl IntoIterator<Item = (FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
+    publish_snapshot: bool,
+) {
+    mutate_all_flows(|flow_data| {
+        flow_data.clear();
+        flow_data.extend(flows);
+    });
+    if publish_snapshot {
+        refresh_active_flow_snapshot();
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn replace_active_flows_for_test(
+    flows: impl IntoIterator<Item = (FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
+) {
+    replace_active_flows_for_test_inner(flows, true);
+}
+
+#[cfg(test)]
+pub(crate) fn replace_active_flows_live_for_test(
+    flows: impl IntoIterator<Item = (FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
+) {
+    replace_active_flows_for_test_inner(flows, false);
 }
 
 #[derive(Clone)]
@@ -52,6 +323,8 @@ pub struct FlowbeeLocalDataTcp {
     pub flags: u8,
     /// Recent RTT data for the flow
     pub rtt: RttBuffer,
+    /// Cached current p50 RTT values for snapshot readers.
+    pub summary_rtt_nanos: DownUpOrder<u64>,
     /// QoQ scores (0..100) for the flow, derived from RTT/throughput/retransmits.
     pub qoq: QoqScores,
     /// When did the retries happen? In nanoseconds since kernel boot
@@ -95,6 +368,8 @@ pub struct FlowbeeLocalData {
     pub circuit_hash: Option<i64>,
     /// Hashed device identifier (bit-pattern of `hash_to_i64` stored as `u64`).
     pub device_hash: Option<i64>,
+    /// Last-known circuit ID copied from the throughput table when catalog metadata is available.
+    pub circuit_id_hint: Option<String>,
     /// TCP-only data. Boxed for now; TODO: use a slab/slot type setup for coherence in the future.
     pub tcp_info: Option<Box<FlowbeeLocalDataTcp>>,
 }
@@ -155,10 +430,12 @@ impl FlowbeeLocalData {
             } else {
                 Some(data.device_hash as i64)
             },
+            circuit_id_hint: None,
             tcp_info: if key.ip_protocol == 6 {
                 Some(Box::new(FlowbeeLocalDataTcp {
                     flags: data.flags,
                     rtt: RttBuffer::default(),
+                    summary_rtt_nanos: DownUpOrder::zeroed(),
                     qoq: QoqScores::default(),
                     retry_times_down: SmallVec::new(),
                     retry_times_up: SmallVec::new(),
@@ -170,45 +447,17 @@ impl FlowbeeLocalData {
     }
 
     pub fn get_summary_rtt_as_nanos(&self, direction: FlowbeeEffectiveDirection) -> u64 {
-        // TODO: This function is due for deprecation, it's in place for
-        // compatibility only right now. Kill it with fire!
-
         let Some(tcp_info) = &self.tcp_info else {
             return 0;
         };
-        tcp_info
-            .rtt
-            .percentile(RttBucket::Current, direction, 50)
-            .unwrap_or(RttData::from_nanos(0))
-            .as_nanos()
+        match direction {
+            FlowbeeEffectiveDirection::Download => tcp_info.summary_rtt_nanos.down,
+            FlowbeeEffectiveDirection::Upload => tcp_info.summary_rtt_nanos.up,
+        }
     }
 
     pub fn get_summary_rtt_as_micros(&self, direction: FlowbeeEffectiveDirection) -> f64 {
-        // TODO: This function is due for deprecation, it's in place for
-        // compatibility only right now. Kill it with fire!
-
-        let Some(tcp_info) = &self.tcp_info else {
-            return 0.0;
-        };
-        tcp_info
-            .rtt
-            .percentile(RttBucket::Current, direction, 50)
-            .unwrap_or(RttData::from_nanos(0))
-            .as_micros()
-    }
-
-    pub fn get_summary_rtt_as_millis(&self, direction: FlowbeeEffectiveDirection) -> f64 {
-        // TODO: This function is due for deprecation, it's in place for
-        // compatibility only right now. Kill it with fire!
-
-        let Some(tcp_info) = &self.tcp_info else {
-            return 0.0;
-        };
-        tcp_info
-            .rtt
-            .percentile(RttBucket::Current, direction, 50)
-            .unwrap_or(RttData::from_nanos(0))
-            .as_millis()
+        self.get_summary_rtt_as_nanos(direction) as f64 / 1_000.0
     }
 
     pub fn get_retry_times_down(&self) -> &[u64] {
@@ -283,16 +532,6 @@ impl FlowbeeLocalData {
         tcp_info.flags
     }
 
-    pub fn get_rtt(&self, direction: FlowbeeEffectiveDirection) -> RttData {
-        let Some(tcp_info) = &self.tcp_info else {
-            return RttData::from_nanos(0);
-        };
-        tcp_info
-            .rtt
-            .percentile(RttBucket::Current, direction, 50)
-            .unwrap_or(RttData::from_nanos(0))
-    }
-
     pub fn set_last_seen(&mut self, last_seen: u64) {
         self.last_seen = last_seen;
     }
@@ -328,11 +567,62 @@ impl FlowbeeLocalData {
         tcp_info.flags = flags;
     }
 
+    /// Updates the live circuit/device metadata copied into active-flow snapshots.
+    pub fn set_tracking_metadata(
+        &mut self,
+        circuit_hash: Option<i64>,
+        device_hash: Option<i64>,
+        circuit_id: Option<&str>,
+    ) {
+        if circuit_hash.is_some() {
+            self.circuit_hash = circuit_hash;
+        }
+        if device_hash.is_some() {
+            self.device_hash = device_hash;
+        }
+        self.set_circuit_id_hint(circuit_id);
+    }
+
+    /// Updates the last-known circuit ID hint without clearing it on transient misses.
+    pub fn set_circuit_id_hint(&mut self, circuit_id: Option<&str>) {
+        let Some(circuit_id) = circuit_id.filter(|id| !id.is_empty()) else {
+            return;
+        };
+        if self.circuit_id_hint.as_deref() != Some(circuit_id) {
+            self.circuit_id_hint = Some(circuit_id.to_string());
+        }
+    }
+
     pub fn set_rtt_buffer(&mut self, rtt: RttBuffer) {
         let Some(tcp_info) = &mut self.tcp_info else {
             return;
         };
         tcp_info.rtt.merge_fresh_from(rtt);
+        tcp_info.summary_rtt_nanos = DownUpOrder::new(
+            tcp_info
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Download, 50)
+                .unwrap_or(RttData::from_nanos(0))
+                .as_nanos(),
+            tcp_info
+                .rtt
+                .percentile(RttBucket::Current, FlowbeeEffectiveDirection::Upload, 50)
+                .unwrap_or(RttData::from_nanos(0))
+                .as_nanos(),
+        );
+    }
+
+    /// Retires the raw RTT histogram while retaining the last-known summary and QoO values.
+    pub fn retire_stale_rtt(&mut self, expire_before_nanos: u64) -> bool {
+        let Some(tcp_info) = &mut self.tcp_info else {
+            return false;
+        };
+        if tcp_info.rtt.last_seen > expire_before_nanos {
+            return false;
+        }
+
+        tcp_info.rtt.clear();
+        true
     }
 
     pub fn set_qoq_scores(&mut self, scores: QoqScores) {
@@ -362,5 +652,251 @@ impl FlowbeeLocalData {
             target.remove(0);
         }
         target.push(timestamp_nanos);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::throughput_tracker::flow_data::flow_analysis::FlowProtocol;
+    use lqos_utils::qoo::QoqScores;
+
+    fn sample_flow() -> (FlowbeeKey, FlowbeeLocalData, FlowAnalysis) {
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 51_515;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+        raw.tcp_retransmits = DownUpOrder::new(1, 2);
+        raw.end_status = 0;
+        raw.tos = 4;
+        raw.flags = 0x12;
+        raw.tc_handle = 123;
+        raw.cpu = 2;
+        raw.circuit_hash = 44;
+        raw.device_hash = 55;
+
+        let mut local = FlowbeeLocalData::from_flow(&raw, &key);
+        let mut rtt = RttBuffer::new(
+            RttData::from_nanos(12_000_000),
+            FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(12_000_000),
+            FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(34_000_000),
+            FlowbeeEffectiveDirection::Upload,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(34_000_000),
+            FlowbeeEffectiveDirection::Upload,
+            raw.last_seen,
+        );
+        local.set_rtt_buffer(rtt);
+        local.set_qoq_scores(QoqScores {
+            download_total: 77,
+            upload_total: 66,
+        });
+        let analysis = FlowAnalysis {
+            asn_id: AsnId(64_512),
+            protocol_analysis: FlowProtocol::Https,
+        };
+        (key, local, analysis)
+    }
+
+    #[test]
+    fn active_flow_snapshot_copies_live_flow_fields() {
+        let (key, mut local, analysis) = sample_flow();
+        local.set_circuit_id_hint(Some("hint-circuit"));
+        let mut flows = FxHashMap::default();
+        flows.insert(key, (local.clone(), analysis));
+
+        let mut snapshot = copy_active_flow_snapshot(&flows);
+        let catalog = lqos_network_devices::NetworkDevicesCatalog::from_snapshots(
+            lqos_network_devices::ShapedDevicesCatalog::from_shaped_devices(Arc::new(
+                lqos_config::ConfigShapedDevices::default(),
+            )),
+            Arc::new(Vec::new()),
+        );
+        enrich_active_flow_snapshot(&mut snapshot, &catalog);
+
+        assert_eq!(snapshot.len(), 1);
+        let row = &snapshot[0];
+        assert_eq!(row.key, key);
+        assert_eq!(row.display.remote_ip, key.remote_ip.as_ip().to_string());
+        assert_eq!(row.display.local_ip, key.local_ip.as_ip().to_string());
+        assert_eq!(row.display.src_port, key.src_port);
+        assert_eq!(row.display.dst_port, key.dst_port);
+        assert_eq!(row.display.ip_protocol, FlowbeeProtocol::TCP);
+        assert_eq!(row.display.remote_asn, analysis.asn_id.0);
+        assert_eq!(row.display.analysis, "HTTPS");
+        assert_eq!(row.bytes_sent, local.bytes_sent);
+        assert_eq!(row.packets_sent, local.packets_sent);
+        assert_eq!(row.rate_estimate_bps, local.rate_estimate_bps);
+        assert_eq!(row.tcp_retransmits, local.tcp_retransmits);
+        assert_eq!(row.end_status, local.end_status);
+        assert_eq!(row.tos, local.tos);
+        assert_eq!(row.flags, local.get_flags());
+        assert_eq!(row.circuit_hash, Some(44));
+        assert_eq!(row.device_hash, Some(55));
+        assert_eq!(row.circuit_id, "hint-circuit");
+        assert_eq!(row.circuit_name, "");
+        assert_eq!(row.device_name, "");
+        assert_eq!(row.last_seen, local.last_seen);
+        assert_eq!(row.start_time, local.start_time);
+        assert_eq!(row.rtt_nanos, DownUpOrder::new(14_000_000, 35_000_000));
+        assert_eq!(row.qoo, DownUpOrder::new(Some(77.0), Some(66.0)));
+    }
+
+    #[test]
+    fn retry_times_to_unix_seconds_filters_zeroes_and_preserves_order() {
+        let converted =
+            retry_times_to_unix_seconds(&[0, 2_000_000_000, 1_000_000_000, 0], |timestamp| {
+                1_700_000_000 + timestamp / 1_000_000_000
+            });
+
+        assert_eq!(converted, vec![1_700_000_002, 1_700_000_001]);
+    }
+
+    #[test]
+    fn retire_stale_rtt_keeps_cached_summary_and_qoo() {
+        let (_key, mut local, _analysis) = sample_flow();
+        assert_eq!(
+            local.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download),
+            14_000_000
+        );
+        assert_eq!(
+            local.get_rtt_array()[0].as_nanos(),
+            local.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download)
+        );
+        assert_eq!(local.get_qoq_scores().download_total_f32(), Some(77.0));
+
+        assert!(local.retire_stale_rtt(21));
+
+        assert_eq!(
+            local.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download),
+            14_000_000
+        );
+        assert_eq!(
+            local.get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Upload),
+            35_000_000
+        );
+        assert_eq!(local.get_rtt_array()[0].as_nanos(), 0);
+        assert_eq!(local.get_rtt_array()[1].as_nanos(), 0);
+        assert_eq!(local.get_qoq_scores().download_total_f32(), Some(77.0));
+
+        let (_key, mut boundary_local, _analysis) = sample_flow();
+        assert!(!boundary_local.retire_stale_rtt(19));
+        assert_ne!(boundary_local.get_rtt_array()[0].as_nanos(), 0);
+        assert!(boundary_local.retire_stale_rtt(20));
+        assert_eq!(boundary_local.get_rtt_array()[0].as_nanos(), 0);
+    }
+
+    #[test]
+    fn tracking_metadata_survives_transient_missing_metadata() {
+        let (_key, mut local, _analysis) = sample_flow();
+
+        local.set_tracking_metadata(Some(100), Some(200), Some("circuit-one"));
+        local.set_tracking_metadata(Some(101), Some(201), None);
+        local.set_tracking_metadata(None, None, None);
+
+        assert_eq!(local.circuit_hash, Some(101));
+        assert_eq!(local.device_hash, Some(201));
+        assert_eq!(local.circuit_id_hint.as_deref(), Some("circuit-one"));
+    }
+
+    #[test]
+    fn circuit_snapshot_reader_matches_preserved_circuit_id_when_hash_is_missing() {
+        let _guard = active_flow_test_lock();
+        let (key, mut local, analysis) = sample_flow();
+        local.circuit_hash = None;
+        local.device_hash = None;
+        local.set_circuit_id_hint(Some("hint-circuit"));
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+            flows.insert(key, (local, analysis));
+        });
+        refresh_active_flow_snapshot();
+
+        let mut matched = Vec::new();
+        for_each_active_flow_for_circuit(hash_to_i64("hint-circuit"), 0, |flow| {
+            matched.push(flow.key);
+        });
+
+        assert_eq!(matched, vec![key]);
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
+    }
+
+    #[test]
+    fn circuit_snapshot_reader_does_not_match_stale_hint_when_hash_is_present() {
+        let _guard = active_flow_test_lock();
+        let (key, mut local, analysis) = sample_flow();
+        local.circuit_hash = Some(hash_to_i64("current-circuit"));
+        local.device_hash = None;
+        local.set_circuit_id_hint(Some("old-circuit"));
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+            flows.insert(key, (local, analysis));
+        });
+        refresh_active_flow_snapshot();
+
+        let mut current_matches = Vec::new();
+        for_each_active_flow_for_circuit(hash_to_i64("current-circuit"), 0, |flow| {
+            current_matches.push(flow.key);
+        });
+        let mut old_matches = Vec::new();
+        for_each_active_flow_for_circuit(hash_to_i64("old-circuit"), 0, |flow| {
+            old_matches.push(flow.key);
+        });
+
+        assert_eq!(current_matches, vec![key]);
+        assert!(old_matches.is_empty());
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
+    }
+
+    #[test]
+    fn refresh_active_flow_snapshot_publishes_count_and_stable_arcs() {
+        let _guard = active_flow_test_lock();
+        let (key, local, analysis) = sample_flow();
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+            flows.insert(key, (local, analysis));
+        });
+        refresh_active_flow_snapshot();
+
+        let snapshot = active_flow_snapshot();
+        assert_eq!(active_flow_snapshot_count(), 1);
+        assert_eq!(live_active_flow_count(), 1);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].key, key);
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+        });
+        refresh_active_flow_snapshot();
+
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].key, key);
+        assert_eq!(active_flow_snapshot_count(), 0);
+        assert_eq!(live_active_flow_count(), 0);
+        assert!(active_flow_snapshot().is_empty());
     }
 }

--- a/src/rust/lqosd/src/throughput_tracker/flow_data/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/mod.rs
@@ -17,10 +17,18 @@ use crossbeam_channel::Sender;
 pub(crate) use flow_analysis::{
     AsnCountryListEntry, AsnListEntry, AsnProtocolListEntry, FlowActor, FlowAnalysis,
     FlowbeeEffectiveDirection, RECENT_FLOWS, RttBuffer, RttData, expire_rtt_flows,
-    flowbee_handle_events, flowbee_rtt_map, get_asn_name_and_country, get_asn_name_by_id,
-    get_flowbee_event_count_and_reset, get_rtt_events_per_second, setup_flow_analysis,
+    flowbee_handle_events, flowbee_rtt_map, get_asn_name_by_id, get_flowbee_event_count_and_reset,
+    get_rtt_events_per_second, setup_flow_analysis,
 };
-pub(crate) use flow_tracker::{ALL_FLOWS, AsnId, FlowbeeLocalData};
+#[cfg(test)]
+pub(crate) use flow_tracker::{
+    active_flow_test_lock, replace_active_flows_for_test, replace_active_flows_live_for_test,
+};
+pub(crate) use flow_tracker::{
+    ActiveFlowDisplayFields, ActiveFlowSnapshot, AsnId, FlowbeeLocalData, active_flow_snapshot,
+    for_each_active_flow_for_circuit, live_active_flow_count, retry_times_to_unix_seconds,
+};
+pub(in crate::throughput_tracker) use flow_tracker::{mutate_all_flows, refresh_active_flow_snapshot};
 use lqos_sys::flowbee_data::FlowbeeKey;
 use tracing::{debug, error, info};
 

--- a/src/rust/lqosd/src/throughput_tracker/flow_data/netflow5/protocol.rs
+++ b/src/rust/lqosd/src/throughput_tracker/flow_data/netflow5/protocol.rs
@@ -176,6 +176,7 @@ mod tests {
             cpu: 0,
             circuit_hash: None,
             device_hash: None,
+            circuit_id_hint: None,
             tcp_info: None,
         }
     }

--- a/src/rust/lqosd/src/throughput_tracker/mod.rs
+++ b/src/rust/lqosd/src/throughput_tracker/mod.rs
@@ -4,8 +4,8 @@ mod throughput_entry;
 mod tracking_data;
 
 use self::flow_data::{
-    ALL_FLOWS, FlowAnalysis, FlowbeeLocalData, get_asn_name_and_country, get_asn_name_by_id,
-    snapshot_asn_heatmaps,
+    ActiveFlowSnapshot, FlowAnalysis, FlowbeeLocalData, active_flow_snapshot, get_asn_name_by_id,
+    live_active_flow_count, refresh_active_flow_snapshot, snapshot_asn_heatmaps,
 };
 use self::throughput_entry::ThroughputEntry;
 use crate::system_stats::SystemStats;
@@ -19,16 +19,21 @@ pub(crate) use flow_data::RttBuffer;
 use fxhash::{FxHashMap, FxHashSet};
 use lqos_bakery::{BakeryCommands, full_reload_in_progress};
 use lqos_bus::{
-    AsnHeatmapData, BusResponse, CircuitHeatmapData, ExecutiveSummaryHeader, FlowbeeProtocol,
-    IpStats, SiteHeatmapData, TcHandle, TopFlowType, XdpPpingResult,
+    AsnHeatmapData, BusResponse, CircuitHeatmapData, ExecutiveSummaryHeader, IpStats,
+    SiteHeatmapData, TcHandle, TopFlowType, XdpPpingResult,
 };
 use lqos_queue_tracker::{ALL_QUEUE_SUMMARY, queue_stats_stale};
 use lqos_sys::flowbee_data::FlowbeeKey;
+#[cfg(test)]
+use lqos_utils::qoo::QoqScores;
 use lqos_utils::rtt::RttBucket;
+#[cfg(test)]
+use lqos_utils::rtt::RttData;
 use lqos_utils::units::{DownUpOrder, TcpRetransmitSample, down_up_retransmit_sample};
 use lqos_utils::{XdpIpAddress, hash_to_i64, unix_time::time_since_boot};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::net::IpAddr;
 use std::sync::Arc;
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
@@ -37,6 +42,7 @@ use tracing::{debug, info, warn};
 
 const RETIRE_AFTER_SECONDS: u64 = 30;
 const RELOAD_THROUGHPUT_POLL_INTERVAL_SECONDS: u64 = 5;
+type FinishedFlowExport = (FlowbeeKey, (FlowbeeLocalData, FlowAnalysis));
 
 pub static THROUGHPUT_TRACKER: Lazy<ThroughputTracker> = Lazy::new(ThroughputTracker::new);
 pub(crate) static CIRCUIT_RTT_BUFFERS: Lazy<ArcSwap<FxHashMap<i64, RttBuffer>>> =
@@ -74,18 +80,51 @@ pub(crate) fn circuit_current_qoo(circuit_hash: i64) -> DownUpOrder<Option<f32>>
     }
 }
 
-fn resolve_circuit_metadata_for_entry(
-    catalog: &lqos_network_devices::NetworkDevicesCatalog,
+fn finish_expired_flows(
+    finished_flow_exports: &mut Vec<FinishedFlowExport>,
+    expired_flows: &mut [FlowbeeKey],
+    netflow_sender: &crossbeam_channel::Sender<FinishedFlowExport>,
+    end_flows: impl FnOnce(&mut [FlowbeeKey]) -> anyhow::Result<()>,
+) {
+    for export in finished_flow_exports.drain(..) {
+        if let Err(e) = netflow_sender.send(export) {
+            warn!("Failed to send finished flow export: {:?}", e);
+        }
+    }
+
+    if !expired_flows.is_empty()
+        && let Err(e) = end_flows(expired_flows)
+    {
+        warn!("Failed to end flows: {:?}", e);
+    }
+}
+
+fn dedup_flow_keys(keys: &mut Vec<FlowbeeKey>) {
+    let mut seen = FxHashSet::default();
+    keys.retain(|key| seen.insert(*key));
+}
+
+/// Resolves the shaped-device row for an active flow from its hashes, then its local IP.
+pub(crate) fn resolve_flow_device<'a>(
+    catalog: &'a lqos_network_devices::NetworkDevicesCatalog,
     ip: &XdpIpAddress,
-    entry: &ThroughputEntry,
+    device_hash: Option<i64>,
+    circuit_hash: Option<i64>,
+) -> Option<&'a lqos_config::ShapedDevice> {
+    catalog
+        .device_by_hashes(device_hash, circuit_hash)
+        .or_else(|| catalog.device_longest_match_for_ip(ip).map(|(_, dev)| dev))
+}
+
+/// Resolves circuit ID/name metadata for an active-flow or throughput row.
+pub(crate) fn flow_circuit_metadata_from_device(
+    device: Option<&lqos_config::ShapedDevice>,
+    circuit_id_hint: Option<&str>,
 ) -> (String, String) {
-    let mut circuit_id = entry.circuit_id.clone().unwrap_or_default();
+    let mut circuit_id = circuit_id_hint.unwrap_or_default().to_string();
     let mut circuit_name = String::new();
 
-    if let Some(device) = catalog
-        .device_by_hashes(entry.device_hash, entry.circuit_hash)
-        .or_else(|| catalog.device_longest_match_for_ip(ip).map(|(_, dev)| dev))
-    {
+    if let Some(device) = device {
         if circuit_id.is_empty() {
             circuit_id = device.circuit_id.clone();
         }
@@ -95,6 +134,17 @@ fn resolve_circuit_metadata_for_entry(
     (circuit_id, circuit_name)
 }
 
+fn resolve_circuit_metadata_for_entry(
+    catalog: &lqos_network_devices::NetworkDevicesCatalog,
+    ip: &XdpIpAddress,
+    entry: &ThroughputEntry,
+) -> (String, String) {
+    flow_circuit_metadata_from_device(
+        resolve_flow_device(catalog, ip, entry.device_hash, entry.circuit_hash),
+        entry.circuit_id.as_deref(),
+    )
+}
+
 pub(crate) fn resolve_circuit_metadata_for_ip(ip: &XdpIpAddress) -> (String, String) {
     let catalog = lqos_network_devices::network_devices_catalog();
     let throughput = THROUGHPUT_TRACKER.raw_data.lock();
@@ -102,6 +152,87 @@ pub(crate) fn resolve_circuit_metadata_for_ip(ip: &XdpIpAddress) -> (String, Str
         return (String::new(), String::new());
     };
     resolve_circuit_metadata_for_entry(&catalog, ip, entry)
+}
+
+#[cfg(test)]
+pub(crate) struct RawThroughputTestEntry {
+    pub(crate) ip: XdpIpAddress,
+    pub(crate) circuit_hash: Option<i64>,
+    pub(crate) device_hash: Option<i64>,
+    pub(crate) most_recent_cycle: u64,
+    pub(crate) bytes_per_second: DownUpOrder<u64>,
+    pub(crate) tcp_packets: DownUpOrder<u64>,
+    pub(crate) tcp_retransmits: DownUpOrder<u64>,
+}
+
+#[cfg(test)]
+pub(crate) struct RawThroughputTestGuard {
+    old_cycle: u64,
+    old_raw_data: Option<std::collections::HashMap<XdpIpAddress, ThroughputEntry>>,
+}
+
+#[cfg(test)]
+impl Drop for RawThroughputTestGuard {
+    fn drop(&mut self) {
+        THROUGHPUT_TRACKER
+            .cycle
+            .store(self.old_cycle, std::sync::atomic::Ordering::Relaxed);
+        if let Some(old_raw_data) = self.old_raw_data.take() {
+            *THROUGHPUT_TRACKER.raw_data.lock() = old_raw_data;
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn replace_raw_throughput_for_test(
+    cycle: u64,
+    entries: Vec<RawThroughputTestEntry>,
+) -> RawThroughputTestGuard {
+    let old_cycle = THROUGHPUT_TRACKER
+        .cycle
+        .swap(cycle, std::sync::atomic::Ordering::Relaxed);
+    let mut raw_data = THROUGHPUT_TRACKER.raw_data.lock();
+    let old_raw_data = std::mem::take(&mut *raw_data);
+    for entry in entries {
+        raw_data.insert(
+            entry.ip,
+            ThroughputEntry {
+                circuit_id: None,
+                circuit_hash: entry.circuit_hash,
+                device_hash: entry.device_hash,
+                network_json_parents: None,
+                first_cycle: 0,
+                most_recent_cycle: entry.most_recent_cycle,
+                bytes: DownUpOrder::zeroed(),
+                actual_bytes: DownUpOrder::zeroed(),
+                packets: DownUpOrder::zeroed(),
+                tcp_packets: entry.tcp_packets,
+                udp_packets: DownUpOrder::zeroed(),
+                icmp_packets: DownUpOrder::zeroed(),
+                prev_bytes: DownUpOrder::zeroed(),
+                prev_actual_bytes: DownUpOrder::zeroed(),
+                prev_packets: DownUpOrder::zeroed(),
+                prev_tcp_packets: DownUpOrder::zeroed(),
+                prev_udp_packets: DownUpOrder::zeroed(),
+                prev_icmp_packets: DownUpOrder::zeroed(),
+                bytes_per_second: entry.bytes_per_second,
+                actual_bytes_per_second: DownUpOrder::zeroed(),
+                packets_per_second: DownUpOrder::zeroed(),
+                tc_handle: TcHandle::from_u32(0),
+                rtt_buffer: RttBuffer::default(),
+                recent_rtt_data: [RttData::from_nanos(0); 60],
+                last_fresh_rtt_data_cycle: 0,
+                last_seen: 0,
+                tcp_retransmits: entry.tcp_retransmits,
+                tcp_retransmit_packets: DownUpOrder::zeroed(),
+                qoq: QoqScores::default(),
+            },
+        );
+    }
+    RawThroughputTestGuard {
+        old_cycle,
+        old_raw_data: Some(old_raw_data),
+    }
 }
 
 /// Create the throughput monitor thread, and begin polling for
@@ -216,6 +347,7 @@ fn throughput_task(
     let mut tcp_retries: FxHashMap<XdpIpAddress, DownUpOrder<u64>> = FxHashMap::default();
     let mut tcp_retry_packets: FxHashMap<XdpIpAddress, DownUpOrder<u64>> = FxHashMap::default();
     let mut expired_flows: Vec<FlowbeeKey> = Vec::new();
+    let mut finished_flow_exports: Vec<FinishedFlowExport> = Vec::new();
 
     // Counter for occasional stats
     let mut stats_counter = 0;
@@ -250,7 +382,6 @@ fn throughput_task(
             reload_backoff_logged = false;
         }
 
-        // Formerly a "spawn blocking" blob
         {
             lqos_network_devices::with_network_json_write(|net_json_calc| {
                 timer_metrics.update_cycle = timer_metrics.start.elapsed().as_secs_f64();
@@ -265,13 +396,13 @@ fn throughput_task(
                     timer_metrics.start.elapsed().as_secs_f64();
                 THROUGHPUT_TRACKER.apply_flow_data(FlowApplyContext {
                     timeout_seconds,
-                    sender: netflow_sender.clone(),
                     net_json_calc,
                     rtt_circuit_tracker: &mut rtt_circuit_tracker,
                     rtt_by_circuit: &mut rtt_by_circuit,
                     tcp_retries: &mut tcp_retries,
                     tcp_retry_packets: &mut tcp_retry_packets,
                     expired_keys: &mut expired_flows,
+                    finished_flow_exports: &mut finished_flow_exports,
                 });
                 CIRCUIT_RTT_BUFFERS.store(Arc::new(rtt_by_circuit.clone()));
                 THROUGHPUT_TRACKER.record_circuit_heatmaps();
@@ -279,18 +410,6 @@ fn throughput_task(
                     .map(|config| config.enable_site_heatmaps)
                     .unwrap_or(true);
                 net_json_calc.record_site_heatmaps(enable_site_heatmaps);
-
-                // Clean up work tables
-                rtt_circuit_tracker.clear();
-                rtt_by_circuit.clear();
-                tcp_retries.clear();
-                tcp_retry_packets.clear();
-                expired_flows.clear();
-                rtt_circuit_tracker.shrink_to_fit();
-                rtt_by_circuit.shrink_to_fit();
-                tcp_retries.shrink_to_fit();
-                tcp_retry_packets.shrink_to_fit();
-                expired_flows.shrink_to_fit();
 
                 timer_metrics.apply_flow_data = timer_metrics.start.elapsed().as_secs_f64();
                 if bakery_reload_in_progress {
@@ -306,6 +425,23 @@ fn throughput_task(
                 THROUGHPUT_TRACKER.next_cycle();
                 timer_metrics.next_cycle = timer_metrics.start.elapsed().as_secs_f64();
             });
+
+            dedup_flow_keys(&mut expired_flows);
+            refresh_active_flow_snapshot();
+            finish_expired_flows(
+                &mut finished_flow_exports,
+                expired_flows.as_mut_slice(),
+                &netflow_sender,
+                lqos_sys::end_flows,
+            );
+
+            // Clean up work tables after post-update exports and BPF cleanup.
+            rtt_circuit_tracker.clear();
+            rtt_by_circuit.clear();
+            tcp_retries.clear();
+            tcp_retry_packets.clear();
+            expired_flows.clear();
+
             timer_metrics.finish_update_cycle = timer_metrics.start.elapsed().as_secs_f64();
             let duration_ms = start.elapsed().as_micros();
             TIME_TO_POLL_HOSTS.store(duration_ms as u64, std::sync::atomic::Ordering::Relaxed);
@@ -319,7 +455,6 @@ fn throughput_task(
             );
         } else if let Some(last) = last_submitted_to_lts {
             let elapsed_f64 = last.elapsed().as_secs_f64();
-            // Temporary: place this in a thread to not block the timer
             let my_system_usage_actor = system_usage_actor.clone();
             // Submit if a reasonable amount of time has passed - drop if there was a long hitch
             if elapsed_f64 < 2.0 {
@@ -405,7 +540,7 @@ pub fn host_counters() -> BusResponse {
 }
 
 #[inline(always)]
-fn retire_check(cycle: u64, recent_cycle: u64) -> bool {
+pub(crate) fn retire_check(cycle: u64, recent_cycle: u64) -> bool {
     cycle < recent_cycle + RETIRE_AFTER_SECONDS
 }
 
@@ -1085,147 +1220,77 @@ pub fn all_unknown_ips() -> BusResponse {
     BusResponse::AllUnknownIps(result)
 }
 
-/// For debugging: dump all active flows!
+fn flow_summary_from_snapshot(flow: &ActiveFlowSnapshot) -> lqos_bus::FlowbeeSummaryData {
+    lqos_bus::FlowbeeSummaryData {
+        remote_ip: flow.display.remote_ip.clone(),
+        local_ip: flow.display.local_ip.clone(),
+        src_port: flow.display.src_port,
+        dst_port: flow.display.dst_port,
+        ip_protocol: flow.display.ip_protocol.clone(),
+        bytes_sent: flow.bytes_sent,
+        packets_sent: flow.packets_sent,
+        rate_estimate_bps: flow.rate_estimate_bps,
+        tcp_retransmits: flow.tcp_retransmits,
+        end_status: flow.end_status,
+        tos: flow.tos,
+        flags: flow.flags,
+        remote_asn: flow.display.remote_asn,
+        remote_asn_name: flow.display.remote_asn_name.clone(),
+        remote_asn_country: flow.display.remote_asn_country.clone(),
+        analysis: flow.display.analysis.clone(),
+        last_seen: flow.last_seen,
+        start_time: flow.start_time,
+        rtt_nanos: flow.rtt_nanos,
+        circuit_id: flow.circuit_id.clone(),
+        circuit_name: flow.circuit_name.clone(),
+    }
+}
+
+/// Returns all rows from the latest active-flow snapshot.
 pub fn dump_active_flows() -> BusResponse {
-    let lock = ALL_FLOWS.lock();
-    let result: Vec<lqos_bus::FlowbeeSummaryData> = lock
-        .flow_data
-        .iter()
-        .map(|(key, row)| {
-            let geo = get_asn_name_and_country(key.remote_ip.as_ip());
-
-            let (circuit_id, circuit_name) = (String::new(), String::new());
-
-            lqos_bus::FlowbeeSummaryData {
-                remote_ip: key.remote_ip.as_ip().to_string(),
-                local_ip: key.local_ip.as_ip().to_string(),
-                src_port: key.src_port,
-                dst_port: key.dst_port,
-                ip_protocol: FlowbeeProtocol::from(key.ip_protocol),
-                bytes_sent: row.0.bytes_sent,
-                packets_sent: row.0.packets_sent,
-                rate_estimate_bps: row.0.rate_estimate_bps,
-                tcp_retransmits: row.0.tcp_retransmits,
-                end_status: row.0.end_status,
-                tos: row.0.tos,
-                flags: row.0.get_flags(),
-                remote_asn: row.1.asn_id.0,
-                remote_asn_name: geo.name,
-                remote_asn_country: geo.country,
-                analysis: row.1.protocol_analysis.to_string(),
-                last_seen: row.0.last_seen,
-                start_time: row.0.start_time,
-                rtt_nanos: DownUpOrder::new(
-                    row.0
-                        .get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download),
-                    row.0
-                        .get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Upload),
-                ),
-                circuit_id,
-                circuit_name,
-            }
-        })
-        .collect();
+    let snapshot = active_flow_snapshot();
+    let result: Vec<lqos_bus::FlowbeeSummaryData> =
+        snapshot.iter().map(flow_summary_from_snapshot).collect();
 
     BusResponse::AllActiveFlows(result)
 }
 
 /// Count active flows
 pub fn count_active_flows() -> BusResponse {
-    let lock = ALL_FLOWS.lock();
-    BusResponse::CountActiveFlows(lock.flow_data.len() as u64)
+    BusResponse::CountActiveFlows(live_active_flow_count())
+}
+
+fn compare_top_flow(
+    a: &ActiveFlowSnapshot,
+    b: &ActiveFlowSnapshot,
+    flow_type: &TopFlowType,
+) -> Ordering {
+    match flow_type {
+        TopFlowType::RateEstimate => b.rate_estimate_bps.sum().cmp(&a.rate_estimate_bps.sum()),
+        TopFlowType::Bytes => b.bytes_sent.sum().cmp(&a.bytes_sent.sum()),
+        TopFlowType::Packets => b.packets_sent.sum().cmp(&a.packets_sent.sum()),
+        TopFlowType::Drops => b.tcp_retransmits.sum().cmp(&a.tcp_retransmits.sum()),
+        TopFlowType::RoundTripTime => a.rtt_nanos.down.cmp(&b.rtt_nanos.down),
+    }
 }
 
 /// Top Flows Report
 pub fn top_flows(n: u32, flow_type: TopFlowType) -> BusResponse {
-    let lock = ALL_FLOWS.lock();
-    let mut table: Vec<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))> = lock
-        .flow_data
-        .iter()
-        .map(|(key, value)| (*key, value.clone()))
-        .collect();
-    std::mem::drop(lock); // Early lock release
+    let snapshot = active_flow_snapshot();
+    let mut table: Vec<&ActiveFlowSnapshot> = snapshot.iter().collect();
+    let limit = n as usize;
 
-    match flow_type {
-        TopFlowType::RateEstimate => {
-            table.sort_by(|a, b| {
-                let a_total = a.1.0.rate_estimate_bps.sum();
-                let b_total = b.1.0.rate_estimate_bps.sum();
-                b_total.cmp(&a_total)
-            });
-        }
-        TopFlowType::Bytes => {
-            table.sort_by(|a, b| {
-                let a_total = a.1.0.bytes_sent.sum();
-                let b_total = b.1.0.bytes_sent.sum();
-                b_total.cmp(&a_total)
-            });
-        }
-        TopFlowType::Packets => {
-            table.sort_by(|a, b| {
-                let a_total = a.1.0.packets_sent.sum();
-                let b_total = b.1.0.packets_sent.sum();
-                b_total.cmp(&a_total)
-            });
-        }
-        TopFlowType::Drops => {
-            table.sort_by(|a, b| {
-                let a_total = a.1.0.tcp_retransmits.sum();
-                let b_total = b.1.0.tcp_retransmits.sum();
-                b_total.cmp(&a_total)
-            });
-        }
-        TopFlowType::RoundTripTime => {
-            table.sort_by(|a, b| {
-                let a_total = a.1.0.get_rtt(FlowbeeEffectiveDirection::Download);
-                let b_total = b.1.0.get_rtt(FlowbeeEffectiveDirection::Download);
-                a_total.cmp(&b_total)
-            });
-        }
+    if limit == 0 {
+        table.clear();
+    } else if limit < table.len() {
+        table.select_nth_unstable_by(limit, |a, b| compare_top_flow(a, b, &flow_type));
+        table.truncate(limit);
     }
-
-    let catalog = lqos_network_devices::network_devices_catalog();
-    let throughput = THROUGHPUT_TRACKER.raw_data.lock();
+    table.sort_by(|a, b| compare_top_flow(a, b, &flow_type));
 
     let result = table
         .iter()
-        .take(n as usize)
-        .map(|(ip, flow)| {
-            let geo = get_asn_name_and_country(ip.remote_ip.as_ip());
-            let (circuit_id, circuit_name) = throughput
-                .get(&ip.local_ip)
-                .map(|te| resolve_circuit_metadata_for_entry(&catalog, &ip.local_ip, te))
-                .unwrap_or_default();
-
-            lqos_bus::FlowbeeSummaryData {
-                remote_ip: ip.remote_ip.as_ip().to_string(),
-                local_ip: ip.local_ip.as_ip().to_string(),
-                src_port: ip.src_port,
-                dst_port: ip.dst_port,
-                ip_protocol: FlowbeeProtocol::from(ip.ip_protocol),
-                bytes_sent: flow.0.bytes_sent,
-                packets_sent: flow.0.packets_sent,
-                rate_estimate_bps: flow.0.rate_estimate_bps,
-                tcp_retransmits: flow.0.tcp_retransmits,
-                end_status: flow.0.end_status,
-                tos: flow.0.tos,
-                flags: flow.0.get_flags(),
-                remote_asn: flow.1.asn_id.0,
-                remote_asn_name: geo.name,
-                remote_asn_country: geo.country,
-                analysis: flow.1.protocol_analysis.to_string(),
-                last_seen: flow.0.last_seen,
-                start_time: flow.0.start_time,
-                rtt_nanos: DownUpOrder::new(
-                    flow.0
-                        .get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download),
-                    flow.0
-                        .get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Upload),
-                ),
-                circuit_id,
-                circuit_name,
-            }
-        })
+        .map(|flow| flow_summary_from_snapshot(flow))
         .collect();
 
     BusResponse::TopFlows(result)
@@ -1235,44 +1300,11 @@ pub fn top_flows(n: u32, flow_type: TopFlowType) -> BusResponse {
 pub fn flows_by_ip(ip: &str) -> BusResponse {
     if let Ok(ip) = ip.parse::<IpAddr>() {
         let ip = XdpIpAddress::from_ip(ip);
-        let lock = ALL_FLOWS.lock();
-        let (circuit_id, circuit_name) = resolve_circuit_metadata_for_ip(&ip);
-        let matching_flows: Vec<_> = lock
-            .flow_data
+        let snapshot = active_flow_snapshot();
+        let matching_flows: Vec<_> = snapshot
             .iter()
-            .filter(|(key, _)| key.local_ip == ip)
-            .map(|(key, row)| {
-                let geo = get_asn_name_and_country(key.remote_ip.as_ip());
-
-                lqos_bus::FlowbeeSummaryData {
-                    remote_ip: key.remote_ip.as_ip().to_string(),
-                    local_ip: key.local_ip.as_ip().to_string(),
-                    src_port: key.src_port,
-                    dst_port: key.dst_port,
-                    ip_protocol: FlowbeeProtocol::from(key.ip_protocol),
-                    bytes_sent: row.0.bytes_sent,
-                    packets_sent: row.0.packets_sent,
-                    rate_estimate_bps: row.0.rate_estimate_bps,
-                    tcp_retransmits: row.0.tcp_retransmits,
-                    end_status: row.0.end_status,
-                    tos: row.0.tos,
-                    flags: row.0.get_flags(),
-                    remote_asn: row.1.asn_id.0,
-                    remote_asn_name: geo.name,
-                    remote_asn_country: geo.country,
-                    analysis: row.1.protocol_analysis.to_string(),
-                    last_seen: row.0.last_seen,
-                    start_time: row.0.start_time,
-                    rtt_nanos: DownUpOrder::new(
-                        row.0
-                            .get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Download),
-                        row.0
-                            .get_summary_rtt_as_nanos(FlowbeeEffectiveDirection::Upload),
-                    ),
-                    circuit_id: circuit_id.clone(),
-                    circuit_name: circuit_name.clone(),
-                }
-            })
+            .filter(|flow| flow.key.local_ip == ip)
+            .map(flow_summary_from_snapshot)
             .collect();
 
         return BusResponse::FlowsByIp(matching_flows);
@@ -1368,7 +1400,7 @@ impl RawNetJsBody {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Lts2Circuit {
     pub circuit_id: String,
     pub circuit_name: String,
@@ -1391,7 +1423,7 @@ pub struct Lts2Circuit {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Lts2Device {
     pub device_id: String,
     pub device_name: String,
@@ -1406,26 +1438,33 @@ pub struct Lts2Device {
 mod compatibility_tests {
     use super::{
         CIRCUIT_RTT_BUFFERS, Lts2Circuit, RawNetJsBody, circuit_current_qoo,
-        circuit_current_rtt_p50_nanos, resolve_circuit_metadata_for_entry,
+        circuit_current_rtt_p50_nanos, finish_expired_flows, resolve_circuit_metadata_for_entry,
+        resolve_flow_device,
     };
-    use crate::throughput_tracker::flow_data::{FlowbeeEffectiveDirection, RttData};
+    use crate::test_support::ActiveFlowSnapshotTestContext;
+    use crate::throughput_tracker::flow_data::{
+        FlowAnalysis, FlowbeeEffectiveDirection, FlowbeeLocalData, RttData, active_flow_snapshot,
+        active_flow_test_lock, mutate_all_flows, refresh_active_flow_snapshot,
+        replace_active_flows_live_for_test,
+    };
     use crate::throughput_tracker::throughput_entry::ThroughputEntry;
     use fxhash::FxHashMap;
-    use lqos_bus::TcHandle;
+    use lqos_bus::{BusResponse, TcHandle, TopFlowType};
     use lqos_config::{ConfigShapedDevices, ShapedDevice};
     use lqos_network_devices::{NetworkDevicesCatalog, ShapedDevicesCatalog};
-    use lqos_utils::XdpIpAddress;
+    use lqos_sys::flowbee_data::{FlowbeeData, FlowbeeKey};
+    use lqos_utils::{XdpIpAddress, hash_to_i64};
     use lqos_utils::qoo::QoqScores;
     use lqos_utils::qoq_heatmap::TemporalQoqHeatmap;
     use lqos_utils::rtt::RttBuffer;
     use lqos_utils::units::DownUpOrder;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
     use serde_json::to_value;
     use std::net::Ipv4Addr;
     use std::sync::Arc;
 
     #[allow(dead_code)]
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Serialize)]
     struct OldLts2Device {
         device_id: String,
         device_name: String,
@@ -1437,7 +1476,7 @@ mod compatibility_tests {
     }
 
     #[allow(dead_code)]
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Serialize)]
     struct OldLts2Circuit {
         circuit_id: String,
         circuit_name: String,
@@ -1487,6 +1526,545 @@ mod compatibility_tests {
 
         assert_eq!(decoded.download_max_mbps, 7);
         assert_eq!(decoded.upload_max_mbps, 4);
+    }
+
+    #[test]
+    fn current_lts2_circuit_round_trips_exact_rate_fields() {
+        let current = Lts2Circuit {
+            circuit_id: "cid".to_string(),
+            circuit_name: "Circuit".to_string(),
+            circuit_hash: 7,
+            download_min_mbps: 3,
+            upload_min_mbps: 2,
+            download_max_mbps: 7,
+            upload_max_mbps: 4,
+            download_min_mbps_exact: Some(2.5),
+            upload_min_mbps_exact: Some(1.5),
+            download_max_mbps_exact: Some(6.6),
+            upload_max_mbps_exact: Some(3.3),
+            parent_node: 9,
+            parent_node_name: Some("Parent".to_string()),
+            devices: Vec::new(),
+        };
+
+        let bytes = serde_cbor::to_vec(&current).expect("current payload serializes");
+        let decoded: Lts2Circuit =
+            serde_cbor::from_slice(&bytes).expect("current payload round trips");
+
+        assert_eq!(decoded.download_min_mbps_exact, Some(2.5));
+        assert_eq!(decoded.upload_min_mbps_exact, Some(1.5));
+        assert_eq!(decoded.download_max_mbps_exact, Some(6.6));
+        assert_eq!(decoded.upload_max_mbps_exact, Some(3.3));
+    }
+
+    #[test]
+    fn current_receivers_default_missing_exact_rate_fields() {
+        let old = OldLts2Circuit {
+            circuit_id: "cid".to_string(),
+            circuit_name: "Circuit".to_string(),
+            circuit_hash: 7,
+            download_min_mbps: 3,
+            upload_min_mbps: 2,
+            download_max_mbps: 7,
+            upload_max_mbps: 4,
+            parent_node: 9,
+            parent_node_name: Some("Parent".to_string()),
+            devices: Vec::new(),
+        };
+
+        let bytes = serde_cbor::to_vec(&old).expect("legacy payload serializes");
+        let decoded: Lts2Circuit =
+            serde_cbor::from_slice(&bytes).expect("current shape accepts missing exact fields");
+
+        assert_eq!(decoded.download_max_mbps, 7);
+        assert_eq!(decoded.upload_max_mbps, 4);
+        assert_eq!(decoded.download_min_mbps_exact, None);
+        assert_eq!(decoded.upload_min_mbps_exact, None);
+        assert_eq!(decoded.download_max_mbps_exact, None);
+        assert_eq!(decoded.upload_max_mbps_exact, None);
+    }
+
+    #[test]
+    fn finish_expired_flows_sends_exports_and_invokes_cleanup_once() {
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 54_321;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+        raw.circuit_hash = 123;
+        raw.device_hash = 456;
+
+        let export = (
+            key,
+            (
+                FlowbeeLocalData::from_flow(&raw, &key),
+                FlowAnalysis::new(&key),
+            ),
+        );
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let mut finished_flow_exports = vec![export];
+        let mut expired_flows = vec![key];
+        let mut cleanup_keys = Vec::new();
+
+        finish_expired_flows(
+            &mut finished_flow_exports,
+            expired_flows.as_mut_slice(),
+            &sender,
+            |keys| {
+                cleanup_keys.extend_from_slice(keys);
+                Ok(())
+            },
+        );
+
+        let received = receiver
+            .try_recv()
+            .expect("finished flow export should be sent");
+        assert_eq!(received.0, key);
+        assert!(receiver.try_recv().is_err());
+        assert!(finished_flow_exports.is_empty());
+        assert_eq!(expired_flows, vec![key]);
+        assert_eq!(cleanup_keys, vec![key]);
+    }
+
+    #[test]
+    fn finish_expired_flows_runs_cleanup_when_export_receiver_is_closed() {
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 54_320;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        drop(receiver);
+        let mut finished_flow_exports = vec![(
+            key,
+            (
+                FlowbeeLocalData::from_flow(&raw, &key),
+                FlowAnalysis::new(&key),
+            ),
+        )];
+        let mut expired_flows = vec![key];
+        let mut cleanup_keys = Vec::new();
+
+        finish_expired_flows(
+            &mut finished_flow_exports,
+            expired_flows.as_mut_slice(),
+            &sender,
+            |keys| {
+                cleanup_keys.extend_from_slice(keys);
+                Ok(())
+            },
+        );
+
+        assert!(finished_flow_exports.is_empty());
+        assert_eq!(cleanup_keys, vec![key]);
+    }
+
+    #[test]
+    fn dedup_flow_keys_keeps_first_seen_order() {
+        let mut key_1 = FlowbeeKey::default();
+        key_1.ip_protocol = 6;
+        key_1.src_port = 443;
+        key_1.dst_port = 54_310;
+        let mut key_2 = key_1;
+        key_2.dst_port = 54_311;
+        let mut key_3 = key_1;
+        key_3.dst_port = 54_312;
+        let mut keys = vec![key_1, key_2, key_1, key_3, key_2];
+
+        super::dedup_flow_keys(&mut keys);
+
+        assert_eq!(keys, vec![key_1, key_2, key_3]);
+    }
+
+    #[test]
+    fn post_write_snapshot_refresh_publishes_live_writes() {
+        let _guard = active_flow_test_lock();
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 54_322;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(3_000, 4_000);
+        raw.packets_sent = DownUpOrder::new(30, 40);
+        raw.rate_estimate_bps = DownUpOrder::new(50_000, 60_000);
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
+        assert!(active_flow_snapshot().is_empty());
+
+        mutate_all_flows(|flows| {
+            flows.insert(
+                key,
+                (
+                    FlowbeeLocalData::from_flow(&raw, &key),
+                    FlowAnalysis::new(&key),
+                ),
+            );
+        });
+        assert!(active_flow_snapshot().is_empty());
+
+        refresh_active_flow_snapshot();
+
+        let snapshot = active_flow_snapshot();
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].key, key);
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
+    }
+
+    #[test]
+    fn active_flow_bus_readers_use_published_snapshot_fields() {
+        let _guard = active_flow_test_lock();
+        let local_ip_1 = XdpIpAddress::from_ip("192.0.2.10".parse().expect("test IP should parse"));
+        let local_ip_2 = XdpIpAddress::from_ip("192.0.2.11".parse().expect("test IP should parse"));
+        let remote_ip_1 =
+            XdpIpAddress::from_ip("198.51.100.20".parse().expect("test IP should parse"));
+        let remote_ip_2 =
+            XdpIpAddress::from_ip("198.51.100.21".parse().expect("test IP should parse"));
+
+        let mut key_1 = FlowbeeKey::default();
+        key_1.local_ip = local_ip_1;
+        key_1.remote_ip = remote_ip_1;
+        key_1.ip_protocol = 6;
+        key_1.src_port = 443;
+        key_1.dst_port = 50_000;
+
+        let mut key_2 = key_1;
+        key_2.local_ip = local_ip_2;
+        key_2.remote_ip = remote_ip_2;
+        key_2.dst_port = 50_001;
+
+        let mut raw_1 = FlowbeeData::default();
+        raw_1.start_time = 10_000_000_000;
+        raw_1.last_seen = 20_000_000_000;
+        raw_1.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw_1.packets_sent = DownUpOrder::new(10, 20);
+        raw_1.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+        raw_1.tcp_retransmits = DownUpOrder::new(1, 2);
+        raw_1.tos = 4;
+        raw_1.flags = 0x12;
+        raw_1.circuit_hash = 9_001;
+        raw_1.device_hash = 9_002;
+
+        let mut raw_2 = raw_1.clone();
+        raw_2.bytes_sent = DownUpOrder::new(10_000, 20_000);
+        raw_2.packets_sent = DownUpOrder::new(100, 200);
+        raw_2.rate_estimate_bps = DownUpOrder::new(300_000, 400_000);
+        raw_2.tcp_retransmits = DownUpOrder::new(9, 9);
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+            let mut local_1 = FlowbeeLocalData::from_flow(&raw_1, &key_1);
+            let mut rtt_1 = RttBuffer::new(
+                RttData::from_nanos(1_000_000),
+                FlowbeeEffectiveDirection::Download,
+                raw_1.last_seen,
+            );
+            rtt_1.push(
+                RttData::from_nanos(1_000_000),
+                FlowbeeEffectiveDirection::Download,
+                raw_1.last_seen,
+            );
+            local_1.set_rtt_buffer(rtt_1);
+            let mut local_2 = FlowbeeLocalData::from_flow(&raw_2, &key_2);
+            let mut rtt_2 = RttBuffer::new(
+                RttData::from_nanos(100_000_000),
+                FlowbeeEffectiveDirection::Download,
+                raw_2.last_seen,
+            );
+            rtt_2.push(
+                RttData::from_nanos(100_000_000),
+                FlowbeeEffectiveDirection::Download,
+                raw_2.last_seen,
+            );
+            local_2.set_rtt_buffer(rtt_2);
+            flows.insert(
+                key_1,
+                (local_1, FlowAnalysis::new(&key_1)),
+            );
+            flows.insert(
+                key_2,
+                (local_2, FlowAnalysis::new(&key_2)),
+            );
+        });
+        let BusResponse::CountActiveFlows(count) = super::count_active_flows() else {
+            panic!("active flow count response should match request");
+        };
+        assert_eq!(count, 2);
+        refresh_active_flow_snapshot();
+
+        let BusResponse::CountActiveFlows(count) = super::count_active_flows() else {
+            panic!("active flow count response should match request");
+        };
+        assert_eq!(count, 2);
+
+        let BusResponse::AllActiveFlows(all_flows) = super::dump_active_flows() else {
+            panic!("active flow dump response should match request");
+        };
+        let first = all_flows
+            .iter()
+            .find(|flow| flow.local_ip == "192.0.2.10")
+            .expect("first flow should be in active-flow dump");
+        assert_eq!(first.remote_ip, "198.51.100.20");
+        assert_eq!(first.src_port, 443);
+        assert_eq!(first.dst_port, 50_000);
+        assert_eq!(first.bytes_sent, raw_1.bytes_sent);
+        assert_eq!(first.packets_sent, raw_1.packets_sent);
+        assert_eq!(first.rate_estimate_bps, raw_1.rate_estimate_bps);
+        assert_eq!(first.tcp_retransmits, raw_1.tcp_retransmits);
+        assert_eq!(first.tos, raw_1.tos);
+        assert_eq!(first.flags, raw_1.flags);
+        assert_eq!(first.remote_asn, 0);
+        assert_eq!(first.remote_asn_name, "");
+        assert_eq!(first.remote_asn_country, "");
+        assert_eq!(first.analysis, "HTTPS");
+        assert_eq!(first.last_seen, raw_1.last_seen);
+        assert_eq!(first.start_time, raw_1.start_time);
+        assert_eq!(first.circuit_id, "");
+        assert_eq!(first.circuit_name, "");
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(1, TopFlowType::Bytes) else {
+            panic!("top flows response should match request");
+        };
+        assert_eq!(top_flows.len(), 1);
+        assert_eq!(top_flows[0].local_ip, "192.0.2.11");
+        assert_eq!(top_flows[0].bytes_sent, raw_2.bytes_sent);
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(1, TopFlowType::RateEstimate)
+        else {
+            panic!("top flows response should match request");
+        };
+        assert_eq!(top_flows.len(), 1);
+        assert_eq!(top_flows[0].local_ip, "192.0.2.11");
+        assert_eq!(top_flows[0].rate_estimate_bps, raw_2.rate_estimate_bps);
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(1, TopFlowType::Packets) else {
+            panic!("top flows response should match request");
+        };
+        assert_eq!(top_flows.len(), 1);
+        assert_eq!(top_flows[0].local_ip, "192.0.2.11");
+        assert_eq!(top_flows[0].packets_sent, raw_2.packets_sent);
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(1, TopFlowType::Drops) else {
+            panic!("top flows response should match request");
+        };
+        assert_eq!(top_flows.len(), 1);
+        assert_eq!(top_flows[0].local_ip, "192.0.2.11");
+        assert_eq!(top_flows[0].tcp_retransmits, raw_2.tcp_retransmits);
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(1, TopFlowType::RoundTripTime)
+        else {
+            panic!("top flows response should match request");
+        };
+        assert_eq!(top_flows.len(), 1);
+        assert_eq!(top_flows[0].local_ip, "192.0.2.10");
+        assert!(top_flows[0].rtt_nanos.down > 0);
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(0, TopFlowType::Bytes) else {
+            panic!("top flows response should match request");
+        };
+        assert!(top_flows.is_empty());
+
+        let BusResponse::TopFlows(top_flows) = super::top_flows(10, TopFlowType::Bytes) else {
+            panic!("top flows response should match request");
+        };
+        assert_eq!(
+            top_flows
+                .iter()
+                .map(|flow| flow.local_ip.as_str())
+                .collect::<Vec<_>>(),
+            vec!["192.0.2.11", "192.0.2.10"]
+        );
+
+        let BusResponse::FlowsByIp(flows_by_ip) = super::flows_by_ip("192.0.2.10") else {
+            panic!("flows-by-ip response should match request");
+        };
+        assert_eq!(flows_by_ip.len(), 1);
+        assert_eq!(flows_by_ip[0].local_ip, "192.0.2.10");
+        assert_eq!(flows_by_ip[0].remote_ip, "198.51.100.20");
+
+        replace_active_flows_live_for_test(Vec::new());
+        let BusResponse::CountActiveFlows(count) = super::count_active_flows() else {
+            panic!("active flow count response should match request");
+        };
+        assert_eq!(count, 0);
+        let BusResponse::FlowsByIp(flows_by_ip) = super::flows_by_ip("192.0.2.10") else {
+            panic!("flows-by-ip response should match request");
+        };
+        assert_eq!(flows_by_ip.len(), 1);
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
+    }
+
+    #[test]
+    fn active_flow_snapshot_publishes_catalog_metadata_for_bus_readers() {
+        let mut ctx = ActiveFlowSnapshotTestContext::with_shaped_devices(
+            "active-flow-test",
+            vec![ShapedDevice {
+                circuit_id: "circuit-meta".to_string(),
+                circuit_name: "Circuit Metadata".to_string(),
+                device_id: "device-meta".to_string(),
+                device_name: "Device Metadata".to_string(),
+                parent_node: "Parent".to_string(),
+                ipv4: vec![(Ipv4Addr::new(192, 0, 2, 20), 32)],
+                ..Default::default()
+            }],
+        );
+        let local_ip = XdpIpAddress::from_ip("192.0.2.20".parse().expect("test IP should parse"));
+        let remote_ip =
+            XdpIpAddress::from_ip("198.51.100.30".parse().expect("test IP should parse"));
+
+        let mut key = FlowbeeKey::default();
+        key.local_ip = local_ip;
+        key.remote_ip = remote_ip;
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_100;
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+        let mut local = FlowbeeLocalData::from_flow(&raw, &key);
+        local.set_circuit_id_hint(Some("stale-circuit"));
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+            flows.insert(key, (local, FlowAnalysis::new(&key)));
+        });
+        refresh_active_flow_snapshot();
+
+        let BusResponse::FlowsByIp(flows_by_ip) = super::flows_by_ip("192.0.2.20") else {
+            panic!("flows-by-ip response should match request");
+        };
+        assert_eq!(flows_by_ip.len(), 1);
+        assert_eq!(flows_by_ip[0].circuit_id, "stale-circuit");
+        assert_eq!(flows_by_ip[0].circuit_name, "Circuit Metadata");
+        let snapshot = active_flow_snapshot();
+        assert_eq!(snapshot[0].circuit_hash, Some(hash_to_i64("circuit-meta")));
+        assert_eq!(snapshot[0].device_hash, Some(hash_to_i64("device-meta")));
+        assert_eq!(snapshot[0].device_name, "Device Metadata");
+
+        ctx.replace_shaped_devices(
+            "active-flow-test-updated",
+            vec![ShapedDevice {
+                circuit_id: "circuit-meta-updated".to_string(),
+                circuit_name: "Circuit Metadata Updated".to_string(),
+                device_id: "device-meta-updated".to_string(),
+                device_name: "Device Metadata Updated".to_string(),
+                parent_node: "Parent".to_string(),
+                ipv4: vec![(Ipv4Addr::new(192, 0, 2, 20), 32)],
+                ..Default::default()
+            }],
+        );
+
+        let BusResponse::FlowsByIp(flows_by_ip) = super::flows_by_ip("192.0.2.20") else {
+            panic!("flows-by-ip response should match request");
+        };
+        assert_eq!(flows_by_ip[0].circuit_id, "stale-circuit");
+
+        refresh_active_flow_snapshot();
+        let BusResponse::FlowsByIp(flows_by_ip) = super::flows_by_ip("192.0.2.20") else {
+            panic!("flows-by-ip response should match request");
+        };
+        assert_eq!(flows_by_ip[0].circuit_id, "stale-circuit");
+        assert_eq!(flows_by_ip[0].circuit_name, "Circuit Metadata Updated");
+        assert_eq!(active_flow_snapshot()[0].device_name, "Device Metadata Updated");
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
+    }
+
+    #[test]
+    fn active_flow_snapshot_prefers_hash_lookup_over_ip_fallback() {
+        let ip_matched_device = ShapedDevice {
+            circuit_id: "ip-circuit".to_string(),
+            circuit_name: "IP Circuit".to_string(),
+            device_id: "ip-device".to_string(),
+            device_name: "IP Device".to_string(),
+            parent_node: "Parent".to_string(),
+            ipv4: vec![(Ipv4Addr::new(192, 0, 2, 30), 32)],
+            ..Default::default()
+        };
+        let hash_matched_device = ShapedDevice {
+            circuit_id: "hash-circuit".to_string(),
+            circuit_name: "Hash Circuit".to_string(),
+            device_id: "hash-device".to_string(),
+            device_name: "Hash Device".to_string(),
+            parent_node: "Parent".to_string(),
+            ipv4: vec![(Ipv4Addr::new(192, 0, 2, 31), 32)],
+            ..Default::default()
+        };
+        let _ctx = ActiveFlowSnapshotTestContext::with_shaped_devices(
+            "active-flow-hash-precedence-test",
+            vec![ip_matched_device, hash_matched_device],
+        );
+
+        let local_ip = XdpIpAddress::from_ip("192.0.2.30".parse().expect("test IP should parse"));
+        let catalog = lqos_network_devices::network_devices_catalog();
+        let resolved = resolve_flow_device(
+            &catalog,
+            &local_ip,
+            Some(hash_to_i64("hash-device")),
+            Some(hash_to_i64("hash-circuit")),
+        )
+        .expect("hash-backed device should resolve");
+        assert_eq!(resolved.device_id, "hash-device");
+
+        let mut key = FlowbeeKey::default();
+        key.local_ip = local_ip;
+        key.remote_ip =
+            XdpIpAddress::from_ip("198.51.100.40".parse().expect("test IP should parse"));
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_110;
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+        raw.device_hash = hash_to_i64("hash-device") as u64;
+        raw.circuit_hash = hash_to_i64("hash-circuit") as u64;
+
+        mutate_all_flows(|flows| {
+            flows.clear();
+            flows.insert(
+                key,
+                (
+                    FlowbeeLocalData::from_flow(&raw, &key),
+                    FlowAnalysis::new(&key),
+                ),
+            );
+        });
+        refresh_active_flow_snapshot();
+
+        let snapshot = active_flow_snapshot();
+        assert_eq!(snapshot[0].circuit_id, "hash-circuit");
+        assert_eq!(snapshot[0].circuit_name, "Hash Circuit");
+        assert_eq!(snapshot[0].device_name, "Hash Device");
+
+        mutate_all_flows(|flows| flows.clear());
+        refresh_active_flow_snapshot();
     }
 
     #[test]
@@ -1548,7 +2126,7 @@ mod compatibility_tests {
         let shaped_catalog = ShapedDevicesCatalog::from_shaped_devices(Arc::new(shaped));
         let catalog = NetworkDevicesCatalog::from_snapshots(shaped_catalog, Arc::new(Vec::new()));
         let ip = XdpIpAddress::from_ip("192.168.1.10".parse().expect("test IP should parse"));
-        let entry = ThroughputEntry {
+        let mut entry = ThroughputEntry {
             circuit_id: None,
             circuit_hash: None,
             device_hash: None,
@@ -1583,6 +2161,12 @@ mod compatibility_tests {
         let (circuit_id, circuit_name) = resolve_circuit_metadata_for_entry(&catalog, &ip, &entry);
 
         assert_eq!(circuit_id, "circuit-1");
+        assert_eq!(circuit_name, "Circuit Alpha");
+
+        entry.circuit_id = Some("hint-circuit".to_string());
+        let (circuit_id, circuit_name) = resolve_circuit_metadata_for_entry(&catalog, &ip, &entry);
+
+        assert_eq!(circuit_id, "hint-circuit");
         assert_eq!(circuit_name, "Circuit Alpha");
     }
 

--- a/src/rust/lqosd/src/throughput_tracker/stats_submission.rs
+++ b/src/rust/lqosd/src/throughput_tracker/stats_submission.rs
@@ -1,11 +1,10 @@
 use crate::lts2_sys::shared_types::{CircuitCakeDrops, CircuitCakeMarks};
 use crate::system_stats::SystemStats;
-use crate::throughput_tracker::flow_data::ALL_FLOWS;
-use crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection;
+use crate::throughput_tracker::flow_data::{FlowbeeEffectiveDirection, live_active_flow_count};
 use crate::throughput_tracker::throughput_entry::ThroughputEntry;
 use crate::throughput_tracker::{
     CIRCUIT_RTT_BUFFERS, Lts2Circuit, Lts2Device, RawNetJs, THROUGHPUT_TRACKER, min_max_median_rtt,
-    min_max_median_tcp_retransmits,
+    min_max_median_tcp_retransmits, resolve_flow_device,
 };
 use csv::ReaderBuilder;
 use fxhash::{FxHashMap, FxHashSet};
@@ -126,9 +125,7 @@ fn resolved_circuit_hash_for_submission(
     entry: &ThroughputEntry,
 ) -> Option<i64> {
     entry.circuit_hash.or_else(|| {
-        catalog
-            .device_by_hashes(entry.device_hash, entry.circuit_hash)
-            .or_else(|| catalog.device_longest_match_for_ip(ip).map(|(_, dev)| dev))
+        resolve_flow_device(catalog, ip, entry.device_hash, entry.circuit_hash)
             .map(|device| device.circuit_hash)
     })
 }
@@ -346,7 +343,7 @@ pub(crate) fn submit_throughput_stats(
         {
             warn!("Error sending message to LTS2.");
         }
-        if let Err(e) = crate::lts2_sys::flow_count(now, ALL_FLOWS.lock().flow_data.len() as u64) {
+        if let Err(e) = crate::lts2_sys::flow_count(now, live_active_flow_count()) {
             debug!("Error sending message to LTS2. {e:?}");
         }
 

--- a/src/rust/lqosd/src/throughput_tracker/tracking_data.rs
+++ b/src/rust/lqosd/src/throughput_tracker/tracking_data.rs
@@ -1,12 +1,12 @@
 use super::{
     RETIRE_AFTER_SECONDS,
     flow_data::{
-        ALL_FLOWS, AsnAggregate, FlowAnalysis, FlowbeeLocalData, RttBuffer, RttData,
-        get_flowbee_event_count_and_reset, update_asn_heatmaps,
+        AsnAggregate, FlowAnalysis, FlowbeeLocalData, RttBuffer, RttData,
+        get_flowbee_event_count_and_reset, mutate_all_flows, update_asn_heatmaps,
     },
     throughput_entry::ThroughputEntry,
 };
-use crate::throughput_tracker::CIRCUIT_RTT_BUFFERS;
+use crate::throughput_tracker::{CIRCUIT_RTT_BUFFERS, resolve_flow_device};
 use crate::{
     stats::HIGH_WATERMARK,
     throughput_tracker::flow_data::{FlowbeeEffectiveDirection, expire_rtt_flows, flowbee_rtt_map},
@@ -16,8 +16,11 @@ use lqos_bakery::BakeryCommands;
 use lqos_bus::TcHandle;
 use lqos_config::NetworkJson;
 use lqos_queue_tracker::ALL_QUEUE_SUMMARY;
-use lqos_sys::{flowbee_data::FlowbeeKey, iterate_flows, throughput_for_each};
-use lqos_utils::qoo::{LossMeasurement, QOQ_UNKNOWN, QoqScores, compute_qoq_scores};
+use lqos_sys::{
+    flowbee_data::{FlowbeeData, FlowbeeKey},
+    iterate_flows, throughput_for_each,
+};
+use lqos_utils::qoo::{LossMeasurement, QOQ_UNKNOWN, QooProfile, QoqScores, compute_qoq_scores};
 use lqos_utils::{XdpIpAddress, unix_time::time_since_boot};
 use lqos_utils::{
     qoq_heatmap::TemporalQoqHeatmap,
@@ -36,16 +39,172 @@ const MAX_FLOWS: usize = 1_000_000;
 
 pub const MAX_RETRY_TIMES: usize = 128;
 const MIN_QOO_FLOW_BYTES: u64 = 1_000_000;
+// Only compact after a large spike has cleared. This avoids per-tick rehashing while still
+// releasing obviously stale peak capacity on systems that briefly approach `MAX_FLOWS`.
+const FLOW_TABLE_SHRINK_MIN_CAPACITY: usize = 16_384;
+const FLOW_TABLE_SHRINK_EXCESS_FACTOR: usize = 4;
 
 pub(crate) struct FlowApplyContext<'a> {
     pub(crate) timeout_seconds: u64,
-    pub(crate) sender: crossbeam_channel::Sender<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
     pub(crate) net_json_calc: &'a mut NetworkJson,
     pub(crate) rtt_circuit_tracker: &'a mut FxHashMap<XdpIpAddress, RttBuffer>,
     pub(crate) rtt_by_circuit: &'a mut FxHashMap<i64, RttBuffer>,
     pub(crate) tcp_retries: &'a mut FxHashMap<XdpIpAddress, DownUpOrder<u64>>,
     pub(crate) tcp_retry_packets: &'a mut FxHashMap<XdpIpAddress, DownUpOrder<u64>>,
     pub(crate) expired_keys: &'a mut Vec<FlowbeeKey>,
+    pub(crate) finished_flow_exports: &'a mut Vec<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
+}
+
+fn collect_finished_flow_exports(
+    flow_data: &mut FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>,
+    expired_keys: &[FlowbeeKey],
+    finished_flow_exports: &mut Vec<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
+) -> usize {
+    let mut removed = 0;
+    for key in expired_keys {
+        if let Some((local, analysis)) = flow_data.remove(key) {
+            finished_flow_exports.push((*key, (local, analysis)));
+            removed += 1;
+        }
+    }
+    removed
+}
+
+fn collect_stale_flow_exports(
+    flow_data: &mut FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>,
+    expire_before_nanos: u64,
+    finished_flow_exports: &mut Vec<(FlowbeeKey, (FlowbeeLocalData, FlowAnalysis))>,
+) -> usize {
+    let mut removed = 0;
+    for export in flow_data.extract_if(|_key, (local, _analysis)| {
+        local.last_seen < expire_before_nanos
+    }) {
+        finished_flow_exports.push(export);
+        removed += 1;
+    }
+    removed
+}
+
+fn shrink_flow_table_if_sparse(
+    flow_data: &mut FxHashMap<FlowbeeKey, (FlowbeeLocalData, FlowAnalysis)>,
+) {
+    let capacity = flow_data.capacity();
+    let shrink_threshold = flow_data
+        .len()
+        .saturating_mul(FLOW_TABLE_SHRINK_EXCESS_FACTOR)
+        .max(FLOW_TABLE_SHRINK_MIN_CAPACITY);
+    if capacity > shrink_threshold {
+        flow_data.shrink_to_fit();
+    }
+}
+
+fn accumulate_device_rtt_samples(
+    rtt_circuit_tracker: &mut FxHashMap<XdpIpAddress, RttBuffer>,
+    raw_entry: Option<&ThroughputEntry>,
+    key: &FlowbeeKey,
+    flow: &FlowbeeLocalData,
+    rtt_buffer: &RttBuffer,
+) {
+    if key.ip_protocol != 6 || flow.end_status != 0 || raw_entry.is_none() {
+        return;
+    }
+
+    let include_download = flow.bytes_sent.down >= MIN_QOO_FLOW_BYTES;
+    let include_upload = flow.bytes_sent.up >= MIN_QOO_FLOW_BYTES;
+    if !include_download && !include_upload {
+        return;
+    }
+
+    let device_rtt = rtt_circuit_tracker.entry(key.local_ip).or_default();
+    if include_download {
+        device_rtt.accumulate_direction(rtt_buffer, FlowbeeEffectiveDirection::Download);
+    }
+    if include_upload {
+        device_rtt.accumulate_direction(rtt_buffer, FlowbeeEffectiveDirection::Upload);
+    }
+}
+
+fn update_flow_qoo(flow: &mut FlowbeeLocalData, key: &FlowbeeKey, profile: Option<&QooProfile>) {
+    if key.ip_protocol != 6 {
+        return;
+    }
+    let Some(profile) = profile else {
+        return;
+    };
+    let Some(tcp_info) = flow.tcp_info.as_ref() else {
+        return;
+    };
+
+    let loss_download =
+        tcp_retransmit_loss_proxy(flow.tcp_retransmits.down as u64, flow.packets_sent.down);
+    let loss_upload =
+        tcp_retransmit_loss_proxy(flow.tcp_retransmits.up as u64, flow.packets_sent.up);
+    let mut scores = compute_qoq_scores(profile, &tcp_info.rtt, loss_download, loss_upload);
+    if flow.bytes_sent.down < MIN_QOO_FLOW_BYTES {
+        scores.download_total = QOQ_UNKNOWN;
+    }
+    if flow.bytes_sent.up < MIN_QOO_FLOW_BYTES {
+        scores.upload_total = QOQ_UNKNOWN;
+    }
+    flow.set_qoq_scores(scores);
+}
+
+fn flow_asn_rtt_ms(
+    raw_entry: Option<&ThroughputEntry>,
+    flow: &FlowbeeLocalData,
+) -> Option<f32> {
+    let excluded = raw_entry
+        .and_then(|entry| entry.circuit_hash)
+        .is_some_and(crate::rtt_exclusions::is_excluded_hash);
+    if excluded {
+        None
+    } else {
+        combine_rtt_ms(flow.get_rtt_array())
+    }
+}
+
+fn flow_deltas(
+    data: &FlowbeeData,
+    previous: &FlowbeeLocalData,
+) -> (DownUpOrder<u64>, DownUpOrder<u64>, DownUpOrder<u64>) {
+    let delta_bytes = data.bytes_sent.checked_sub_or_zero(previous.bytes_sent);
+    let delta_packets = data.packets_sent.checked_sub_or_zero(previous.packets_sent);
+    let delta_retrans = data
+        .tcp_retransmits
+        .checked_sub_or_zero(previous.tcp_retransmits);
+    (
+        delta_bytes,
+        delta_packets,
+        DownUpOrder::new(delta_retrans.down as u64, delta_retrans.up as u64),
+    )
+}
+
+fn apply_flow_rtt_and_qoo(
+    flow: &mut FlowbeeLocalData,
+    raw_entry: Option<&ThroughputEntry>,
+    rtt_circuit_tracker: &mut FxHashMap<XdpIpAddress, RttBuffer>,
+    key: &FlowbeeKey,
+    rtt_buffer: Option<RttBuffer>,
+    rtt_expire: u64,
+    qoo_profile: Option<&QooProfile>,
+) {
+    if let Some(raw_entry) = raw_entry {
+        flow.set_tracking_metadata(
+            raw_entry.circuit_hash,
+            raw_entry.device_hash,
+            raw_entry.circuit_id.as_deref(),
+        );
+    }
+    let retired_stale_rtt = if let Some(rtt_buffer) = rtt_buffer {
+        accumulate_device_rtt_samples(rtt_circuit_tracker, raw_entry, key, flow, &rtt_buffer);
+        flow.set_rtt_buffer(rtt_buffer);
+        false
+    } else {
+        flow.retire_stale_rtt(rtt_expire)
+    };
+    if !retired_stale_rtt {
+        update_flow_qoo(flow, key, qoo_profile);
+    }
 }
 
 pub struct ThroughputTracker {
@@ -408,20 +567,6 @@ impl ThroughputTracker {
         });
     }
 
-    fn shaped_device_for_ip_or_hashes<'a>(
-        catalog: &'a lqos_network_devices::NetworkDevicesCatalog,
-        ip: &XdpIpAddress,
-        device_hash: Option<i64>,
-        circuit_hash: Option<i64>,
-    ) -> Option<&'a lqos_config::ShapedDevice> {
-        if let Some(device) = catalog.device_by_hashes(device_hash, circuit_hash) {
-            return Some(device);
-        }
-        catalog
-            .device_longest_match_for_ip(ip)
-            .map(|(_net, device)| device)
-    }
-
     fn lookup_network_parents_from_ip_or_hashes(
         catalog: &lqos_network_devices::NetworkDevicesCatalog,
         ip: &XdpIpAddress,
@@ -429,7 +574,7 @@ impl ThroughputTracker {
         circuit_hash: Option<i64>,
         lock: &NetworkJson,
     ) -> Option<Vec<usize>> {
-        Self::shaped_device_for_ip_or_hashes(catalog, ip, device_hash, circuit_hash)
+        resolve_flow_device(catalog, ip, device_hash, circuit_hash)
             .and_then(|device| lock.get_parents_for_circuit_id(&device.parent_node))
     }
 
@@ -437,12 +582,8 @@ impl ThroughputTracker {
         let catalog = lqos_network_devices::network_devices_catalog();
         let mut raw_data = self.raw_data.lock();
         raw_data.iter_mut().for_each(|(ip, data)| {
-            let shaped_device = Self::shaped_device_for_ip_or_hashes(
-                &catalog,
-                ip,
-                data.device_hash,
-                data.circuit_hash,
-            );
+            let shaped_device =
+                resolve_flow_device(&catalog, ip, data.device_hash, data.circuit_hash);
             if data.device_hash.is_none()
                 && let Some(device) = shaped_device
             {
@@ -453,9 +594,12 @@ impl ThroughputTracker {
             {
                 data.circuit_hash = Some(device.circuit_hash);
             }
-            data.circuit_id = shaped_device.map(|d| d.circuit_id.clone());
-            data.network_json_parents = shaped_device
-                .and_then(|device| lock.get_parents_for_circuit_id(&device.parent_node));
+            if let Some(device) = shaped_device {
+                data.circuit_id = Some(device.circuit_id.clone());
+                data.network_json_parents = lock.get_parents_for_circuit_id(&device.parent_node);
+            } else {
+                data.network_json_parents = None;
+            }
         });
     }
 
@@ -527,7 +671,7 @@ impl ThroughputTracker {
                 entry.last_seen = reduced.last_seen;
 
                 entry.tc_handle = reduced.tc_handle;
-                let shaped_device = Self::shaped_device_for_ip_or_hashes(
+                let shaped_device = resolve_flow_device(
                     &catalog,
                     xdp_ip,
                     reduced.device_hash,
@@ -544,16 +688,19 @@ impl ThroughputTracker {
                 entry.circuit_hash = resolved_circuit_hash;
                 entry.device_hash = resolved_device_hash;
                 if hashes_changed {
-                    let shaped_device = Self::shaped_device_for_ip_or_hashes(
+                    let shaped_device = resolve_flow_device(
                         &catalog,
                         xdp_ip,
                         entry.device_hash,
                         entry.circuit_hash,
                     );
-                    entry.circuit_id = shaped_device.map(|d| d.circuit_id.clone());
-                    entry.network_json_parents = shaped_device.and_then(|device| {
-                        net_json_calc.get_parents_for_circuit_id(&device.parent_node)
-                    });
+                    if let Some(device) = shaped_device {
+                        entry.circuit_id = Some(device.circuit_id.clone());
+                        entry.network_json_parents =
+                            net_json_calc.get_parents_for_circuit_id(&device.parent_node);
+                    } else {
+                        entry.network_json_parents = None;
+                    }
 
                     if shaped_device.is_none() {
                         record_dynamic_observation(
@@ -651,7 +798,7 @@ impl ThroughputTracker {
                     }
                 }
             } else {
-                let shaped_device = Self::shaped_device_for_ip_or_hashes(
+                let shaped_device = resolve_flow_device(
                     &catalog,
                     xdp_ip,
                     reduced.device_hash,
@@ -781,13 +928,13 @@ impl ThroughputTracker {
     pub(crate) fn apply_flow_data(&self, ctx: FlowApplyContext<'_>) {
         let FlowApplyContext {
             timeout_seconds,
-            sender,
             net_json_calc,
             rtt_circuit_tracker,
             rtt_by_circuit,
             tcp_retries,
             tcp_retry_packets,
             expired_keys,
+            finished_flow_exports,
         } = ctx;
         //log::debug!("Flowbee events this second: {}", get_flowbee_event_count_and_reset());
         let self_cycle = self.cycle.load(std::sync::atomic::Ordering::Relaxed);
@@ -820,377 +967,252 @@ impl ThroughputTracker {
             let expire = since_boot
                 .saturating_sub(Duration::from_secs(timeout_seconds))
                 .as_nanos() as u64;
+            let rtt_expire = since_boot
+                .saturating_sub(Duration::from_secs(RETIRE_AFTER_SECONDS))
+                .as_nanos() as u64;
 
-            let mut all_flows_lock = ALL_FLOWS.lock();
-            let mut raw_data = self.raw_data.lock();
+            finished_flow_exports.clear();
 
-            // Track through all the flows
-            iterate_flows(&mut |key, data| {
-                let mut rtt_buffer = rtt_samples.remove(key);
-                let mut rtt_for_circuit: Option<[RttData; 2]> = None;
-                if data.end_status == 3 {
-                    // The flow has been handled already and should be ignored.
-                    // DO NOT process it again.
-                } else if data.last_seen < expire {
-                    // This flow has expired but not been handled yet. Add it to the list to be cleaned.
-                    expired_keys.push(*key);
-                } else {
-                    // We have a valid flow, so it needs to be tracked
-                    if let Some(this_flow) = all_flows_lock.flow_data.get_mut(key) {
-                        let delta_bytes =
-                            data.bytes_sent.checked_sub_or_zero(this_flow.0.bytes_sent);
-                        let delta_packets = data
-                            .packets_sent
-                            .checked_sub_or_zero(this_flow.0.packets_sent);
-                        let delta_retrans = data
-                            .tcp_retransmits
-                            .checked_sub_or_zero(this_flow.0.tcp_retransmits);
-                        let delta_retrans =
-                            DownUpOrder::new(delta_retrans.down as u64, delta_retrans.up as u64);
-                        // If retransmits have changed, add the time to the retry list
-                        if data.tcp_retransmits.down != this_flow.0.tcp_retransmits.down {
-                            this_flow.0.record_tcp_retry_time(
-                                FlowbeeEffectiveDirection::Download,
-                                data.last_seen,
-                            );
-                        }
-                        if data.tcp_retransmits.up != this_flow.0.tcp_retransmits.up {
-                            this_flow.0.record_tcp_retry_time(
-                                FlowbeeEffectiveDirection::Upload,
-                                data.last_seen,
-                            );
-                        }
+            mutate_all_flows(|flow_data| {
+                let mut raw_data = self.raw_data.lock();
 
-                        //let change_since_last_time = data.bytes_sent.checked_sub_or_zero(this_flow.0.bytes_sent);
-                        //this_flow.0.throughput_buffer.push(change_since_last_time);
-                        //println!("{change_since_last_time:?}");
-
-                        this_flow.0.set_last_seen(data.last_seen);
-                        this_flow.0.set_bytes_sent(data.bytes_sent);
-                        this_flow.0.set_packets_sent(data.packets_sent);
-                        this_flow.0.set_rate_estimate_bps(data.rate_estimate_bps);
-                        this_flow.0.set_tcp_retransmits(data.tcp_retransmits);
-                        this_flow.0.set_end_status(data.end_status);
-                        this_flow.0.set_tos(data.tos);
-                        this_flow.0.set_flags(data.flags);
-
-                        if let Some(rtt_buffer) = rtt_buffer.take() {
-                            // Accumulate histogram data per-device so the device median is
-                            // weighted by RTT sample volume (not just per-flow medians).
-                            if key.ip_protocol == 6
-                                && data.end_status == 0
-                                && raw_data.contains_key(&key.local_ip)
-                            {
-                                let device_rtt =
-                                    rtt_circuit_tracker.entry(key.local_ip).or_default();
-                                if data.bytes_sent.down >= MIN_QOO_FLOW_BYTES {
-                                    device_rtt.accumulate_direction(
-                                        &rtt_buffer,
-                                        FlowbeeEffectiveDirection::Download,
-                                    );
-                                }
-                                if data.bytes_sent.up >= MIN_QOO_FLOW_BYTES {
-                                    device_rtt.accumulate_direction(
-                                        &rtt_buffer,
-                                        FlowbeeEffectiveDirection::Upload,
-                                    );
-                                }
-                            }
-
-                            this_flow.0.set_rtt_buffer(rtt_buffer);
-                        }
-
-                        // Per-flow QoO (stored for UI display).
-                        if key.ip_protocol == 6
-                            && let (Some(profile), Some(tcp_info)) =
-                                (qoo_profile.as_ref(), this_flow.0.tcp_info.as_ref())
-                        {
-                            let loss_download = tcp_retransmit_loss_proxy(
-                                this_flow.0.tcp_retransmits.down as u64,
-                                this_flow.0.packets_sent.down,
-                            );
-                            let loss_upload = tcp_retransmit_loss_proxy(
-                                this_flow.0.tcp_retransmits.up as u64,
-                                this_flow.0.packets_sent.up,
-                            );
-                            let scores = compute_qoq_scores(
-                                profile.as_ref(),
-                                &tcp_info.rtt,
-                                loss_download,
-                                loss_upload,
-                            );
-                            let mut scores = scores;
-                            if data.bytes_sent.down < MIN_QOO_FLOW_BYTES {
-                                scores.download_total = QOQ_UNKNOWN;
-                            }
-                            if data.bytes_sent.up < MIN_QOO_FLOW_BYTES {
-                                scores.upload_total = QOQ_UNKNOWN;
-                            }
-                            this_flow.0.set_qoq_scores(scores);
-                        }
-                        if enable_asn_heatmaps {
-                            let excluded = raw_data
-                                .get(&key.local_ip)
-                                .and_then(|t| t.circuit_hash)
-                                .is_some_and(crate::rtt_exclusions::is_excluded_hash);
-                            let flow_rtt = if excluded {
-                                None
-                            } else {
-                                combine_rtt_ms(this_flow.0.get_rtt_array())
-                            };
-                            add_asn_sample(
-                                this_flow.1.asn_id.0,
-                                delta_bytes,
-                                delta_packets,
-                                delta_retrans,
-                                flow_rtt,
-                            );
-                        }
-                        if key.ip_protocol == 6
-                            && data.end_status == 0
-                            && raw_data.contains_key(&key.local_ip)
-                        {
-                            tcp_retries
-                                .entry(key.local_ip)
-                                .or_insert_with(DownUpOrder::zeroed)
-                                .checked_add(delta_retrans);
-                            tcp_retry_packets
-                                .entry(key.local_ip)
-                                .or_insert_with(DownUpOrder::zeroed)
-                                .checked_add(delta_packets);
-                        }
+                // Track through all the flows
+                iterate_flows(&mut |key, data| {
+                    let mut rtt_buffer = rtt_samples.remove(key);
+                    let raw_entry = raw_data.get(&key.local_ip);
+                    if data.end_status == 3 {
+                        // The flow has been handled already and should be ignored.
+                        // DO NOT process it again.
+                    } else if data.last_seen < expire {
+                        // This flow has expired but not been handled yet. Add it to the list to be cleaned.
+                        expired_keys.push(*key);
                     } else {
-                        // Check if we've hit the flow limit
-                        if all_flows_lock.flow_data.len() >= MAX_FLOWS {
-                            // Log warning once per second to avoid spam
-                            static LAST_WARNING: std::sync::atomic::AtomicU64 =
-                                std::sync::atomic::AtomicU64::new(0);
-                            let now = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_secs();
-                            let last = LAST_WARNING.load(std::sync::atomic::Ordering::Relaxed);
-                            if now > last {
-                                warn!("Flow limit of {} reached, dropping new flow", MAX_FLOWS);
-                                LAST_WARNING.store(now, std::sync::atomic::Ordering::Relaxed);
+                        // We have a valid flow, so it needs to be tracked
+                        if let Some(this_flow) = flow_data.get_mut(key) {
+                            let (delta_bytes, delta_packets, delta_retrans) =
+                                flow_deltas(data, &this_flow.0);
+                            // If retransmits have changed, add the time to the retry list
+                            if data.tcp_retransmits.down != this_flow.0.tcp_retransmits.down {
+                                this_flow.0.record_tcp_retry_time(
+                                    FlowbeeEffectiveDirection::Download,
+                                    data.last_seen,
+                                );
+                            }
+                            if data.tcp_retransmits.up != this_flow.0.tcp_retransmits.up {
+                                this_flow.0.record_tcp_retry_time(
+                                    FlowbeeEffectiveDirection::Upload,
+                                    data.last_seen,
+                                );
+                            }
+
+                            this_flow.0.set_last_seen(data.last_seen);
+                            this_flow.0.set_bytes_sent(data.bytes_sent);
+                            this_flow.0.set_packets_sent(data.packets_sent);
+                            this_flow.0.set_rate_estimate_bps(data.rate_estimate_bps);
+                            this_flow.0.set_tcp_retransmits(data.tcp_retransmits);
+                            this_flow.0.set_end_status(data.end_status);
+                            this_flow.0.set_tos(data.tos);
+                            this_flow.0.set_flags(data.flags);
+
+                            apply_flow_rtt_and_qoo(
+                                &mut this_flow.0,
+                                raw_entry,
+                                rtt_circuit_tracker,
+                                key,
+                                rtt_buffer.take(),
+                                rtt_expire,
+                                qoo_profile.as_deref(),
+                            );
+                            if enable_asn_heatmaps {
+                                add_asn_sample(
+                                    this_flow.1.asn_id.0,
+                                    delta_bytes,
+                                    delta_packets,
+                                    delta_retrans,
+                                    flow_asn_rtt_ms(raw_entry, &this_flow.0),
+                                );
+                            }
+                            if key.ip_protocol == 6 && data.end_status == 0 && raw_entry.is_some()
+                            {
+                                tcp_retries
+                                    .entry(key.local_ip)
+                                    .or_insert_with(DownUpOrder::zeroed)
+                                    .checked_add(delta_retrans);
+                                tcp_retry_packets
+                                    .entry(key.local_ip)
+                                    .or_insert_with(DownUpOrder::zeroed)
+                                    .checked_add(delta_packets);
                             }
                         } else {
-                            // Insert it into the map
-                            let flow_analysis = FlowAnalysis::new(key);
-                            let mut flow_summary = FlowbeeLocalData::from_flow(data, key);
-                            if let Some(rtt_buffer) = rtt_buffer.take() {
-                                if key.ip_protocol == 6
-                                    && data.end_status == 0
-                                    && raw_data.contains_key(&key.local_ip)
-                                {
-                                    let device_rtt =
-                                        rtt_circuit_tracker.entry(key.local_ip).or_default();
-                                    if data.bytes_sent.down >= MIN_QOO_FLOW_BYTES {
-                                        device_rtt.accumulate_direction(
-                                            &rtt_buffer,
-                                            FlowbeeEffectiveDirection::Download,
-                                        );
-                                    }
-                                    if data.bytes_sent.up >= MIN_QOO_FLOW_BYTES {
-                                        device_rtt.accumulate_direction(
-                                            &rtt_buffer,
-                                            FlowbeeEffectiveDirection::Upload,
-                                        );
-                                    }
+                            // Check if we've hit the flow limit
+                            if flow_data.len() >= MAX_FLOWS {
+                                // Log warning once per second to avoid spam
+                                static LAST_WARNING: std::sync::atomic::AtomicU64 =
+                                    std::sync::atomic::AtomicU64::new(0);
+                                let now = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs();
+                                let last = LAST_WARNING.load(std::sync::atomic::Ordering::Relaxed);
+                                if now > last {
+                                    warn!("Flow limit of {} reached, dropping new flow", MAX_FLOWS);
+                                    LAST_WARNING.store(now, std::sync::atomic::Ordering::Relaxed);
                                 }
-                                rtt_for_circuit = Some([
-                                    rtt_buffer.median_new_data(FlowbeeEffectiveDirection::Download),
-                                    rtt_buffer.median_new_data(FlowbeeEffectiveDirection::Upload),
-                                ]);
-                                flow_summary.set_rtt_buffer(rtt_buffer);
+                            } else {
+                                // Insert it into the map
+                                let flow_analysis = FlowAnalysis::new(key);
+                                let mut flow_summary = FlowbeeLocalData::from_flow(data, key);
+                                apply_flow_rtt_and_qoo(
+                                    &mut flow_summary,
+                                    raw_entry,
+                                    rtt_circuit_tracker,
+                                    key,
+                                    rtt_buffer.take(),
+                                    rtt_expire,
+                                    qoo_profile.as_deref(),
+                                );
+                                if enable_asn_heatmaps {
+                                    let delta_retrans = DownUpOrder::new(
+                                        data.tcp_retransmits.down as u64,
+                                        data.tcp_retransmits.up as u64,
+                                    );
+                                    add_asn_sample(
+                                        flow_analysis.asn_id.0,
+                                        data.bytes_sent,
+                                        data.packets_sent,
+                                        delta_retrans,
+                                        flow_asn_rtt_ms(raw_entry, &flow_summary),
+                                    );
+                                }
+                                flow_data.insert(*key, (flow_summary, flow_analysis));
                             }
+                        }
 
-                            // Per-flow QoO (stored for UI display).
-                            if key.ip_protocol == 6
-                                && let (Some(profile), Some(tcp_info)) =
-                                    (qoo_profile.as_ref(), flow_summary.tcp_info.as_ref())
-                            {
-                                let loss_download = tcp_retransmit_loss_proxy(
-                                    flow_summary.tcp_retransmits.down as u64,
-                                    flow_summary.packets_sent.down,
-                                );
-                                let loss_upload = tcp_retransmit_loss_proxy(
-                                    flow_summary.tcp_retransmits.up as u64,
-                                    flow_summary.packets_sent.up,
-                                );
-                                let scores = compute_qoq_scores(
-                                    profile.as_ref(),
-                                    &tcp_info.rtt,
-                                    loss_download,
-                                    loss_upload,
-                                );
-                                let mut scores = scores;
-                                if data.bytes_sent.down < MIN_QOO_FLOW_BYTES {
-                                    scores.download_total = QOQ_UNKNOWN;
-                                }
-                                if data.bytes_sent.up < MIN_QOO_FLOW_BYTES {
-                                    scores.upload_total = QOQ_UNKNOWN;
-                                }
-                                flow_summary.set_qoq_scores(scores);
-                            }
-                            if enable_asn_heatmaps {
-                                let excluded = raw_data
-                                    .get(&key.local_ip)
-                                    .and_then(|t| t.circuit_hash)
-                                    .is_some_and(crate::rtt_exclusions::is_excluded_hash);
-                                let flow_rtt = if excluded {
-                                    None
-                                } else {
-                                    rtt_for_circuit.and_then(combine_rtt_ms)
-                                };
-                                let delta_retrans = DownUpOrder::new(
-                                    data.tcp_retransmits.down as u64,
-                                    data.tcp_retransmits.up as u64,
-                                );
-                                add_asn_sample(
-                                    flow_analysis.asn_id.0,
-                                    data.bytes_sent,
-                                    data.packets_sent,
-                                    delta_retrans,
-                                    flow_rtt,
-                                );
-                            }
-                            all_flows_lock
-                                .flow_data
-                                .insert(*key, (flow_summary, flow_analysis));
+                        if data.end_status != 0 {
+                            // The flow has ended. We need to remove it from the map.
+                            expired_keys.push(*key);
                         }
                     }
+                }); // End flow iterator
 
-                    if data.end_status != 0 {
-                        // The flow has ended. We need to remove it from the map.
-                        expired_keys.push(*key);
-                    }
-                }
-            }); // End flow iterator
+                // Merge in the per-flow RTT data into the per-circuit tracker
+                for (local_ip, rtt_buffer) in rtt_circuit_tracker {
+                    let rtt_buffer = std::mem::take(rtt_buffer);
+                    let download = rtt_buffer.median_new_data(FlowbeeEffectiveDirection::Download);
+                    let upload = rtt_buffer.median_new_data(FlowbeeEffectiveDirection::Upload);
 
-            // Merge in the per-flow RTT data into the per-circuit tracker
-            for (local_ip, rtt_buffer) in rtt_circuit_tracker {
-                let rtt_buffer = std::mem::take(rtt_buffer);
-                let download = rtt_buffer.median_new_data(FlowbeeEffectiveDirection::Download);
-                let upload = rtt_buffer.median_new_data(FlowbeeEffectiveDirection::Upload);
+                    let rtt_median = match (download.as_nanos(), upload.as_nanos()) {
+                        (0, 0) => None,
+                        (d, 0) => Some(RttData::from_nanos(d)),
+                        (0, u) => Some(RttData::from_nanos(u)),
+                        (d, u) => Some(RttData::from_nanos(d.saturating_add(u) / 2)),
+                    };
 
-                let rtt_median = match (download.as_nanos(), upload.as_nanos()) {
-                    (0, 0) => None,
-                    (d, 0) => Some(RttData::from_nanos(d)),
-                    (0, u) => Some(RttData::from_nanos(u)),
-                    (d, u) => Some(RttData::from_nanos(d.saturating_add(u) / 2)),
-                };
-
-                if let Some(rtt_median) = rtt_median
-                    && let Some(tracker) = raw_data.get_mut(local_ip)
-                {
-                    // Shift left
-                    for i in 1..60 {
-                        tracker.recent_rtt_data[i] = tracker.recent_rtt_data[i - 1];
-                    }
-                    tracker.recent_rtt_data[0] = rtt_median;
-                    tracker.last_fresh_rtt_data_cycle = self_cycle;
-                    tracker.rtt_buffer = rtt_buffer;
-                    let excluded = tracker
-                        .circuit_hash
-                        .is_some_and(crate::rtt_exclusions::is_excluded_hash);
-                    if !excluded {
-                        if let Some(circuit_hash) = tracker.circuit_hash {
-                            rtt_by_circuit
-                                .entry(circuit_hash)
-                                .or_default()
-                                .accumulate(&tracker.rtt_buffer);
-                        }
-                        if let Some(parents) = &tracker.network_json_parents {
-                            net_json_calc.add_rtt_buffer_cycle(parents, &tracker.rtt_buffer);
-                        }
-                    }
-                }
-            }
-
-            // Merge in the TCP retries
-            // Reset all entries in the tracker to 0
-            for (_k, circuit) in raw_data.iter_mut() {
-                circuit.tcp_retransmits = DownUpOrder::zeroed();
-                circuit.tcp_retransmit_packets = DownUpOrder::zeroed();
-            }
-            // Apply the new ones
-            for (local_ip, retries) in tcp_retries {
-                if let Some(tracker) = raw_data.get_mut(local_ip) {
-                    tracker.tcp_retransmit_packets = tcp_retry_packets
-                        .get(local_ip)
-                        .copied()
-                        .unwrap_or_else(DownUpOrder::zeroed);
-                    tracker.tcp_retransmits = *retries;
-
-                    // Send it upstream
-                    if let Some(parents) = &tracker.network_json_parents {
-                        net_json_calc.add_retransmit_cycle(
-                            parents,
-                            tracker.tcp_retransmits,
-                            tracker.tcp_retransmit_packets,
-                        );
-                    }
-                }
-            }
-
-            // Per-device QoO (stored for UI display via `NetworkTreeClients`).
-            //
-            // NOTE: `compute_qoq_scores` uses the TOTAL RTT histogram bucket, so scores remain
-            // meaningful even when the current RTT window has few samples. We only update scores
-            // when prerequisites are available; otherwise we keep the last known values so the UI
-            // doesn't flap to unknown ("-") on idle seconds.
-            if let Some(profile) = qoo_profile.as_ref() {
-                for tracker in raw_data.values_mut() {
-                    if tracker
-                        .circuit_hash
-                        .is_some_and(crate::rtt_exclusions::is_excluded_hash)
+                    if let Some(rtt_median) = rtt_median
+                        && let Some(tracker) = raw_data.get_mut(local_ip)
                     {
-                        tracker.qoq = QoqScores::default();
-                        continue;
-                    }
-                    let tcp_packets_delta = tracker.tcp_retransmit_packets;
-                    let loss_download = tcp_retransmit_loss_proxy(
-                        tracker.tcp_retransmits.down,
-                        tcp_packets_delta.down,
-                    );
-                    let loss_upload =
-                        tcp_retransmit_loss_proxy(tracker.tcp_retransmits.up, tcp_packets_delta.up);
-                    let scores = compute_qoq_scores(
-                        profile.as_ref(),
-                        &tracker.rtt_buffer,
-                        loss_download,
-                        loss_upload,
-                    );
-                    if scores.download_total != QOQ_UNKNOWN {
-                        tracker.qoq.download_total = scores.download_total;
-                    }
-                    if scores.upload_total != QOQ_UNKNOWN {
-                        tracker.qoq.upload_total = scores.upload_total;
-                    }
-                }
-            }
-
-            // Key Expiration
-            if !expired_keys.is_empty() {
-                for key in expired_keys.iter() {
-                    // Send it off to netperf for analysis if we are supporting doing so.
-                    if let Some(d) = all_flows_lock.flow_data.remove(key) {
-                        let _ = sender.send((*key, (d.0.clone(), d.1)));
+                        // Shift left
+                        for i in 1..60 {
+                            tracker.recent_rtt_data[i] = tracker.recent_rtt_data[i - 1];
+                        }
+                        tracker.recent_rtt_data[0] = rtt_median;
+                        tracker.last_fresh_rtt_data_cycle = self_cycle;
+                        tracker.rtt_buffer = rtt_buffer;
+                        let excluded = tracker
+                            .circuit_hash
+                            .is_some_and(crate::rtt_exclusions::is_excluded_hash);
+                        if !excluded {
+                            if let Some(circuit_hash) = tracker.circuit_hash {
+                                rtt_by_circuit
+                                    .entry(circuit_hash)
+                                    .or_default()
+                                    .accumulate(&tracker.rtt_buffer);
+                            }
+                            if let Some(parents) = &tracker.network_json_parents {
+                                net_json_calc.add_rtt_buffer_cycle(parents, &tracker.rtt_buffer);
+                            }
+                        }
                     }
                 }
 
-                let ret = lqos_sys::end_flows(expired_keys);
-                if let Err(e) = ret {
-                    warn!("Failed to end flows: {:?}", e);
+                // Merge in the TCP retries
+                // Reset all entries in the tracker to 0
+                for (_k, circuit) in raw_data.iter_mut() {
+                    circuit.tcp_retransmits = DownUpOrder::zeroed();
+                    circuit.tcp_retransmit_packets = DownUpOrder::zeroed();
                 }
-            }
+                // Apply the new ones
+                for (local_ip, retries) in tcp_retries {
+                    if let Some(tracker) = raw_data.get_mut(local_ip) {
+                        tracker.tcp_retransmit_packets = tcp_retry_packets
+                            .get(local_ip)
+                            .copied()
+                            .unwrap_or_else(DownUpOrder::zeroed);
+                        tracker.tcp_retransmits = *retries;
 
-            // Cleaning run
-            all_flows_lock
-                .flow_data
-                .retain(|_k, v| v.0.last_seen >= expire);
-            all_flows_lock.flow_data.shrink_to_fit();
+                        // Send it upstream
+                        if let Some(parents) = &tracker.network_json_parents {
+                            net_json_calc.add_retransmit_cycle(
+                                parents,
+                                tracker.tcp_retransmits,
+                                tracker.tcp_retransmit_packets,
+                            );
+                        }
+                    }
+                }
+
+                // Per-device QoO (stored for UI display via `NetworkTreeClients`).
+                //
+                // NOTE: `compute_qoq_scores` uses the TOTAL RTT histogram bucket, so scores remain
+                // meaningful even when the current RTT window has few samples. We only update scores
+                // when prerequisites are available; otherwise we keep the last known values so the UI
+                // doesn't flap to unknown ("-") on idle seconds.
+                if let Some(profile) = qoo_profile.as_ref() {
+                    for tracker in raw_data.values_mut() {
+                        if tracker
+                            .circuit_hash
+                            .is_some_and(crate::rtt_exclusions::is_excluded_hash)
+                        {
+                            tracker.qoq = QoqScores::default();
+                            continue;
+                        }
+                        let tcp_packets_delta = tracker.tcp_retransmit_packets;
+                        let loss_download = tcp_retransmit_loss_proxy(
+                            tracker.tcp_retransmits.down,
+                            tcp_packets_delta.down,
+                        );
+                        let loss_upload = tcp_retransmit_loss_proxy(
+                            tracker.tcp_retransmits.up,
+                            tcp_packets_delta.up,
+                        );
+                        let scores = compute_qoq_scores(
+                            profile.as_ref(),
+                            &tracker.rtt_buffer,
+                            loss_download,
+                            loss_upload,
+                        );
+                        if scores.download_total != QOQ_UNKNOWN {
+                            tracker.qoq.download_total = scores.download_total;
+                        }
+                        if scores.upload_total != QOQ_UNKNOWN {
+                            tracker.qoq.upload_total = scores.upload_total;
+                        }
+                    }
+                }
+
+                // Key Expiration
+                let mut removed_flows = 0;
+                if !expired_keys.is_empty() {
+                    removed_flows +=
+                        collect_finished_flow_exports(flow_data, expired_keys, finished_flow_exports);
+                }
+                removed_flows += collect_stale_flow_exports(flow_data, expire, finished_flow_exports);
+                if removed_flows > 0 {
+                    shrink_flow_table_if_sparse(flow_data);
+                }
+
+            });
+
             expire_rtt_flows();
         }
 
@@ -1417,13 +1439,26 @@ fn tcp_retransmit_loss_proxy(retransmits: u64, packets: u64) -> Option<LossMeasu
 
 #[cfg(test)]
 mod tests {
-    use super::{ThroughputEntry, ThroughputTracker};
-    use crate::test_support::runtime_config_test_lock;
-    use crate::throughput_tracker::flow_data::{RttBuffer, RttData};
+    use super::{
+        MIN_QOO_FLOW_BYTES, ThroughputEntry, ThroughputTracker, apply_flow_rtt_and_qoo,
+        collect_finished_flow_exports, collect_stale_flow_exports, update_flow_qoo,
+    };
+    use crate::test_support::{
+        ActiveFlowSnapshotTestContext, active_flow_entry, runtime_config_test_lock,
+    };
+    use crate::throughput_tracker::flow_data::{
+        FlowAnalysis, FlowbeeLocalData, RttBuffer, RttData, active_flow_snapshot,
+        mutate_all_flows, refresh_active_flow_snapshot,
+    };
+    use fxhash::FxHashMap;
     use lqos_bus::TcHandle;
     use lqos_config::{ConfigShapedDevices, ShapedDevice};
     use lqos_network_devices::{NetworkDevicesCatalog, ShapedDevicesCatalog};
-    use lqos_utils::qoo::QoqScores;
+    use lqos_sys::flowbee_data::{FlowbeeData, FlowbeeKey};
+    use lqos_utils::qoo::{
+        LatencyNormalization, LatencyReq, LossHandling, LowHigh, QOQ_UNKNOWN, QooProfile,
+        QoqScores,
+    };
     use lqos_utils::units::DownUpOrder;
     use lqos_utils::{XdpIpAddress, hash_to_i64};
     use std::ffi::OsString;
@@ -1565,11 +1600,435 @@ mod tests {
         let catalog = NetworkDevicesCatalog::from_snapshots(shaped_catalog, Arc::new(Vec::new()));
         let ip = XdpIpAddress::from_ip("192.168.1.10".parse().expect("test IP should parse"));
 
-        let matched = ThroughputTracker::shaped_device_for_ip_or_hashes(&catalog, &ip, None, None)
-            .expect("lookup should resolve by IP");
+        let matched =
+            crate::throughput_tracker::resolve_flow_device(&catalog, &ip, None, None)
+                .expect("lookup should resolve by IP");
 
         assert_eq!(matched.circuit_hash, hash_to_i64("circuit-1"));
         assert_eq!(matched.device_hash, hash_to_i64("device-1"));
+    }
+
+    #[test]
+    fn collect_finished_flow_exports_removes_and_queues_live_flow_once() {
+        let mut expired_key = FlowbeeKey::default();
+        expired_key.ip_protocol = 6;
+        expired_key.src_port = 443;
+        expired_key.dst_port = 50_000;
+
+        let mut second_expired_key = expired_key;
+        second_expired_key.dst_port = 50_001;
+
+        let mut live_key = expired_key;
+        live_key.dst_port = 50_002;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        raw.packets_sent = DownUpOrder::new(10, 20);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+        let mut second_raw = raw.clone();
+        second_raw.bytes_sent = DownUpOrder::new(3_000, 4_000);
+        second_raw.packets_sent = DownUpOrder::new(30, 40);
+
+        let expired_flow = (
+            FlowbeeLocalData::from_flow(&raw, &expired_key),
+            FlowAnalysis::new(&expired_key),
+        );
+        let second_expired_flow = (
+            FlowbeeLocalData::from_flow(&second_raw, &second_expired_key),
+            FlowAnalysis::new(&second_expired_key),
+        );
+        let live_flow = (
+            FlowbeeLocalData::from_flow(&raw, &live_key),
+            FlowAnalysis::new(&live_key),
+        );
+        let mut flow_data = FxHashMap::default();
+        flow_data.insert(expired_key, expired_flow);
+        flow_data.insert(second_expired_key, second_expired_flow);
+        flow_data.insert(live_key, live_flow);
+        let mut exports = Vec::new();
+
+        let removed = collect_finished_flow_exports(
+            &mut flow_data,
+            &[expired_key, second_expired_key, expired_key],
+            &mut exports,
+        );
+
+        assert_eq!(removed, 2);
+        assert_eq!(exports.len(), 2);
+        assert_eq!(exports[0].0, expired_key);
+        assert_eq!(exports[0].1.0.bytes_sent, raw.bytes_sent);
+        assert_eq!(exports[0].1.0.packets_sent, raw.packets_sent);
+        assert_eq!(exports[0].1.1, FlowAnalysis::new(&expired_key));
+        assert_eq!(exports[1].0, second_expired_key);
+        assert_eq!(exports[1].1.0.bytes_sent, second_raw.bytes_sent);
+        assert_eq!(exports[1].1.0.packets_sent, second_raw.packets_sent);
+        assert_eq!(exports[1].1.1, FlowAnalysis::new(&second_expired_key));
+        assert!(!flow_data.contains_key(&expired_key));
+        assert!(!flow_data.contains_key(&second_expired_key));
+        assert!(flow_data.contains_key(&live_key));
+    }
+
+    #[test]
+    fn collect_stale_flow_exports_removes_unseen_old_flows() {
+        let mut stale_key = FlowbeeKey::default();
+        stale_key.ip_protocol = 6;
+        stale_key.src_port = 443;
+        stale_key.dst_port = 50_010;
+
+        let mut live_key = stale_key;
+        live_key.dst_port = 50_011;
+        let mut boundary_key = stale_key;
+        boundary_key.dst_port = 50_012;
+
+        let mut stale_raw = FlowbeeData::default();
+        stale_raw.start_time = 1;
+        stale_raw.last_seen = 10;
+        stale_raw.bytes_sent = DownUpOrder::new(1_000, 2_000);
+        stale_raw.packets_sent = DownUpOrder::new(10, 20);
+
+        let mut live_raw = stale_raw.clone();
+        live_raw.last_seen = 200;
+        live_raw.bytes_sent = DownUpOrder::new(3_000, 4_000);
+        let mut boundary_raw = stale_raw.clone();
+        boundary_raw.last_seen = 100;
+        boundary_raw.bytes_sent = DownUpOrder::new(5_000, 6_000);
+
+        let mut flow_data = FxHashMap::default();
+        flow_data.insert(
+            stale_key,
+            (
+                FlowbeeLocalData::from_flow(&stale_raw, &stale_key),
+                FlowAnalysis::new(&stale_key),
+            ),
+        );
+        flow_data.insert(
+            live_key,
+            (
+                FlowbeeLocalData::from_flow(&live_raw, &live_key),
+                FlowAnalysis::new(&live_key),
+            ),
+        );
+        flow_data.insert(
+            boundary_key,
+            (
+                FlowbeeLocalData::from_flow(&boundary_raw, &boundary_key),
+                FlowAnalysis::new(&boundary_key),
+            ),
+        );
+        let mut exports = Vec::new();
+
+        let removed = collect_stale_flow_exports(&mut flow_data, 100, &mut exports);
+
+        assert_eq!(removed, 1);
+        assert_eq!(exports.len(), 1);
+        assert_eq!(exports[0].0, stale_key);
+        assert_eq!(exports[0].1.0.bytes_sent, stale_raw.bytes_sent);
+        assert!(!flow_data.contains_key(&stale_key));
+        assert!(flow_data.contains_key(&boundary_key));
+        assert!(flow_data.contains_key(&live_key));
+    }
+
+    #[test]
+    fn expired_flow_cycle_publishes_removal_before_export_cleanup() {
+        let _ctx = ActiveFlowSnapshotTestContext::empty();
+        let bytes_sent = DownUpOrder::new(1_000, 2_000);
+        let (key, (local, analysis)) = active_flow_entry(
+            [192, 0, 2, 60],
+            [198, 51, 100, 60],
+            50_003,
+            20,
+            DownUpOrder::new(30_000, 40_000),
+            bytes_sent,
+            DownUpOrder::new(10, 20),
+        );
+
+        mutate_all_flows(|flows| {
+            flows.insert(key, (local, analysis));
+        });
+        refresh_active_flow_snapshot();
+        assert_eq!(active_flow_snapshot().len(), 1);
+
+        let mut expired_keys = vec![key, key];
+        crate::throughput_tracker::dedup_flow_keys(&mut expired_keys);
+        let mut finished_flow_exports = Vec::new();
+        mutate_all_flows(|flows| {
+            collect_finished_flow_exports(flows, &expired_keys, &mut finished_flow_exports);
+        });
+        assert_eq!(finished_flow_exports.len(), 1);
+        assert_eq!(active_flow_snapshot().len(), 1);
+
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        let mut cleanup_keys = Vec::new();
+        refresh_active_flow_snapshot();
+        assert!(active_flow_snapshot().is_empty());
+        crate::throughput_tracker::finish_expired_flows(
+            &mut finished_flow_exports,
+            expired_keys.as_mut_slice(),
+            &sender,
+            |keys| {
+                let received = receiver
+                    .try_recv()
+                    .expect("expired flow export should be sent before cleanup");
+                assert_eq!(received.0, key);
+                assert_eq!(received.1.0.bytes_sent, bytes_sent);
+                cleanup_keys.extend_from_slice(keys);
+                Ok(())
+            },
+        );
+
+        assert!(receiver.try_recv().is_err());
+        assert!(finished_flow_exports.is_empty());
+        assert_eq!(cleanup_keys, vec![key]);
+    }
+
+    #[test]
+    fn update_flow_qoo_suppresses_sub_threshold_flow_bytes() {
+        fn scores_for_bytes(bytes_sent: DownUpOrder<u64>) -> QoqScores {
+            let mut key = FlowbeeKey::default();
+            key.ip_protocol = 6;
+            key.src_port = 443;
+            key.dst_port = 50_004;
+
+            let mut raw = FlowbeeData::default();
+            raw.start_time = 10;
+            raw.last_seen = 20;
+            raw.bytes_sent = bytes_sent;
+            raw.packets_sent = DownUpOrder::new(10_000, 10_000);
+            raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+            raw.tcp_retransmits = DownUpOrder::new(0, 0);
+
+            let mut flow = FlowbeeLocalData::from_flow(&raw, &key);
+            let mut rtt = RttBuffer::new(
+                RttData::from_nanos(20_000_000),
+                crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+                raw.last_seen,
+            );
+            for _ in 0..5 {
+                rtt.push(
+                    RttData::from_nanos(20_000_000),
+                    crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+                    raw.last_seen,
+                );
+                rtt.push(
+                    RttData::from_nanos(20_000_000),
+                    crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Upload,
+                    raw.last_seen,
+                );
+            }
+            flow.set_rtt_buffer(rtt);
+
+            let profile = QooProfile {
+                name: "test".to_string(),
+                latency: vec![LatencyReq {
+                    percentile: 50,
+                    rtt_ms: LowHigh::lower_is_better(100.0, 20.0),
+                }],
+                loss_fraction: LowHigh::lower_is_better(0.05, 0.0),
+                loss_handling: LossHandling::Strict,
+                latency_normalization: LatencyNormalization::None,
+            };
+
+            update_flow_qoo(&mut flow, &key, Some(&profile));
+            flow.get_qoq_scores()
+        }
+
+        let download_below =
+            scores_for_bytes(DownUpOrder::new(MIN_QOO_FLOW_BYTES - 1, MIN_QOO_FLOW_BYTES + 1));
+        assert_eq!(download_below.download_total, QOQ_UNKNOWN);
+        assert_ne!(download_below.upload_total, QOQ_UNKNOWN);
+
+        let upload_below =
+            scores_for_bytes(DownUpOrder::new(MIN_QOO_FLOW_BYTES + 1, MIN_QOO_FLOW_BYTES - 1));
+        assert_ne!(upload_below.download_total, QOQ_UNKNOWN);
+        assert_eq!(upload_below.upload_total, QOQ_UNKNOWN);
+    }
+
+    #[test]
+    fn apply_flow_rtt_and_qoo_skips_sub_threshold_device_rtt_samples() {
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_005;
+        key.local_ip =
+            XdpIpAddress::from_ip("192.0.2.54".parse().expect("test IP should parse"));
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(MIN_QOO_FLOW_BYTES - 1, MIN_QOO_FLOW_BYTES - 1);
+        raw.packets_sent = DownUpOrder::new(10_000, 10_000);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+
+        let mut flow = FlowbeeLocalData::from_flow(&raw, &key);
+        let mut rtt = RttBuffer::new(
+            RttData::from_nanos(20_000_000),
+            crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(20_000_000),
+            crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        rtt.push(
+            RttData::from_nanos(30_000_000),
+            crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Upload,
+            raw.last_seen,
+        );
+        let entry = make_entry(300, 0, 0);
+        let mut rtt_circuit_tracker = FxHashMap::default();
+
+        apply_flow_rtt_and_qoo(
+            &mut flow,
+            Some(&entry),
+            &mut rtt_circuit_tracker,
+            &key,
+            Some(rtt),
+            0,
+            None,
+        );
+
+        assert!(rtt_circuit_tracker.is_empty());
+    }
+
+    #[test]
+    fn apply_flow_rtt_and_qoo_keeps_qoo_when_retiring_stale_rtt() {
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_005;
+        key.local_ip =
+            XdpIpAddress::from_ip("192.0.2.55".parse().expect("test IP should parse"));
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(MIN_QOO_FLOW_BYTES + 1, MIN_QOO_FLOW_BYTES + 1);
+        raw.packets_sent = DownUpOrder::new(10_000, 10_000);
+        raw.rate_estimate_bps = DownUpOrder::new(30_000, 40_000);
+
+        let mut flow = FlowbeeLocalData::from_flow(&raw, &key);
+        let mut rtt = RttBuffer::new(
+            RttData::from_nanos(25_000_000),
+            crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+            raw.last_seen,
+        );
+        for _ in 0..5 {
+            rtt.push(
+                RttData::from_nanos(25_000_000),
+                crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+                raw.last_seen,
+            );
+            rtt.push(
+                RttData::from_nanos(45_000_000),
+                crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Upload,
+                raw.last_seen,
+            );
+        }
+        flow.set_rtt_buffer(rtt);
+        flow.set_qoq_scores(QoqScores {
+            download_total: 77,
+            upload_total: 66,
+        });
+        let cached_download_rtt = flow.get_summary_rtt_as_nanos(
+            crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download,
+        );
+        let cached_upload_rtt = flow.get_summary_rtt_as_nanos(
+            crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Upload,
+        );
+
+        let profile = QooProfile {
+            name: "test".to_string(),
+            latency: vec![LatencyReq {
+                percentile: 50,
+                rtt_ms: LowHigh::lower_is_better(100.0, 20.0),
+            }],
+            loss_fraction: LowHigh::lower_is_better(0.05, 0.0),
+            loss_handling: LossHandling::Strict,
+            latency_normalization: LatencyNormalization::None,
+        };
+        let mut rtt_circuit_tracker = FxHashMap::default();
+
+        apply_flow_rtt_and_qoo(
+            &mut flow,
+            None,
+            &mut rtt_circuit_tracker,
+            &key,
+            None,
+            raw.last_seen + 1,
+            Some(&profile),
+        );
+
+        assert_eq!(
+            flow.get_summary_rtt_as_nanos(
+                crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Download
+            ),
+            cached_download_rtt
+        );
+        assert_eq!(
+            flow.get_summary_rtt_as_nanos(
+                crate::throughput_tracker::flow_data::FlowbeeEffectiveDirection::Upload
+            ),
+            cached_upload_rtt
+        );
+        assert_eq!(flow.get_qoq_scores().download_total_f32(), Some(77.0));
+        assert_eq!(flow.get_qoq_scores().upload_total_f32(), Some(66.0));
+    }
+
+    #[test]
+    fn apply_flow_rtt_and_qoo_refreshes_live_flow_metadata() {
+        let mut key = FlowbeeKey::default();
+        key.ip_protocol = 6;
+        key.src_port = 443;
+        key.dst_port = 50_006;
+
+        let mut raw = FlowbeeData::default();
+        raw.start_time = 10;
+        raw.last_seen = 20;
+        raw.bytes_sent = DownUpOrder::new(10_000, 20_000);
+        raw.packets_sent = DownUpOrder::new(100, 200);
+        raw.circuit_hash = 100;
+        raw.device_hash = 200;
+
+        let mut flow = FlowbeeLocalData::from_flow(&raw, &key);
+        flow.set_circuit_id_hint(Some("old-circuit"));
+        let mut entry = make_entry(300, 0, 0);
+        entry.circuit_id = Some("new-circuit".to_string());
+        entry.device_hash = Some(400);
+        let mut rtt_circuit_tracker = FxHashMap::default();
+
+        apply_flow_rtt_and_qoo(
+            &mut flow,
+            Some(&entry),
+            &mut rtt_circuit_tracker,
+            &key,
+            None,
+            0,
+            None,
+        );
+
+        assert_eq!(flow.circuit_hash, Some(300));
+        assert_eq!(flow.device_hash, Some(400));
+        assert_eq!(flow.circuit_id_hint.as_deref(), Some("new-circuit"));
+
+        entry.circuit_hash = Some(301);
+        entry.device_hash = Some(401);
+        entry.circuit_id = None;
+        apply_flow_rtt_and_qoo(
+            &mut flow,
+            Some(&entry),
+            &mut rtt_circuit_tracker,
+            &key,
+            None,
+            0,
+            None,
+        );
+
+        assert_eq!(flow.circuit_hash, Some(301));
+        assert_eq!(flow.device_hash, Some(401));
+        assert_eq!(flow.circuit_id_hint.as_deref(), Some("new-circuit"));
     }
 
     #[test]


### PR DESCRIPTION
Hide the live flow table behind accessors, publish an ArcSwap active-flow snapshot for informational readers, and move export/BPF cleanup work outside the ALL_FLOWS lock.

Preserve existing wire and circuit identity behavior while adding regression coverage for snapshot readers, stale filtering, exact-rate serialization, and QoO/RTT thresholds.

Adds an `ArcSwap` setup for visualization snapshots.

The previous system worked - but was causing UI hangs under load, especially with the enhanced front-end querying it more heavily.