### PR TITLE
Fix topology runtime effective-network generation mismatch

### DIFF
--- a/src/rust/lqos_topology/src/lib.rs
+++ b/src/rust/lqos_topology/src/lib.rs
@@ -15,7 +15,7 @@ use lqos_config::{
     TopologyEffectiveNodeState, TopologyEffectiveStateFile, TopologyQueueVisibilityPolicy,
     TopologyRuntimeStatusFile, TopologyShapingCircuitInput, TopologyShapingDeviceInput,
     TopologyShapingInputsFile, TopologyShapingResolutionSource, circuit_anchors_path,
-    compute_effective_network_generation, detect_shaping_cpus, plan_top_level_assignments,
+    compute_effective_network_file_generation, detect_shaping_cpus, plan_top_level_assignments,
     topology_auto_attachment_option, topology_effective_network_path,
     topology_effective_state_path, topology_runtime_status_path, topology_shaping_inputs_path,
 };

--- a/src/rust/lqos_topology/src/publish.rs
+++ b/src/rust/lqos_topology/src/publish.rs
@@ -35,11 +35,6 @@ pub fn publish_effective_topology_artifacts(
     let effective_state_value = serde_json::to_value(&artifacts.effective)?;
 
     let effective_network_path = topology_effective_network_path(config);
-    let effective_generation = artifacts
-        .effective_network
-        .as_ref()
-        .map(compute_effective_network_generation)
-        .transpose()?;
 
     let shaping_inputs_path = topology_shaping_inputs_path(config);
     let shaping_inputs = build_shaping_inputs(config, artifacts)?;
@@ -87,6 +82,21 @@ pub fn publish_effective_topology_artifacts(
             )
         })?;
     }
