### PR TITLE
Fix crossbeam-epoch security advisory

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- update crossbeam-epoch from 0.9.18 to 0.9.20 in Cargo.lock
- resolve RUSTSEC-2026-0204 without changing manifests or feature flags
- preserve a single crossbeam-epoch version in the dependency graph

The dependency is reachable only through the lqos_queue_tracker Criterion benchmark dev-dependency. It is not present in normal or build dependency graphs. cargo bloat was therefore not useful for this change, and feature trimming would expand scope without affecting shipped binaries.

## Validation

- cargo audit
- cargo tree -i crossbeam-epoch@0.9.20 --locked --workspace
- cargo tree --locked --workspace --duplicates
- cargo machete
- cargo check --workspace --all-targets --locked
- cargo test --workspace --locked
- cargo clippy -p lqos_queue_tracker --all-targets --locked -- -D warnings

The full workspace all-target Clippy run reaches an unrelated pre-existing field_reassign_with_default lint in lqos_config/src/etc/v15/top_config.rs:996. The focused affected-path Clippy run passes.