### PR TITLE
Fix packaging after lqos_topology binary removal

### DIFF
--- a/src/build_dpkg.sh
+++ b/src/build_dpkg.sh
@@ -70,7 +70,6 @@ RUSTPROGS=(
   lqos_map_perf
   uisp_integration
   lqos_overrides
-  lqos_topology
 )
 
 ####################################################

--- a/src/build_rust.sh
+++ b/src/build_rust.sh
@@ -72,7 +72,6 @@ PROGS=(
     lqos_map_perf
     uisp_integration
     lqos_overrides
-    lqos_topology
 )
 BUILD_PACKAGES=(
     lqosd


### PR DESCRIPTION
## Summary

- stop `build_dpkg.sh` from copying `lqos_topology` as a standalone binary
- keep `build_rust.sh` aligned with the package build
- retain the `lqos_topology` Cargo package build because it remains a library used by `lqosd`

## Verification

- `cargo metadata --no-deps` reports `lqos_topology` as a library-only target
- `bash -n src/build_dpkg.sh`
- `bash -n src/build_rust.sh`
- `git diff --check`

A full `.deb` package build was not run.