+
+    let effective_generation = if artifacts.effective_network.is_some() {
+        Some(
+            compute_effective_network_file_generation(&effective_network_path).with_context(
+                || {
+                    format!(
+                        "Unable to compute effective topology generation from {:?}",
+                        effective_network_path
+                    )
+                },
+            )?,
+        )
+    } else {
+        None
+    };
 
     match prepared_shaping_inputs {
         Some((shaping_inputs, shaping_inputs_value)) => {

--- a/src/rust/lqos_topology/src/tests/group_01.rs
+++ b/src/rust/lqos_topology/src/tests/group_01.rs
@@ -565,10 +565,6 @@
         assert!(ready.ready);
         assert_eq!(ready.error, None);
         assert!(!ready.shaping_generation.is_empty());
-        let effective_network_generation =
-            compute_effective_network_file_generation(&topology_effective_network_path(&config))
-                .expect("effective network generation should compute from published file");
-        assert_eq!(ready.effective_generation, effective_network_generation);
         assert_eq!(
             ready.effective_state_path,
             topology_effective_state_path(&config)
@@ -591,6 +587,70 @@
         assert!(topology_effective_network_path(&config).exists());
         assert!(topology_shaping_inputs_path(&config).exists());
         assert!(topology_runtime_status_path(&config).exists());
+    }
+
+    #[test]
+    fn publish_runtime_status_hashes_existing_equal_effective_network_file() {
+        let lqos_directory = unique_temp_dir("lqos-topology-runtime-status-existing-network");
+        let config = Config {
+            lqos_directory: lqos_directory.to_string_lossy().to_string(),
+            state_directory: None,
+            ..Config::default()
+        };
+        fs::write(
+            lqos_directory.join("ShapedDevices.csv"),
+            concat!(
+                "Circuit ID,Circuit Name,Device ID,Device Name,Parent Node,Parent Node ID,Anchor Node ID,MAC,IPv4,IPv6,Download Min Mbps,Upload Min Mbps,Download Max Mbps,Upload Max Mbps,Comment\n",
+                "\"circuit-1\",\"Circuit 1\",\"device-1\",\"Device 1\",\"Tower 1\",\"tower-1\",\"tower-1\",\"aa:bb:cc:dd:ee:ff\",\"192.0.2.10/32\",\"\",\"10\",\"10\",\"100\",\"100\",\"\"\n",
+            ),
+        )
+        .expect("ShapedDevices.csv should write");
+
+        let mut artifacts = sample_runtime_artifacts();
+        artifacts.effective_network = Some(json!({
+            "Tower 1": {
+                "id": "tower-1",
+                "name": "Tower 1",
+                "downloadBandwidthMbps": -0.0,
+                "uploadBandwidthMbps": 100.0,
+                "children": {}
+            }
+        }));
+        let effective_network_path = topology_effective_network_path(&config);
+        let existing_effective_network = r#"{
+  "Tower 1": {
+    "id": "tower-1",
+    "name": "Tower 1",
+    "downloadBandwidthMbps": 0.0,
+    "uploadBandwidthMbps": 100.0,
+    "children": {}
+  }
+}"#;
+        fs::create_dir_all(
+            effective_network_path
+                .parent()
+                .expect("effective network path should have a parent"),
+        )
+        .expect("effective network state directory should exist");
+        fs::write(
+            &effective_network_path,
+            existing_effective_network,
+        )
+        .expect("existing effective network should write");
+
+        publish_effective_topology_artifacts(&config, &artifacts, "generation-1")
+            .expect("ready status should publish");
+        let ready = TopologyRuntimeStatusFile::load(&config).expect("ready status should load");
+        assert!(ready.ready);
+        assert_eq!(
+            fs::read_to_string(&effective_network_path)
+                .expect("effective network should remain readable"),
+            existing_effective_network,
+        );
+        let effective_network_generation =
+            compute_effective_network_file_generation(&effective_network_path)
+                .expect("effective network generation should compute from published file");
+        assert_eq!(ready.effective_generation, effective_network_generation);
     }
 
 

--- a/src/rust/lqos_topology/src/tests/group_01.rs
+++ b/src/rust/lqos_topology/src/tests/group_01.rs
@@ -565,6 +565,10 @@
         assert!(ready.ready);
         assert_eq!(ready.error, None);
         assert!(!ready.shaping_generation.is_empty());
+        let effective_network_generation =
+            compute_effective_network_file_generation(&topology_effective_network_path(&config))
+                .expect("effective network generation should compute from published file");
+        assert_eq!(ready.effective_generation, effective_network_generation);
         assert_eq!(
             ready.effective_state_path,
             topology_effective_state_path(&config)

--- a/src/rust/lqos_topology/src/tests/helpers.rs
+++ b/src/rust/lqos_topology/src/tests/helpers.rs
@@ -18,9 +18,9 @@
         TopologyCanonicalRateInputSource, TopologyCanonicalStateFile, TopologyEditorNode,
         TopologyEditorStateFile, TopologyEffectiveAttachmentState, TopologyEffectiveNodeState,
         TopologyEffectiveStateFile, TopologyQueueVisibilityPolicy, TopologyRuntimeStatusFile,
-        TopologyShapingResolutionSource, topology_auto_attachment_option as auto_attachment_option,
-        topology_effective_network_path, topology_effective_state_path, topology_runtime_status_path,
-        topology_shaping_inputs_path,
+        TopologyShapingResolutionSource, compute_effective_network_file_generation,
+        topology_auto_attachment_option as auto_attachment_option, topology_effective_network_path,
+        topology_effective_state_path, topology_runtime_status_path, topology_shaping_inputs_path,
     };
     use lqos_overrides::{TopologyAttachmentMode, TopologyOverridesFile};
     use serde_json::{Value, json};


### PR DESCRIPTION
## Summary

- Compute topology runtime `effective_generation` from the published `network.effective.json` file instead of the in-memory effective-network payload.
- Keep runtime status generation aligned with the same file-based validation path used by scheduler and shaping-input loading.
- Preserve the existing not-ready status behavior when topology runtime cannot produce shaping inputs.
- Add a regression test for the skip-rewrite path where an existing effective-network file is semantically equal to the new payload but byte-different.

## Why

Schedulers can get stuck on `Waiting for topology runtime` when `topology_runtime_status.json` advertises an `effective_generation` that does not match the generation recomputed from the published `network.effective.json`.

The publisher previously computed `effective_generation` from the in-memory JSON payload before the scheduler later validated against the on-disk file. If an existing effective-network file compared equal and was not rewritten, those two representations could diverge. The scheduler correctly rejected the runtime artifacts, leaving shaping blocked even though topology runtime had marked itself ready.

## Approach

- Publish or remove `network.effective.json` first.
- If an effective network exists, read/hash the published file with `compute_effective_network_file_generation`.
- Publish topology runtime status using that file-derived generation.
- Cover the edge case with a test that pre-seeds an equal-but-byte-different effective-network file and verifies:
  - the file is not rewritten;
  - runtime status is ready;
  - `status.effective_generation` matches the published file generation.