### PR TITLE
Feat: support bonded interfaces for XDP setup

### DIFF
--- a/docs-es/v2.0/bridge-es.md
+++ b/docs-es/v2.0/bridge-es.md
@@ -12,11 +12,11 @@ El puente regular de Linux es recomendado para la mayoría de las instalaciones.
 A continuación, se encuentran las instrucciones para configurar Netplan, ya sea usando el puente de Linux o el puente Bifrost con XDP:
 
 ```{note}
-La página Network Mode en la interfaz web de LibreQoS ahora inspecciona los archivos actuales de Netplan, ofrece en menús desplegables las interfaces elegibles que no forman parte de la ruta de gestión, prepara cambios administrados para `libreqos.yaml` en los modos puente de Linux y de interfaz única, los aplica con una ventana temporizada de reversión manejada por LibreQoS y le permite confirmar o revertir el cambio pendiente. También puede restaurar desde esa página la copia de seguridad administrada anterior. El modo puente XDP sigue siendo un flujo manual de Netplan.
+La página Network Mode de la interfaz web de LibreQoS inspecciona los archivos actuales de Netplan y ofrece interfaces elegibles que no forman parte de la ruta de gestión. Los modos puente de Linux e interfaz única pueden preparar y aplicar cambios administrados en `libreqos.yaml` con una ventana temporizada de reversión. El modo XDP guarda solamente `lqos.conf`; nunca genera ni aplica Netplan.
 ```
 
 ```{note}
-La configuración inicial actual solo ofrece Puente Linux e Interfaz Única para instalaciones nuevas. Si LibreQoS detecta un despliegue XDP existente, la configuración preserva ese modo XDP heredado y le avisa antes de migrar fuera de él.
+La configuración inicial ofrece Puente Linux, Puente XDP e Interfaz Única. Para usar XDP con un bond, configure primero el bond en Netplan y seleccione su interfaz maestra en LibreQoS. No seleccione una interfaz miembro del bond.
 ```
 
 ```{note}
@@ -99,3 +99,51 @@ sudo netplan apply
 ```
 
 Para usar el puente XDP, asegurese de establecer `use_xdp_bridge` como `true` en el archivo lqos.conf dentro de la sección [Configuración](configuration-es.md).
+
+### Puente XDP con bonds 802.3ad
+
+El controlador de bonding de Linux admite XDP nativo en interfaces maestras `802.3ad` cuando los controladores de todas las interfaces miembro también admiten XDP nativo. Configure LACP en los puertos conectados del switch y defina los bonds en Netplan antes de seleccionarlos en LibreQoS. El siguiente ejemplo usa un bond de dos puertos a cada lado del regulador:
+
+```yaml
+network:
+    ethernets:
+        enp1s0:
+            dhcp4: false
+            dhcp6: false
+        enp2s0:
+            dhcp4: false
+            dhcp6: false
+        enp3s0:
+            dhcp4: false
+            dhcp6: false
+        enp4s0:
+            dhcp4: false
+            dhcp6: false
+    bonds:
+        bond-wan:
+            interfaces: [enp1s0, enp2s0]
+            parameters:
+                mode: 802.3ad
+        bond-lan:
+            interfaces: [enp3s0, enp4s0]
+            parameters:
+                mode: 802.3ad
+    version: 2
+```
+
+Después seleccione `bond-wan` como interfaz orientada a Internet y `bond-lan` como interfaz orientada a la LAN. La sección equivalente de `lqos.conf` es:
+
+```toml
+[bridge]
+use_xdp_bridge = true
+to_internet = "bond-wan"
+to_network = "bond-lan"
+```
+
+No seleccione `enp1s0` a `enp4s0` en LibreQoS. Son miembros de los bonds; XDP debe adjuntarse a las interfaces maestras. Confirme que cada bond exponga varias colas RX/TX y que `lqosd` se adjunte en modo nativo del controlador antes de transportar tráfico de producción. La documentación del kernel de Linux enumera los [modos de bonding que admiten XDP nativo](https://docs.kernel.org/networking/bonding.html#what-bonding-modes-support-native-xdp).
+
+Después de cambiar un nodo existente para usar las interfaces maestras de los bonds, reinicie `lqosd` para que adjunte XDP a las nuevas interfaces seleccionadas:
+
+```shell
+sudo systemctl restart lqosd
+```

--- a/docs-es/v2.0/configuration-advanced-es.md
+++ b/docs-es/v2.0/configuration-advanced-es.md
@@ -37,6 +37,17 @@ En la sección ```[bridge]```, cambie `to_internet` y `to_network` para que coin
 
 En la sección `[bridge]` del archivo lqos.conf, puede habilitar o deshabilitar el puente XDP con la opción `use_xdp_bridge`. El valor predeterminado es `false` - ya que la configuración por defecto asume un [Puente Linux](prereq-es.md). Si eligió usar el puente XDP durante la configuración de requisitos previos, establezca `use_xdp_bridge = true`.
 
+Para un despliegue XDP con enlaces agregados, configure `to_internet` y/o `to_network` con los nombres de las interfaces maestras de los bonds, no con los nombres de sus interfaces miembro. Los bonds deben estar configurados previamente en Netplan, exponer varias colas RX/TX y usar un modo de bonding compatible con XDP nativo. Por ejemplo:
+
+```toml
+[bridge]
+use_xdp_bridge = true
+to_internet = "bond-wan"
+to_network = "bond-lan"
+```
+
+Consulte [Configurar el Puente de Regulación](bridge-es.md#puente-xdp-con-bonds-8023ad) para ver el ejemplo de Netplan y las comprobaciones de compatibilidad.
+
 - Configure downlink_bandwidth_mbps y uplink_bandwidth_mbps para que coincidan con el ancho de banda en Mbps de la conexión WAN/Upstream de su red. Lo mismo puede hacerse para generated_pn_download_mbps y generated_pn_upload_mbps.
 - to_internet es la interfaz que apunta hacia su router de borde (edge router) y el internet.
 - to_network es la interfaz que apunta hacia su router interno (core router) (o la red interna puenteada, si su red está configurada de esa manera).

--- a/docs-es/v2.0/requirements-es.md
+++ b/docs-es/v2.0/requirements-es.md
@@ -109,6 +109,8 @@ Estos proveedores suelen ofrecer servidores capaces de manejar un rendimiento de
 * Una interfaz de red de administración completamente separada de las interfaces de regulamiento de tráfico. Usualmente esta sería la interfaz Ethernet integrada en la placa base.
 * Una Tarjeta de Red Dedicada para Dos Interfaces de Regulamiento
 
+> **Interfaces enlazadas:** El puente XDP puede usar una interfaz maestra de bond cuando el kernel en ejecución y los controladores de todas las NIC miembro admiten XDP nativo. Linux documenta soporte para XDP nativo con `balance-rr`, `active-backup`, `balance-xor` y `802.3ad`; la política de hash de transmisión `vlan+srcmac` no es compatible. Seleccione la interfaz maestra del bond en LibreQoS, no sus interfaces miembro. Consulte la [documentación de Linux sobre bonding y XDP](https://docs.kernel.org/networking/bonding.html#what-bonding-modes-support-native-xdp).
+
 Las Tarjetas de Red oficialmente soportadas para las dos interfaces de regulamiento se enumeran a continuación:
 
 | Controlador NIC         | Velocidad de Puerto       | Modelos Sugeridos                                                                        | Problemas Conocidos                                                                                  |

--- a/docs/v2.0/bridge.md
+++ b/docs/v2.0/bridge.md
@@ -12,11 +12,11 @@ The regular Linux bridge is recommended for most installations. The Linux Bridge
 Below are the instructions to configure Netplan, whether using the Linux Bridge or Bifrost XDP bridge:
 
 ```{note}
-The Network Mode page in the LibreQoS web UI now inspects the current Netplan files, offers eligible non-management interfaces in dropdowns, stages managed `libreqos.yaml` changes for Linux bridge and single-interface modes, applies them with a timed LibreQoS rollback window, and lets you confirm or revert the pending change. You can also restore the previous managed backup from that page. XDP bridge mode remains a manual Netplan workflow.
+The Network Mode page in the LibreQoS web UI inspects the current Netplan files and offers eligible non-management interfaces. Linux bridge and single-interface modes can stage and apply managed `libreqos.yaml` changes with a timed rollback window. XDP mode saves only `lqos.conf`; it never generates or applies Netplan.
 ```
 
 ```{note}
-Current first-run setup only offers Linux Bridge and Single Interface for new installs. If LibreQoS detects an existing XDP deployment, setup preserves that legacy XDP mode and warns before you migrate away from it.
+First-run setup offers Linux Bridge, XDP Bridge, and Single Interface. When using XDP with a bond, configure the bond in Netplan first and select the bond master in LibreQoS. Do not select an individual bond member.
 ```
 
 ```{note}
@@ -99,3 +99,51 @@ sudo netplan apply
 ```
 
 To use the XDP bridge, please be sure to set `use_xdp_bridge` to `true` in lqos.conf in the [Configuration](configuration.md) section.
+
+### XDP bridge with 802.3ad bonds
+
+The Linux bonding driver supports native XDP on `802.3ad` bond masters when every member driver also supports native XDP. Configure LACP on the connected switch ports and define the bonds in Netplan before selecting them in LibreQoS. The following example uses one two-port bond on each side of the shaper:
+
+```yaml
+network:
+    ethernets:
+        enp1s0:
+            dhcp4: false
+            dhcp6: false
+        enp2s0:
+            dhcp4: false
+            dhcp6: false
+        enp3s0:
+            dhcp4: false
+            dhcp6: false
+        enp4s0:
+            dhcp4: false
+            dhcp6: false
+    bonds:
+        bond-wan:
+            interfaces: [enp1s0, enp2s0]
+            parameters:
+                mode: 802.3ad
+        bond-lan:
+            interfaces: [enp3s0, enp4s0]
+            parameters:
+                mode: 802.3ad
+    version: 2
+```
+
+Then select `bond-wan` as the Internet-facing interface and `bond-lan` as the LAN-facing interface. The equivalent `lqos.conf` section is:
+
+```toml
+[bridge]
+use_xdp_bridge = true
+to_internet = "bond-wan"
+to_network = "bond-lan"
+```
+
+Do not select `enp1s0` through `enp4s0` in LibreQoS. They are bond members; XDP must attach to the bond masters. Confirm that each bond exposes multiple RX/TX queues and that `lqosd` attaches in native driver mode before carrying production traffic. The Linux kernel documentation lists the [bonding modes that support native XDP](https://docs.kernel.org/networking/bonding.html#what-bonding-modes-support-native-xdp).
+
+After changing an existing node to use the bond masters, restart `lqosd` so it attaches XDP to the newly selected interfaces:
+
+```shell
+sudo systemctl restart lqosd
+```

--- a/docs/v2.0/configuration-advanced.md
+++ b/docs/v2.0/configuration-advanced.md
@@ -39,6 +39,17 @@ In the ```[bridge]``` section, change `to_internet` and `to_network` to match yo
 
 In the `[bridge]` section of the lqos.conf file, you can enable or disable the XDP Bridge with the setting `use_xdp_bridge`. The default value is `false` - because the default setup assumes a [Linux Bridge](prereq.md). If you chose to use the XDP Bridge during that pre-requisites setup, please set `use_xdp_bridge = true` instead.
 
+For an XDP deployment using bonded links, set `to_internet` and/or `to_network` to the bond master names, not the member interface names. The bonds must already be configured in Netplan, expose multiple RX/TX queues, and use a bonding mode supported by native XDP. For example:
+
+```toml
+[bridge]
+use_xdp_bridge = true
+to_internet = "bond-wan"
+to_network = "bond-lan"
+```
+
+See [Configure Shaping Bridge](bridge.md#xdp-bridge-with-8023ad-bonds) for the Netplan example and compatibility checks.
+
 - Set downlink_bandwidth_mbps and uplink_bandwidth_mbps to match the bandwidth in Mbps of your network's upstream / WAN internet connection. The same can be done for generated_pn_download_mbps and generated_pn_upload_mbps.
 - to_internet would be the interface facing your edge router and the broader internet
 - to_network would be the interface facing your core router (or bridged internal network if your network is bridged)

--- a/docs/v2.0/requirements.md
+++ b/docs/v2.0/requirements.md
@@ -109,7 +109,7 @@ Such vendors often stock servers capable of 10 Gbps throughput, for around $500 
 * One management network interface completely separate from the traffic shaping interfaces. Usually this would be the Ethernet interface built in to the motherboard.
 * A Dedicated Network Interface Card for Two Shaping Interfaces
 
-> **⚠️ Bonded Interfaces**: LibreQoS does not support the use of bonded interfaces. This is a limitation of XDP.
+> **Bonded interfaces:** The XDP bridge can use a bond master when the running kernel and every member NIC driver support native XDP. Linux documents native XDP support for `balance-rr`, `active-backup`, `balance-xor`, and `802.3ad`; the `vlan+srcmac` transmit hash policy is not supported. Select the bond master in LibreQoS, not its member interfaces. See the [Linux bonding XDP documentation](https://docs.kernel.org/networking/bonding.html#what-bonding-modes-support-native-xdp).
 
 Officially supported Network Interface Cards for the two shaping interfaces are listed below:
 

--- a/src/rust/lqos_config/src/etc/mod.rs
+++ b/src/rust/lqos_config/src/etc/mod.rs
@@ -25,8 +25,8 @@ pub use v15::{
     RadiusFallbackSpeedProfile, RadiusSharedSecretSource, RateProfileValidationError,
     RttThresholds, SingleInterfaceConfig, SslConfig, StormguardConfig, StormguardStrategy,
     TopologyConfig, TreeguardCircuitsConfig, TreeguardConfig, TreeguardCpuConfig, TreeguardCpuMode,
-    TreeguardLinksConfig, TreeguardQooConfig, Tunables, normalize_external_hostname,
-    validate_rate_profile_mbps,
+    TreeguardLinksConfig, TreeguardQooConfig, Tunables, native_xdp_bond_issue,
+    normalize_external_hostname, validate_rate_profile_mbps,
 };
 
 static CONFIG: Lazy<ArcSwap<Option<Arc<Config>>>> = Lazy::new(|| ArcSwap::from_pointee(None));

--- a/src/rust/lqos_config/src/etc/v15/bridge.rs
+++ b/src/rust/lqos_config/src/etc/v15/bridge.rs
@@ -5,16 +5,50 @@
 use allocative::Allocative;
 use serde::{Deserialize, Serialize};
 
+/// Returns a compatibility issue when Linux bonding settings cannot use native XDP.
+///
+/// An omitted mode uses the bonding driver's native-XDP-compatible default. Member NIC driver
+/// support cannot be determined from configuration alone and is validated when XDP attaches.
+pub fn native_xdp_bond_issue(
+    mode: Option<&str>,
+    transmit_hash_policy: Option<&str>,
+) -> Option<String> {
+    if let Some(mode) = mode
+        && !matches!(
+            mode.trim()
+                .trim_matches(['[', ']'])
+                .to_ascii_lowercase()
+                .as_str(),
+            "balance-rr" | "active-backup" | "balance-xor" | "802.3ad" | "0" | "1" | "2" | "4"
+        )
+    {
+        return Some(format!("Bond mode {mode} does not support native XDP."));
+    }
+    if transmit_hash_policy.is_some_and(|policy| {
+        policy
+            .trim()
+            .trim_matches(['[', ']'])
+            .eq_ignore_ascii_case("vlan+srcmac")
+    }) {
+        return Some(
+            "Bond transmit hash policy vlan+srcmac does not support native XDP.".to_string(),
+        );
+    }
+    None
+}
+
 /// Represents a two-interface bridge configuration.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Allocative)]
 pub struct BridgeConfig {
     /// Use the XDP-accelerated bridge?
     pub use_xdp_bridge: bool,
 
-    /// The name of the first interface, facing the Internet
+    /// The name of the first interface, facing the Internet. XDP mode also
+    /// accepts a bond master when the kernel and member drivers support native XDP.
     pub to_internet: String,
 
-    /// The name of the second interface, facing the LAN
+    /// The name of the second interface, facing the LAN. XDP mode also accepts
+    /// a bond master when the kernel and member drivers support native XDP.
     pub to_network: String,
 
     /// Optional MTU for LibreQoS-managed Linux bridge interfaces.
@@ -58,5 +92,35 @@ impl Default for SingleInterfaceConfig {
             network_vlan: 3,
             mtu: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::native_xdp_bond_issue;
+
+    #[test]
+    fn native_xdp_bond_settings_match_linux_support() {
+        for mode in [
+            None,
+            Some("balance-rr"),
+            Some("active-backup"),
+            Some("balance-xor"),
+            Some("802.3ad"),
+            Some("0"),
+            Some("1"),
+            Some("2"),
+            Some("4"),
+        ] {
+            assert_eq!(native_xdp_bond_issue(mode, Some("layer3+4")), None);
+        }
+        assert!(
+            native_xdp_bond_issue(Some("balance-alb"), None)
+                .is_some_and(|issue| issue.contains("balance-alb"))
+        );
+        assert!(
+            native_xdp_bond_issue(Some("802.3ad"), Some("vlan+srcmac"))
+                .is_some_and(|issue| issue.contains("vlan+srcmac"))
+        );
     }
 }

--- a/src/rust/lqos_config/src/etc/v15/top_config.rs
+++ b/src/rust/lqos_config/src/etc/v15/top_config.rs
@@ -882,6 +882,20 @@ mod test {
     }
 
     #[test]
+    fn xdp_bridge_accepts_bond_master_names() {
+        let raw = include_str!("example.toml")
+            .replace("to_internet = \"eth0\"", "to_internet = \"bond-wan\"")
+            .replace("to_network = \"eth1\"", "to_network = \"bond-lan\"")
+            .replace("use_xdp_bridge = false", "use_xdp_bridge = true");
+        let config = Config::load_from_string(&raw).expect("bond master names should load");
+        let bridge = config.bridge.expect("bridge config");
+
+        assert!(bridge.use_xdp_bridge);
+        assert_eq!(bridge.to_internet, "bond-wan");
+        assert_eq!(bridge.to_network, "bond-lan");
+    }
+
+    #[test]
     fn interface_mtu_values_deserialize() {
         let bridge_raw = include_str!("example.toml")
             .replace("to_network = \"eth1\"", "to_network = \"eth1\"\nmtu = 9000");

--- a/src/rust/lqos_config/src/lib.rs
+++ b/src/rust/lqos_config/src/lib.rs
@@ -48,7 +48,7 @@ pub use etc::{
     RttThresholds, SingleInterfaceConfig, SslConfig, StormguardConfig, StormguardStrategy,
     TopologyConfig, TreeguardCircuitsConfig, TreeguardConfig, TreeguardCpuConfig, TreeguardCpuMode,
     TreeguardLinksConfig, TreeguardQooConfig, Tunables, clear_cached_config, disable_xdp_bridge,
-    enable_long_term_stats, load_config, normalize_external_hostname,
+    enable_long_term_stats, load_config, native_xdp_bond_issue, normalize_external_hostname,
     treeguard_cpu_mode_migration_notice, update_config, validate_rate_profile_mbps,
 };
 pub use ethernet_port_limits::{

--- a/src/rust/lqos_netplan_helper/src/inspect.rs
+++ b/src/rust/lqos_netplan_helper/src/inspect.rs
@@ -58,6 +58,8 @@ pub struct InterfaceCandidate {
     #[serde(default)]
     pub details: Vec<String>,
     pub bridge_eligible: bool,
+    #[serde(default)]
+    pub xdp_bridge_eligible: bool,
     pub single_interface_eligible: bool,
     #[serde(default)]
     pub current_selection: bool,
@@ -163,6 +165,28 @@ struct NetplanBridge {
 struct NetplanRelationship {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     interfaces: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    parameters: BTreeMap<String, serde_yaml::Value>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_netplan_bool",
+        skip_serializing_if = "Option::is_none"
+    )]
+    dhcp4: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_netplan_bool",
+        skip_serializing_if = "Option::is_none"
+    )]
+    dhcp6: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    addresses: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    gateway4: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    gateway6: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    routes: Vec<serde_yaml::Value>,
     #[serde(flatten)]
     extra: BTreeMap<String, serde_yaml::Value>,
 }
@@ -235,6 +259,31 @@ impl NetplanBridge {
             || !self.routes.is_empty()
             || self.dhcp4 == Some(true)
             || self.dhcp6 == Some(true)
+    }
+}
+
+impl NetplanRelationship {
+    fn has_l3_config(&self) -> bool {
+        !self.addresses.is_empty()
+            || self.gateway4.is_some()
+            || self.gateway6.is_some()
+            || !self.routes.is_empty()
+            || self.dhcp4 == Some(true)
+            || self.dhcp6 == Some(true)
+    }
+
+    fn parameter_text(&self, key: &str) -> Option<String> {
+        let value = self.parameters.get(key)?;
+        value
+            .as_str()
+            .map(ToOwned::to_owned)
+            .or_else(|| value.as_i64().map(|value| value.to_string()))
+    }
+
+    fn native_xdp_issue(&self) -> Option<String> {
+        let mode = self.parameter_text("mode");
+        let transmit_hash_policy = self.parameter_text("transmit-hash-policy");
+        lqos_config::native_xdp_bond_issue(mode.as_deref(), transmit_hash_policy.as_deref())
     }
 }
 
@@ -393,7 +442,7 @@ fn managed_preview_yaml(mode: &RequestedMode) -> (Option<String>, Option<String>
         RequestedMode::XdpBridge { .. } => (
             None,
             Some(
-                "XDP bridge mode remains a manual workflow. LibreQoS does not generate netplan for this mode."
+                "XDP bridge mode saves lqos.conf only. LibreQoS does not generate or apply netplan for this mode."
                     .to_string(),
             ),
         ),
@@ -470,6 +519,7 @@ fn add_interface_reason(
 fn collect_interface_restrictions(
     doc: &NetplanDocument,
     restrictions: &mut BTreeMap<String, BTreeSet<String>>,
+    bond_names: &mut BTreeSet<String>,
 ) {
     for (iface, cfg) in &doc.network.ethernets {
         if cfg.has_l3_config() {
@@ -492,6 +542,27 @@ fn collect_interface_restrictions(
                     ),
                 );
             }
+        }
+    }
+
+    for (bond_name, bond) in &doc.network.bonds {
+        bond_names.insert(bond_name.clone());
+        if bond.has_l3_config() {
+            add_interface_reason(
+                restrictions,
+                bond_name,
+                "Carries DHCP, static addressing, or routes in current netplan.",
+            );
+        }
+        if let Some(issue) = bond.native_xdp_issue() {
+            add_interface_reason(restrictions, bond_name, issue);
+        }
+        for member in &bond.interfaces {
+            add_interface_reason(
+                restrictions,
+                member,
+                format!("Member of bond {bond_name}; select the bond master for XDP instead."),
+            );
         }
     }
 }
@@ -530,6 +601,7 @@ fn build_interface_candidates(
     selected: &[String],
     default_interface_name: Option<&str>,
     interface_restrictions: &BTreeMap<String, BTreeSet<String>>,
+    bond_names: &BTreeSet<String>,
 ) -> Vec<InterfaceCandidate> {
     let selected_set = selected.iter().cloned().collect::<BTreeSet<_>>();
     let mut candidates = system_ifaces
@@ -537,7 +609,8 @@ fn build_interface_candidates(
         .map(|iface| {
             let mut details = Vec::new();
 
-            if let Some(reason) = interface_name_role_reason(iface) {
+            let is_bond = bond_names.contains(iface);
+            if !is_bond && let Some(reason) = interface_name_role_reason(iface) {
                 details.push(reason.to_string());
             }
             if default_interface_name.is_some_and(|default_iface| default_iface == iface) {
@@ -553,11 +626,18 @@ fn build_interface_candidates(
             details.dedup();
 
             let eligible = details.is_empty();
+            if is_bond && eligible {
+                details.push(
+                    "Bond master; Netplan settings allow native XDP. Member drivers must also support native XDP."
+                        .to_string(),
+                );
+            }
             InterfaceCandidate {
                 name: iface.clone(),
                 details,
-                bridge_eligible: eligible,
-                single_interface_eligible: eligible,
+                bridge_eligible: eligible && !is_bond,
+                xdp_bridge_eligible: eligible,
+                single_interface_eligible: eligible && !is_bond,
                 current_selection: selected_set.contains(iface),
             }
         })
@@ -802,9 +882,37 @@ fn assess_file(path: &Path, doc: &NetplanDocument, mode: &RequestedMode) -> File
 
     for (bond_name, bond) in &doc.network.bonds {
         for iface in selected_interfaces(mode) {
-            if bond.interfaces.iter().any(|member| member == &iface) {
+            if iface == *bond_name {
                 relevant.insert(iface.clone());
-                details.push(format!("{iface} is already part of bond {bond_name}."));
+                details.push(format!(
+                    "{iface} is a bond containing interfaces: {}.",
+                    bond.interfaces.join(", ")
+                ));
+                if matches!(mode, RequestedMode::XdpBridge { .. }) {
+                    if bond.has_l3_config() {
+                        details.push(format!(
+                            "Bond master {iface} carries DHCP, static addressing, or routes; shaping bond masters must not carry host networking."
+                        ));
+                        has_conflict = true;
+                        is_complex = true;
+                    }
+                    if let Some(issue) = bond.native_xdp_issue() {
+                        details.push(issue);
+                        has_conflict = true;
+                        is_complex = true;
+                    }
+                } else {
+                    details.push(format!(
+                        "Bond master {iface} is only supported as a LibreQoS interface in XDP bridge mode."
+                    ));
+                    has_conflict = true;
+                    is_complex = true;
+                }
+            } else if bond.interfaces.iter().any(|member| member == &iface) {
+                relevant.insert(iface.clone());
+                details.push(format!(
+                    "{iface} is a member of bond {bond_name}; select the bond master instead."
+                ));
                 has_conflict = true;
                 is_complex = true;
             }
@@ -876,6 +984,7 @@ pub fn inspect_network_mode_with_paths(
     let has_pending_try = pending_try_exists(pending_dir);
     let default_interface_name = get_default_interface().ok().map(|iface| iface.name);
     let mut interface_restrictions = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut bond_names = BTreeSet::new();
 
     if selected.is_empty() {
         warnings.push(
@@ -910,7 +1019,7 @@ pub fn inspect_network_mode_with_paths(
 
         match parse_netplan_file(&path) {
             Ok(doc) => {
-                collect_interface_restrictions(&doc, &mut interface_restrictions);
+                collect_interface_restrictions(&doc, &mut interface_restrictions, &mut bond_names);
                 let assessment = assess_file(&path, &doc, &mode);
                 if assessment.has_conflict {
                     conflicts.extend(assessment.detected.details.clone());
@@ -951,6 +1060,21 @@ pub fn inspect_network_mode_with_paths(
 
     dangerous_changes.sort();
     dangerous_changes.dedup();
+
+    let interface_candidates = build_interface_candidates(
+        system_ifaces,
+        queue_caps,
+        &selected,
+        default_interface_name.as_deref(),
+        &interface_restrictions,
+        &bond_names,
+    );
+    let xdp_selection_eligible = matches!(mode, RequestedMode::XdpBridge { .. })
+        && selected.iter().all(|selected_interface| {
+            interface_candidates.iter().any(|candidate| {
+                candidate.name == *selected_interface && candidate.xdp_bridge_eligible
+            })
+        });
 
     let can_take_over = takeover_candidate && !has_pending_try;
     let can_adopt = external_sources.len() == 1 && !has_complex && !has_pending_try;
@@ -1008,6 +1132,20 @@ pub fn inspect_network_mode_with_paths(
             ),
             false,
         )
+    } else if matches!(mode, RequestedMode::XdpBridge { .. }) && xdp_selection_eligible {
+        (
+            "Ready",
+            "The selected XDP interfaces are eligible. Saving will update lqos.conf and leave netplan unchanged."
+                .to_string(),
+            false,
+        )
+    } else if matches!(mode, RequestedMode::XdpBridge { .. }) {
+        (
+            "ComplexUnsupported",
+            "One or more selected XDP interfaces are unavailable. Review the interface details before saving."
+                .to_string(),
+            true,
+        )
     } else if has_managed {
         (
             "ManagedByLibreQoS",
@@ -1047,27 +1185,30 @@ pub fn inspect_network_mode_with_paths(
             false,
         )
     } else {
-        (
-            "Ready",
-            "No blocking netplan conflicts were detected for the selected mode. Review the managed preview before applying changes.".to_string(),
-            false,
-        )
+        let summary = if matches!(mode, RequestedMode::XdpBridge { .. }) {
+            "No blocking netplan conflicts were detected for the selected XDP interfaces. Saving will update lqos.conf and leave netplan unchanged."
+        } else {
+            "No blocking netplan conflicts were detected for the selected mode. Review the managed preview before applying changes."
+        };
+        ("Ready", summary.to_string(), false)
     };
 
     if matches!(mode, RequestedMode::XdpBridge { .. }) {
         warnings.push(
-            "XDP bridge mode remains manual. LibreQoS only provides inspection for this mode in the current helper slice."
+            "Configure XDP interfaces and bonds in netplan before saving this mode. LibreQoS will leave netplan unchanged."
                 .to_string(),
         );
     }
 
-    let can_apply = !editing_locked
-        && !matches!(
-            mode,
-            RequestedMode::XdpBridge { .. } | RequestedMode::Unknown
-        )
-        && !has_pending_try
-        && preview.is_some();
+    let can_apply = if matches!(mode, RequestedMode::XdpBridge { .. }) {
+        !has_pending_try && xdp_selection_eligible
+    } else {
+        !editing_locked
+            && !matches!(mode, RequestedMode::Unknown)
+            && !has_pending_try
+            && matches!(inspector_state, "Ready" | "ManagedByLibreQoS")
+            && preview.is_some()
+    };
     let strong_confirmation_text = if dangerous_changes.is_empty() {
         None
     } else {
@@ -1076,14 +1217,6 @@ pub fn inspect_network_mode_with_paths(
                 .to_string(),
         )
     };
-    let interface_candidates = build_interface_candidates(
-        system_ifaces,
-        queue_caps,
-        &selected,
-        default_interface_name.as_deref(),
-        &interface_restrictions,
-    );
-
     NetworkModeInspection {
         mode_label: mode_label(&mode),
         selected_interfaces: selected,
@@ -1155,6 +1288,25 @@ mod tests {
             }),
             ..lqos_config::Config::default()
         }
+    }
+
+    fn xdp_bond_config() -> lqos_config::Config {
+        lqos_config::Config {
+            bridge: Some(lqos_config::BridgeConfig {
+                use_xdp_bridge: true,
+                to_internet: "bond-wan".to_string(),
+                to_network: "bond-lan".to_string(),
+                mtu: None,
+            }),
+            single_interface: None,
+            ..lqos_config::Config::default()
+        }
+    }
+
+    fn xdp_physical_config() -> lqos_config::Config {
+        let mut config = linux_bridge_config();
+        config.bridge.as_mut().expect("bridge").use_xdp_bridge = true;
+        config
     }
 
     fn test_env(name: &str) -> std::path::PathBuf {
@@ -1241,7 +1393,7 @@ mod tests {
     }
 
     #[test]
-    fn xdp_bridge_mode_keeps_managed_preview_disabled() {
+    fn xdp_bridge_mode_allows_config_only_apply() {
         let mut config = linux_bridge_config();
         let bridge = config.bridge.as_mut().expect("bridge");
         bridge.use_xdp_bridge = true;
@@ -1257,12 +1409,303 @@ mod tests {
         );
 
         assert!(inspection.managed_preview_yaml.is_none());
+        assert!(inspection.can_apply);
         assert!(
             inspection
                 .preview_note
                 .as_deref()
-                .is_some_and(|note| note.contains("manual workflow"))
+                .is_some_and(|note| note.contains("lqos.conf only"))
         );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn xdp_config_only_apply_ignores_unrelated_unmanaged_netplan_errors() {
+        let root = test_env("xdp-unrelated-netplan-error");
+        std::fs::write(
+            root.join("netplan").join("99-unrelated.yaml"),
+            "network: [invalid",
+        )
+        .expect("write invalid unrelated netplan fixture");
+        let system_ifaces = BTreeSet::from(["ens19".to_string(), "ens20".to_string()]);
+        let queue_caps = system_ifaces
+            .iter()
+            .map(|name| (name.clone(), true))
+            .collect::<BTreeMap<_, _>>();
+
+        let inspection = inspect_network_mode_with_paths(
+            &xdp_physical_config(),
+            &root.join("netplan"),
+            &root.join("pending"),
+            &system_ifaces,
+            &queue_caps,
+        );
+
+        assert_eq!(inspection.inspector_state, "Ready");
+        assert!(inspection.can_apply);
+        assert!(
+            inspection
+                .detected_files
+                .iter()
+                .any(|file| file.classification == "ComplexUnsupported")
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn xdp_bridge_mode_cannot_save_missing_interfaces() {
+        let root = test_env("xdp-missing-interface");
+        let inspection = inspect_network_mode_with_paths(
+            &xdp_bond_config(),
+            &root.join("netplan"),
+            &root.join("pending"),
+            &BTreeSet::new(),
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(inspection.inspector_state, "Missing");
+        assert!(!inspection.can_apply);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn xdp_mode_offers_bond_masters_and_rejects_their_members() {
+        let root = test_env("xdp-bond-candidates");
+        std::fs::write(
+            root.join("netplan").join("50-bonds.yaml"),
+            r#"
+network:
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: false
+      dhcp6: false
+    enp2s0:
+      dhcp4: false
+      dhcp6: false
+    enp3s0:
+      dhcp4: false
+      dhcp6: false
+    enp4s0:
+      dhcp4: false
+      dhcp6: false
+  bonds:
+    bond-wan:
+      interfaces: [enp1s0, enp2s0]
+      parameters:
+        mode: 802.3ad
+    bond-lan:
+      interfaces: [enp3s0, enp4s0]
+      parameters:
+        mode: 802.3ad
+"#,
+        )
+        .expect("write bonded netplan fixture");
+
+        let system_ifaces = BTreeSet::from([
+            "bond-lan".to_string(),
+            "bond-wan".to_string(),
+            "enp1s0".to_string(),
+            "enp2s0".to_string(),
+            "enp3s0".to_string(),
+            "enp4s0".to_string(),
+        ]);
+        let queue_caps = system_ifaces
+            .iter()
+            .map(|name| (name.clone(), true))
+            .collect::<BTreeMap<_, _>>();
+        let inspection = inspect_network_mode_with_paths(
+            &xdp_bond_config(),
+            &root.join("netplan"),
+            &root.join("pending"),
+            &system_ifaces,
+            &queue_caps,
+        );
+
+        assert_eq!(inspection.inspector_state, "Ready");
+        assert_eq!(inspection.detected_files.len(), 1);
+        assert_eq!(inspection.detected_files[0].classification, "Relevant");
+        for bond_name in ["bond-wan", "bond-lan"] {
+            let candidate = inspection
+                .interface_candidates
+                .iter()
+                .find(|candidate| candidate.name == bond_name)
+                .expect("bond candidate");
+            assert!(candidate.xdp_bridge_eligible);
+            assert!(!candidate.bridge_eligible);
+            assert!(!candidate.single_interface_eligible);
+        }
+        let member = inspection
+            .interface_candidates
+            .iter()
+            .find(|candidate| candidate.name == "enp1s0")
+            .expect("bond member candidate");
+        assert!(!member.xdp_bridge_eligible);
+        assert!(
+            member
+                .details
+                .iter()
+                .any(|detail| detail.contains("bond-wan"))
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn xdp_mode_rejects_bond_settings_without_native_xdp() {
+        let root = test_env("xdp-unsupported-bond-settings");
+        std::fs::write(
+            root.join("netplan").join("50-bonds.yaml"),
+            r#"
+network:
+  version: 2
+  bonds:
+    bond-wan:
+      interfaces: [enp1s0, enp2s0]
+      parameters:
+        mode: balance-alb
+    bond-lan:
+      interfaces: [enp3s0, enp4s0]
+      parameters:
+        mode: 802.3ad
+        transmit-hash-policy: vlan+srcmac
+"#,
+        )
+        .expect("write unsupported bonded netplan fixture");
+        let system_ifaces = BTreeSet::from(["bond-lan".to_string(), "bond-wan".to_string()]);
+        let queue_caps = system_ifaces
+            .iter()
+            .map(|name| (name.clone(), true))
+            .collect::<BTreeMap<_, _>>();
+
+        let inspection = inspect_network_mode_with_paths(
+            &xdp_bond_config(),
+            &root.join("netplan"),
+            &root.join("pending"),
+            &system_ifaces,
+            &queue_caps,
+        );
+
+        assert_eq!(inspection.inspector_state, "ComplexUnsupported");
+        for (bond_name, expected_issue) in [
+            ("bond-wan", "Bond mode balance-alb"),
+            ("bond-lan", "vlan+srcmac"),
+        ] {
+            let candidate = inspection
+                .interface_candidates
+                .iter()
+                .find(|candidate| candidate.name == bond_name)
+                .expect("bond candidate");
+            assert!(!candidate.xdp_bridge_eligible);
+            assert!(
+                candidate
+                    .details
+                    .iter()
+                    .any(|detail| detail.contains(expected_issue))
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn xdp_mode_rejects_a_bond_master_with_host_networking() {
+        let root = test_env("xdp-bond-host-networking");
+        std::fs::write(
+            root.join("netplan").join("50-bonds.yaml"),
+            r#"
+network:
+  version: 2
+  bonds:
+    bond-wan:
+      interfaces: [enp1s0, enp2s0]
+      parameters:
+        mode: 802.3ad
+      addresses: [192.0.2.10/24]
+    bond-lan:
+      interfaces: [enp3s0, enp4s0]
+      parameters:
+        mode: 802.3ad
+"#,
+        )
+        .expect("write bonded netplan fixture");
+        let system_ifaces = BTreeSet::from(["bond-lan".to_string(), "bond-wan".to_string()]);
+        let queue_caps = system_ifaces
+            .iter()
+            .map(|name| (name.clone(), true))
+            .collect::<BTreeMap<_, _>>();
+
+        let inspection = inspect_network_mode_with_paths(
+            &xdp_bond_config(),
+            &root.join("netplan"),
+            &root.join("pending"),
+            &system_ifaces,
+            &queue_caps,
+        );
+
+        assert_eq!(inspection.inspector_state, "ComplexUnsupported");
+        assert!(!inspection.can_apply);
+        let candidate = inspection
+            .interface_candidates
+            .iter()
+            .find(|candidate| candidate.name == "bond-wan")
+            .expect("bond candidate");
+        assert!(!candidate.xdp_bridge_eligible);
+        assert!(
+            candidate
+                .details
+                .iter()
+                .any(|detail| detail.contains("DHCP, static addressing, or routes"))
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn managed_linux_bridge_rejects_a_bond_master() {
+        let root = test_env("linux-bond-rejected");
+        std::fs::write(
+            root.join("netplan").join("50-bond.yaml"),
+            r#"
+network:
+  version: 2
+  bonds:
+    bond-wan:
+      interfaces: [enp1s0, enp2s0]
+      parameters:
+        mode: 802.3ad
+"#,
+        )
+        .expect("write bonded netplan fixture");
+        let mut config = linux_bridge_config();
+        config.bridge.as_mut().expect("bridge").to_internet = "bond-wan".to_string();
+        let system_ifaces = BTreeSet::from([
+            "bond-wan".to_string(),
+            "ens20".to_string(),
+            "enp1s0".to_string(),
+            "enp2s0".to_string(),
+        ]);
+        let queue_caps = system_ifaces
+            .iter()
+            .map(|name| (name.clone(), true))
+            .collect::<BTreeMap<_, _>>();
+
+        let inspection = inspect_network_mode_with_paths(
+            &config,
+            &root.join("netplan"),
+            &root.join("pending"),
+            &system_ifaces,
+            &queue_caps,
+        );
+
+        assert_eq!(inspection.inspector_state, "ComplexUnsupported");
+        assert!(!inspection.can_apply);
+        assert!(inspection.conflicts.iter().any(|detail| {
+            detail.contains("only supported as a LibreQoS interface in XDP bridge mode")
+        }));
+
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/src/rust/lqos_netplan_helper/src/transaction.rs
+++ b/src/rust/lqos_netplan_helper/src/transaction.rs
@@ -113,6 +113,13 @@ fn mode_label(config: &Config) -> String {
     }
 }
 
+fn is_xdp_bridge(config: &Config) -> bool {
+    config
+        .bridge
+        .as_ref()
+        .is_some_and(|bridge| bridge.use_xdp_bridge)
+}
+
 fn mode_interfaces(config: &Config) -> Vec<String> {
     if let Some(bridge) = &config.bridge {
         [bridge.to_internet.trim(), bridge.to_network.trim()]
@@ -141,6 +148,22 @@ fn load_config_from_path(path: &Path) -> Result<Config> {
 fn write_config_to_path(path: &Path, config: &Config) -> Result<()> {
     let serialized = toml::to_string_pretty(config).context("Unable to serialize config")?;
     fs::write(path, serialized).with_context(|| format!("Unable to write {}", path.display()))
+}
+
+fn write_xdp_config_only(path: &Path, config: &Config) -> Result<()> {
+    if path.exists() {
+        let mut backup_name = path.as_os_str().to_os_string();
+        backup_name.push(".webbackup");
+        let backup_path = PathBuf::from(backup_name);
+        fs::copy(path, &backup_path).with_context(|| {
+            format!(
+                "Unable to back up {} to {}",
+                path.display(),
+                backup_path.display()
+            )
+        })?;
+    }
+    write_config_to_path(path, config)
 }
 
 fn ensure_parent(path: &Path) -> Result<()> {
@@ -207,6 +230,15 @@ fn inspect_with_paths_and_interfaces(
         .iter()
         .map(|iface| (iface.clone(), supports_multi_queue(iface)))
         .collect::<BTreeMap<_, _>>();
+    inspect_with_paths_and_capabilities(paths, config, system_ifaces, queue_caps)
+}
+
+fn inspect_with_paths_and_capabilities(
+    paths: &HelperPaths,
+    config: &Config,
+    system_ifaces: BTreeSet<String>,
+    queue_caps: BTreeMap<String, bool>,
+) -> NetworkModeInspection {
     inspect_network_mode_with_paths(
         config,
         &paths.netplan_dir,
@@ -719,6 +751,13 @@ fn validate_apply_request(
         );
     }
 
+    if is_xdp_bridge(&request.config) && matches!(request.mode, ApplyMode::Apply) {
+        if !inspection.can_apply {
+            bail!("{}", inspection.summary);
+        }
+        return Ok(());
+    }
+
     match request.mode {
         ApplyMode::Apply => {
             if inspection.can_take_over {
@@ -731,9 +770,7 @@ fn validate_apply_request(
                     "Adopt into libreqos.yaml is required before LibreQoS can manage the external compatible netplan file."
                 );
             }
-            if inspection.inspector_state != "Ready"
-                && inspection.inspector_state != "ManagedByLibreQoS"
-            {
+            if !inspection.can_apply {
                 bail!("{}", inspection.summary);
             }
         }
@@ -767,6 +804,20 @@ fn apply_transaction_with_interfaces(
     request: ApplyRequest,
     system_ifaces: BTreeSet<String>,
 ) -> Result<ApplyResponse> {
+    let queue_caps = system_ifaces
+        .iter()
+        .map(|iface| (iface.clone(), supports_multi_queue(iface)))
+        .collect::<BTreeMap<_, _>>();
+    apply_transaction_with_capabilities(paths, pending_children, request, system_ifaces, queue_caps)
+}
+
+fn apply_transaction_with_capabilities(
+    paths: &HelperPaths,
+    pending_children: &mut PendingChildren,
+    request: ApplyRequest,
+    system_ifaces: BTreeSet<String>,
+    queue_caps: BTreeMap<String, bool>,
+) -> Result<ApplyResponse> {
     normalize_pending_children(paths, pending_children)?;
     if !list_pending_records(paths)?.is_empty() {
         bail!("A pending network change already exists. Confirm or revert it first.");
@@ -777,8 +828,22 @@ fn apply_transaction_with_interfaces(
     } else {
         Config::default()
     };
-    let inspection = inspect_with_paths_and_interfaces(paths, &request.config, system_ifaces);
+    let inspection =
+        inspect_with_paths_and_capabilities(paths, &request.config, system_ifaces, queue_caps);
     validate_apply_request(&request, &inspection, &previous_config)?;
+
+    if is_xdp_bridge(&request.config) {
+        write_xdp_config_only(&paths.config_path, &request.config)?;
+        lqos_config::clear_cached_config();
+        return Ok(ApplyResponse {
+            ok: true,
+            message:
+                "XDP bridge configuration saved. Netplan was not changed. Restart lqosd to activate the new XDP interfaces."
+                    .to_string(),
+            operation: None,
+            last_backup_id: None,
+        });
+    }
 
     let preview_yaml = inspection.managed_preview_yaml.as_ref().ok_or_else(|| {
         anyhow!(
@@ -1065,6 +1130,116 @@ esac
             single_interface: None,
             ..Config::default()
         }
+    }
+
+    fn xdp_bond_config() -> Config {
+        Config {
+            bridge: Some(lqos_config::BridgeConfig {
+                use_xdp_bridge: true,
+                to_internet: "bond-wan".to_string(),
+                to_network: "bond-lan".to_string(),
+                mtu: None,
+            }),
+            single_interface: None,
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn xdp_apply_updates_only_config_and_keeps_a_backup() {
+        let root = base_dir("xdp-config-only");
+        write_netplan_stub(&root);
+        let paths = helper_paths(&root);
+        let mut pending = PendingChildren::default();
+        let existing = linux_bridge_config();
+        write_config(&paths.config_path, &existing);
+        write_text_file(&paths.managed_netplan_path, "network:\n  version: 2\n")
+            .expect("seed managed netplan");
+        write_text_file(
+            &paths.netplan_dir.join("50-bonded.yaml"),
+            r#"
+network:
+  version: 2
+  ethernets:
+    enp1s0:
+      dhcp4: false
+      dhcp6: false
+    enp2s0:
+      dhcp4: false
+      dhcp6: false
+    enp3s0:
+      dhcp4: false
+      dhcp6: false
+    enp4s0:
+      dhcp4: false
+      dhcp6: false
+  bonds:
+    bond-wan:
+      interfaces: [enp1s0, enp2s0]
+      parameters:
+        mode: 802.3ad
+    bond-lan:
+      interfaces: [enp3s0, enp4s0]
+      parameters:
+        mode: 802.3ad
+"#,
+        )
+        .expect("seed selected bonded netplan");
+        write_text_file(
+            &paths.netplan_dir.join("99-unrelated.yaml"),
+            "network: [invalid",
+        )
+        .expect("seed unrelated invalid netplan");
+
+        let system_ifaces = BTreeSet::from([
+            "bond-lan".to_string(),
+            "bond-wan".to_string(),
+            "enp1s0".to_string(),
+            "enp2s0".to_string(),
+            "enp3s0".to_string(),
+            "enp4s0".to_string(),
+        ]);
+        let queue_caps = system_ifaces
+            .iter()
+            .map(|interface| (interface.clone(), true))
+            .collect();
+        let apply = apply_transaction_with_capabilities(
+            &paths,
+            &mut pending,
+            ApplyRequest {
+                config: xdp_bond_config(),
+                source: "ui".to_string(),
+                operator_username: Some("admin".to_string()),
+                mode: ApplyMode::Apply,
+                confirm_dangerous_changes: true,
+            },
+            system_ifaces,
+            queue_caps,
+        )
+        .expect("XDP config-only apply should succeed");
+
+        assert!(apply.ok);
+        assert!(apply.operation.is_none());
+        assert!(apply.message.contains("Netplan was not changed"));
+        assert!(
+            load_config_from_path(&paths.config_path)
+                .expect("load updated config")
+                .bridge
+                .expect("bridge")
+                .use_xdp_bridge
+        );
+        let mut backup_name = paths.config_path.as_os_str().to_os_string();
+        backup_name.push(".webbackup");
+        let backup = load_config_from_path(&PathBuf::from(backup_name))
+            .expect("load previous config backup");
+        assert_eq!(backup.bridge, existing.bridge);
+        assert_eq!(
+            fs::read_to_string(&paths.managed_netplan_path).expect("read managed netplan"),
+            "network:\n  version: 2\n"
+        );
+        assert!(!root.join("netplan.log").exists());
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/rust/lqos_setup/src/bridge_mode.rs
+++ b/src/rust/lqos_setup/src/bridge_mode.rs
@@ -4,11 +4,10 @@ use cursive::{
     views::{Dialog, LinearLayout, RadioGroup, TextView},
 };
 
-use crate::config_builder::{BridgeMode, CURRENT_CONFIG, existing_config_uses_xdp};
+use crate::config_builder::{BridgeMode, CURRENT_CONFIG};
 
 pub fn bridge_mode(s: &mut Cursive) {
     let current_mode = CURRENT_CONFIG.lock().bridge_mode;
-    let show_legacy_xdp = existing_config_uses_xdp() || current_mode == BridgeMode::XDP;
 
     // create the group and buttons
     let mut group = RadioGroup::new().on_change(|_s, mode| {
@@ -20,12 +19,10 @@ pub fn bridge_mode(s: &mut Cursive) {
         BridgeMode::Linux,
         "Linux Bridge (2 interfaces) - LibreQoS will inspect and stage the managed Netplan change",
     );
-    let mut xdp_btn = show_legacy_xdp.then(|| {
-        group.button(
-            BridgeMode::XDP,
-            "Legacy XDP Bridge (existing installs only - keep only if you already run it)",
-        )
-    });
+    let mut xdp_btn = group.button(
+        BridgeMode::XDP,
+        "XDP Bridge (2 interfaces; supported bond masters allowed)",
+    );
     let mut single_btn = group.button(BridgeMode::Single, "Single Interface (1 interface)");
 
     // mark the one we want as selected
@@ -33,10 +30,8 @@ pub fn bridge_mode(s: &mut Cursive) {
         BridgeMode::Single => {
             single_btn.select();
         }
-        BridgeMode::XDP if show_legacy_xdp => {
-            if let Some(button) = xdp_btn.as_mut() {
-                button.select();
-            }
+        BridgeMode::XDP => {
+            xdp_btn.select();
         }
         _ => {
             linux_btn.select();
@@ -46,13 +41,11 @@ pub fn bridge_mode(s: &mut Cursive) {
     // now add them (in any order) to your layout
     let mut layout = LinearLayout::vertical()
         .child(TextView::new("Select the bridge mode you want to use:"))
-        .child(linux_btn);
-    if let Some(button) = xdp_btn {
-        layout.add_child(TextView::new(
-            "Legacy XDP mode was detected on this install. New installs should use Linux Bridge; leave XDP selected only if you intend to keep the existing XDP deployment.",
+        .child(linux_btn)
+        .child(xdp_btn)
+        .child(TextView::new(
+            "XDP supports bond masters in native-XDP modes. Configure bonds in Netplan first and select the master, not a member.",
         ));
-        layout.add_child(button);
-    }
     layout.add_child(single_btn);
 
     s.add_layer(

--- a/src/rust/lqos_setup/src/config_builder.rs
+++ b/src/rust/lqos_setup/src/config_builder.rs
@@ -110,13 +110,6 @@ pub fn existing_config_load_error() -> Option<String> {
     existing_config_load_error_for_path(&current_config_path())
 }
 
-pub fn existing_config_uses_xdp() -> bool {
-    lqos_config::load_config()
-        .ok()
-        .and_then(|config| config.bridge.as_ref().map(|bridge| bridge.use_xdp_bridge))
-        .unwrap_or(false)
-}
-
 #[cfg(test)]
 mod tests {
     use super::ConfigBuilder;

--- a/src/rust/lqos_setup/src/interfaces.rs
+++ b/src/rust/lqos_setup/src/interfaces.rs
@@ -12,6 +12,59 @@ use crate::config_builder::{BridgeMode, CURRENT_CONFIG};
 pub struct InterfaceOption {
     pub name: String,
     pub label: String,
+    pub role: InterfaceRole,
+}
+
+impl InterfaceOption {
+    pub(crate) fn supports_mode(&self, mode: BridgeMode) -> bool {
+        self.role.supports_mode(mode)
+    }
+
+    pub(crate) fn is_bond(&self) -> bool {
+        matches!(self.role, InterfaceRole::BondMaster { .. })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum InterfaceRole {
+    Missing,
+    Physical,
+    BondMaster { native_xdp_issue: Option<String> },
+    BondMember { master: String },
+}
+
+impl InterfaceRole {
+    fn supports_mode(&self, mode: BridgeMode) -> bool {
+        match self {
+            Self::Missing => false,
+            Self::Physical => true,
+            Self::BondMaster { native_xdp_issue } => {
+                mode == BridgeMode::XDP && native_xdp_issue.is_none()
+            }
+            Self::BondMember { .. } => false,
+        }
+    }
+
+    fn ensure_mode(&self, interface: &str, mode: BridgeMode) -> anyhow::Result<()> {
+        match self {
+            Self::Missing => Err(anyhow::anyhow!(
+                "Interface {interface} is not present on this system."
+            )),
+            Self::Physical => Ok(()),
+            Self::BondMaster { .. } if mode != BridgeMode::XDP => Err(anyhow::anyhow!(
+                "Bond master {interface} is supported only in XDP bridge mode."
+            )),
+            Self::BondMaster {
+                native_xdp_issue: Some(issue),
+            } => Err(anyhow::anyhow!("Bond master {interface}: {issue}")),
+            Self::BondMaster {
+                native_xdp_issue: None,
+            } => Ok(()),
+            Self::BondMember { master } => Err(anyhow::anyhow!(
+                "Interface {interface} is a member of bond {master}; select the bond master instead."
+            )),
+        }
+    }
 }
 
 pub fn get_interfaces() -> anyhow::Result<Vec<String>> {
@@ -30,11 +83,61 @@ pub fn get_interface_options() -> anyhow::Result<Vec<InterfaceOption>> {
     interfaces.dedup();
     Ok(interfaces
         .into_iter()
-        .map(|name| InterfaceOption {
-            label: interface_label(&name),
-            name,
+        .map(|name| {
+            let role = interface_role(&name);
+            InterfaceOption {
+                label: interface_label(&name, &role),
+                name,
+                role,
+            }
         })
         .collect())
+}
+
+pub(crate) fn ensure_interface_supports_mode(
+    interface: &str,
+    mode: BridgeMode,
+) -> anyhow::Result<()> {
+    interface_role(interface).ensure_mode(interface, mode)
+}
+
+fn interface_role(interface: &str) -> InterfaceRole {
+    interface_role_at(Path::new("/sys/class/net"), interface)
+}
+
+fn interface_role_at(sys_class_net: &Path, interface: &str) -> InterfaceRole {
+    let interface_path = sys_class_net.join(interface);
+    if !interface_path.exists() {
+        return InterfaceRole::Missing;
+    }
+    if interface_path.join("bonding").is_dir() {
+        return InterfaceRole::BondMaster {
+            native_xdp_issue: bond_native_xdp_issue(&interface_path),
+        };
+    }
+
+    let master_path = interface_path.join("master");
+    if let Ok(target) = std::fs::read_link(master_path)
+        && let Some(master) = target.file_name().and_then(|name| name.to_str())
+        && sys_class_net.join(master).join("bonding").is_dir()
+    {
+        return InterfaceRole::BondMember {
+            master: master.to_string(),
+        };
+    }
+
+    InterfaceRole::Physical
+}
+
+fn bond_native_xdp_issue(interface_path: &Path) -> Option<String> {
+    let bonding_path = interface_path.join("bonding");
+    let mode = std::fs::read_to_string(bonding_path.join("mode"))
+        .ok()
+        .and_then(|value| value.split_whitespace().next().map(ToOwned::to_owned));
+    let transmit_hash_policy = std::fs::read_to_string(bonding_path.join("xmit_hash_policy"))
+        .ok()
+        .and_then(|value| value.split_whitespace().next().map(ToOwned::to_owned));
+    lqos_config::native_xdp_bond_issue(mode.as_deref(), transmit_hash_policy.as_deref())
 }
 
 pub(crate) fn interface_supports_lqos(interface: &str) -> anyhow::Result<()> {
@@ -78,12 +181,12 @@ pub(crate) fn interface_supports_lqos(interface: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn interface_label(interface: &str) -> String {
+fn interface_label(interface: &str, role: &InterfaceRole) -> String {
     let mut parts = vec![interface.to_string()];
     if let Some(speed) = interface_speed_label(interface) {
         parts.push(speed);
     }
-    if let Some(kind) = interface_kind_label(interface) {
+    if let Some(kind) = interface_kind_label(interface, role) {
         parts.push(kind);
     }
     parts.join(" - ")
@@ -112,7 +215,11 @@ fn interface_speed_label(interface: &str) -> Option<String> {
     Some(label)
 }
 
-fn interface_kind_label(interface: &str) -> Option<String> {
+fn interface_kind_label(interface: &str, role: &InterfaceRole) -> Option<String> {
+    if matches!(role, InterfaceRole::BondMaster { .. }) {
+        return Some("bond".to_string());
+    }
+
     if let Some(port) = interface_port_label(interface) {
         return Some(port);
     }
@@ -187,7 +294,11 @@ fn build_layout() -> LinearLayout {
     let bridge_mode = CURRENT_CONFIG.lock().bridge_mode;
     match bridge_mode {
         BridgeMode::Linux | BridgeMode::XDP => {
-            let interfaces = get_interface_options().expect("Failed to get interfaces");
+            let interfaces = get_interface_options()
+                .expect("Failed to get interfaces")
+                .into_iter()
+                .filter(|interface| interface.supports_mode(bridge_mode))
+                .collect::<Vec<_>>();
 
             // If the configuration has empty interface fields, set them to the first available interface
             {
@@ -241,7 +352,11 @@ fn build_layout() -> LinearLayout {
                 .child(network_layout)
         }
         BridgeMode::Single => {
-            let interfaces = get_interface_options().expect("Failed to get interfaces");
+            let interfaces = get_interface_options()
+                .expect("Failed to get interfaces")
+                .into_iter()
+                .filter(|interface| interface.supports_mode(bridge_mode))
+                .collect::<Vec<_>>();
 
             // If the configuration has empty interface field, set it to the first available interface
             {
@@ -328,4 +443,135 @@ pub fn interface_menu(s: &mut Cursive) {
             })
             .full_screen(),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InterfaceOption, InterfaceRole, interface_role_at};
+    use crate::config_builder::BridgeMode;
+    use std::path::PathBuf;
+
+    fn test_sys_class_net(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "libreqos-setup-interfaces-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create fake sysfs root");
+        root
+    }
+
+    #[test]
+    fn bond_masters_are_only_offered_for_xdp_bridge_mode() {
+        let bond = InterfaceOption {
+            name: "bond0".to_string(),
+            label: "bond0 - bond".to_string(),
+            role: InterfaceRole::BondMaster {
+                native_xdp_issue: None,
+            },
+        };
+
+        assert!(bond.supports_mode(BridgeMode::XDP));
+        assert!(!bond.supports_mode(BridgeMode::Linux));
+        assert!(!bond.supports_mode(BridgeMode::Single));
+    }
+
+    #[test]
+    fn physical_interfaces_remain_available_in_all_modes() {
+        let interface = InterfaceOption {
+            name: "enp1s0".to_string(),
+            label: "enp1s0 - 10G".to_string(),
+            role: InterfaceRole::Physical,
+        };
+
+        assert!(interface.supports_mode(BridgeMode::XDP));
+        assert!(interface.supports_mode(BridgeMode::Linux));
+        assert!(interface.supports_mode(BridgeMode::Single));
+    }
+
+    #[test]
+    fn bond_members_are_never_offered_as_shaping_interfaces() {
+        let member = InterfaceOption {
+            name: "enp1s0".to_string(),
+            label: "enp1s0 - 10G".to_string(),
+            role: InterfaceRole::BondMember {
+                master: "bond0".to_string(),
+            },
+        };
+
+        assert!(!member.supports_mode(BridgeMode::XDP));
+        assert!(!member.supports_mode(BridgeMode::Linux));
+        assert!(!member.supports_mode(BridgeMode::Single));
+        let error = member
+            .role
+            .ensure_mode(&member.name, BridgeMode::XDP)
+            .unwrap_err();
+        assert!(error.to_string().contains("select the bond master"));
+    }
+
+    #[test]
+    fn incompatible_bond_modes_are_rejected_for_xdp() {
+        let bond = InterfaceRole::BondMaster {
+            native_xdp_issue: Some(
+                "bond mode balance-alb does not support native XDP.".to_string(),
+            ),
+        };
+
+        let error = bond.ensure_mode("bond0", BridgeMode::XDP).unwrap_err();
+        assert!(error.to_string().contains("balance-alb"));
+    }
+
+    #[test]
+    fn missing_interfaces_are_rejected() {
+        let root = test_sys_class_net("missing-interface");
+        let role = interface_role_at(&root, "not-present");
+
+        assert_eq!(role, InterfaceRole::Missing);
+        assert!(!role.supports_mode(BridgeMode::XDP));
+        assert!(
+            role.ensure_mode("not-present", BridgeMode::XDP)
+                .unwrap_err()
+                .to_string()
+                .contains("not present")
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn live_bond_mode_and_membership_are_read_from_sysfs() {
+        let root = test_sys_class_net("bond-role");
+        let bonding = root.join("bond0/bonding");
+        std::fs::create_dir_all(&bonding).expect("create fake bond sysfs");
+        std::fs::write(bonding.join("mode"), "802.3ad 4\n").expect("write bond mode");
+        std::fs::write(bonding.join("xmit_hash_policy"), "layer3+4 1\n")
+            .expect("write bond hash policy");
+        std::fs::create_dir_all(root.join("enp1s0")).expect("create fake member sysfs");
+        std::os::unix::fs::symlink(root.join("bond0"), root.join("enp1s0/master"))
+            .expect("link fake bond master");
+
+        assert_eq!(
+            interface_role_at(&root, "bond0"),
+            InterfaceRole::BondMaster {
+                native_xdp_issue: None,
+            }
+        );
+        assert_eq!(
+            interface_role_at(&root, "enp1s0"),
+            InterfaceRole::BondMember {
+                master: "bond0".to_string(),
+            }
+        );
+
+        std::fs::write(bonding.join("mode"), "balance-alb 6\n").expect("replace bond mode");
+        let InterfaceRole::BondMaster {
+            native_xdp_issue: Some(issue),
+        } = interface_role_at(&root, "bond0")
+        else {
+            panic!("expected incompatible bond master");
+        };
+        assert!(issue.contains("balance-alb"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/src/rust/lqos_setup/src/setup_actions.rs
+++ b/src/rust/lqos_setup/src/setup_actions.rs
@@ -1,6 +1,9 @@
 //! Shared setup commit/apply helpers used by both Cursive and the setup WebUI.
 
-use crate::config_builder::{BridgeMode, CURRENT_CONFIG, existing_config_load_error};
+use crate::{
+    config_builder::{BridgeMode, CURRENT_CONFIG, existing_config_load_error},
+    interfaces,
+};
 use anyhow::{Context, Result, bail};
 use lqos_netplan_helper::protocol::{ApplyMode, ApplyRequest};
 use lqos_netplan_helper::transaction::{
@@ -119,6 +122,21 @@ pub(crate) fn inspection_report(inspection: &lqos_netplan_helper::NetworkModeIns
     report
 }
 
+fn validate_candidate_interfaces(config: &lqos_config::Config) -> Result<()> {
+    if let Some(bridge) = &config.bridge {
+        let mode = if bridge.use_xdp_bridge {
+            BridgeMode::XDP
+        } else {
+            BridgeMode::Linux
+        };
+        interfaces::ensure_interface_supports_mode(&bridge.to_internet, mode)?;
+        interfaces::ensure_interface_supports_mode(&bridge.to_network, mode)?;
+    } else if let Some(single) = &config.single_interface {
+        interfaces::ensure_interface_supports_mode(&single.interface, BridgeMode::Single)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn prepare_commit() -> Result<CommitOutcome> {
     if !lqos_setup::bootstrap::first_admin_exists() {
         bail!("Setup requires at least one admin user before configuration can be committed.");
@@ -127,11 +145,12 @@ pub(crate) fn prepare_commit() -> Result<CommitOutcome> {
     let mut event_log = Vec::new();
     let existing_config = load_existing_or_default(&mut event_log)?;
     let config = build_candidate_config(Some(existing_config));
+    validate_candidate_interfaces(&config)?;
     let using_helper = !matches!(CURRENT_CONFIG.lock().bridge_mode, BridgeMode::XDP);
 
     if !using_helper {
         lqos_config::update_config(&config)?;
-        event_log.push("Configuration updated.".to_string());
+        event_log.push("XDP configuration updated. Netplan was not changed.".to_string());
         return Ok(CommitOutcome::Complete(Box::new(CommitSuccess {
             config,
             event_log,
@@ -280,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn build_candidate_config_preserves_existing_mtu_for_same_mode() {
+    fn build_candidate_config_preserves_mtu_and_xdp_bond_names() {
         let previous_builder = {
             let mut builder = CURRENT_CONFIG.lock();
             let previous = builder.clone();
@@ -302,6 +321,19 @@ mod tests {
             candidate.bridge.as_ref().and_then(|bridge| bridge.mtu),
             Some(9000)
         );
+
+        {
+            let mut builder = CURRENT_CONFIG.lock();
+            builder.bridge_mode = BridgeMode::XDP;
+            builder.to_internet = "bond-wan".to_string();
+            builder.to_network = "bond-lan".to_string();
+        }
+
+        let candidate = build_candidate_config(Some(lqos_config::Config::default()));
+        let bridge = candidate.bridge.expect("XDP bridge config");
+        assert!(bridge.use_xdp_bridge);
+        assert_eq!(bridge.to_internet, "bond-wan");
+        assert_eq!(bridge.to_network, "bond-lan");
 
         *CURRENT_CONFIG.lock() = previous_builder;
     }

--- a/src/rust/lqos_setup/src/web.rs
+++ b/src/rust/lqos_setup/src/web.rs
@@ -1,7 +1,7 @@
 //! Minimal setup-only web server for first-run LibreQoS configuration.
 
 use crate::{
-    config_builder::{BridgeMode, CURRENT_CONFIG, existing_config_uses_xdp},
+    config_builder::{BridgeMode, CURRENT_CONFIG},
     interfaces, service_handoff,
     setup_actions::{self, CommitOutcome},
 };
@@ -263,7 +263,6 @@ fn render_setup_page(
         BridgeMode::XDP => "xdp",
         BridgeMode::Linux => "linux",
     };
-    let persisted_xdp = existing_config_uses_xdp();
 
     let mut html = page_shell("LibreQoS Setup");
     html.push_str("<main class=\"setup-shell\">");
@@ -298,16 +297,6 @@ fn render_setup_page(
         yes_no(snapshot.hotfix_required)
     ));
     html.push_str("</ul></section>");
-
-    if persisted_xdp {
-        html.push_str("<section class=\"card\"><h2>Legacy XDP Mode Detected</h2>");
-        if config.bridge_mode == BridgeMode::XDP {
-            html.push_str("<p class=\"notice\">This system already uses legacy XDP bridge mode. LibreQoS no longer recommends XDP for new installs, but this page will preserve it if you leave the mode unchanged.</p>");
-        } else {
-            html.push_str("<p class=\"notice\">This system previously used legacy XDP bridge mode. Saving with Linux Bridge or Single Interface will migrate the node away from XDP.</p>");
-        }
-        html.push_str("<p class=\"muted\">Use Linux Bridge for long-term maintenance unless you intentionally need to keep the existing XDP deployment.</p></section>");
-    }
 
     if snapshot.hotfix_required {
         html.push_str("<section class=\"card\"><h2>Ubuntu 24.04 Hotfix Required</h2>");
@@ -359,45 +348,53 @@ fn render_setup_page(
             "<option value=\"linux\"{}>Linux Bridge</option>",
             selected(mode_label == "linux")
         ));
-        if persisted_xdp {
-            html.push_str(&format!(
-                "<option value=\"xdp\"{}>Legacy XDP Bridge (existing installs only)</option>",
-                selected(mode_label == "xdp")
-            ));
-        }
+        html.push_str(&format!(
+            "<option value=\"xdp\"{}>XDP Bridge</option>",
+            selected(mode_label == "xdp")
+        ));
         html.push_str(&format!(
             "<option value=\"single\"{}>Single Interface</option>",
             selected(mode_label == "single")
         ));
         html.push_str("</select></label>");
         html.push_str("<div class=\"mode-section\" data-mode-section=\"bridge\">");
-        html.push_str("<p class=\"muted\">Linux Bridge is recommended for most installs. Select the WAN-facing and subscriber-facing interfaces below. Existing XDP installs use the same interface pair if you choose to preserve XDP.</p>");
+        html.push_str("<p class=\"muted\">Linux Bridge is recommended for most installs. XDP also supports bond masters in native-XDP modes. Configure bonds in Netplan first and select the master, not a member.</p>");
         html.push_str("<label>To Internet<select name=\"to_internet\">");
-        for iface in &interface_options {
+        for iface in interface_options.iter().filter(|iface| {
+            iface.supports_mode(BridgeMode::Linux) || iface.supports_mode(BridgeMode::XDP)
+        }) {
             html.push_str(&format!(
-                "<option value=\"{}\"{}>{}</option>",
+                "<option value=\"{}\"{}{}>{}</option>",
                 escape_html(&iface.name),
                 selected(config.to_internet == iface.name),
+                xdp_only_option(iface.is_bond()),
                 escape_html(&iface.label)
             ));
         }
         html.push_str("</select></label>");
         html.push_str("<label>To Network<select name=\"to_network\">");
-        for iface in &interface_options {
+        for iface in interface_options.iter().filter(|iface| {
+            iface.supports_mode(BridgeMode::Linux) || iface.supports_mode(BridgeMode::XDP)
+        }) {
             html.push_str(&format!(
-                "<option value=\"{}\"{}>{}</option>",
+                "<option value=\"{}\"{}{}>{}</option>",
                 escape_html(&iface.name),
                 selected(config.to_network == iface.name),
+                xdp_only_option(iface.is_bond()),
                 escape_html(&iface.label)
             ));
         }
         html.push_str("</select></label>");
         html.push_str("<p id=\"interfaceValidationMessage\" class=\"validation-message\" hidden>Internet and network interfaces must be different.</p>");
+        html.push_str("<p id=\"modeSelectionMessage\" class=\"muted\" role=\"status\" aria-live=\"polite\" hidden></p>");
         html.push_str("</div>");
         html.push_str("<div class=\"mode-section\" data-mode-section=\"single\">");
         html.push_str("<p class=\"muted\">Use this when a single interface carries both internet and subscriber traffic with optional VLAN tags.</p>");
         html.push_str("<label>Interface<select name=\"single_interface\">");
-        for iface in &interface_options {
+        for iface in interface_options
+            .iter()
+            .filter(|iface| iface.supports_mode(BridgeMode::Single))
+        {
             html.push_str(&format!(
                 "<option value=\"{}\"{}>{}</option>",
                 escape_html(&iface.name),
@@ -465,8 +462,7 @@ fn apply_form_to_current_config(form: &SaveForm) -> Result<()> {
     config.mbps_to_internet = downlink;
     config.mbps_to_network = uplink;
     config.allow_subnets = allow_subnets;
-    let allow_legacy_xdp = config.bridge_mode == BridgeMode::XDP || existing_config_uses_xdp();
-    match resolve_requested_bridge_mode(&form.bridge_mode, allow_legacy_xdp)? {
+    match resolve_requested_bridge_mode(&form.bridge_mode)? {
         "single" => {
             config.bridge_mode = BridgeMode::Single;
             let interface = form
@@ -490,11 +486,12 @@ fn apply_form_to_current_config(form: &SaveForm) -> Result<()> {
             if form.to_internet.trim() == to_network {
                 bail!("Internet and network interfaces must be different.");
             }
-            config.bridge_mode = if form.bridge_mode == "xdp" {
+            let bridge_mode = if form.bridge_mode == "xdp" {
                 BridgeMode::XDP
             } else {
                 BridgeMode::Linux
             };
+            config.bridge_mode = bridge_mode;
             config.to_internet = form.to_internet.trim().to_string();
             config.to_network = to_network.to_string();
             config.internet_vlan = 0;
@@ -532,10 +529,9 @@ fn ssl_request_value(
         .then(|| external_hostname.unwrap_or("").trim().to_string())
 }
 
-fn resolve_requested_bridge_mode(requested_mode: &str, allow_legacy_xdp: bool) -> Result<&str> {
+fn resolve_requested_bridge_mode(requested_mode: &str) -> Result<&str> {
     match requested_mode {
-        "single" | "linux" => Ok(requested_mode),
-        "xdp" if allow_legacy_xdp => Ok("xdp"),
+        "single" | "linux" | "xdp" => Ok(requested_mode),
         _ => bail!("Unsupported bridge mode."),
     }
 }
@@ -767,7 +763,8 @@ fn base_css() -> &'static str {
 
 fn base_js() -> &'static str {
     "function bridgeSectionForMode(mode){return mode==='single'?'single':'bridge';}\
-    function syncModeSections(){const mode=document.querySelector('select[name=\"bridge_mode\"]')?.value||'linux';const visibleSection=bridgeSectionForMode(mode);document.querySelectorAll('.mode-section').forEach((section)=>{section.hidden=section.dataset.modeSection!==visibleSection;});updateCoreSetupValidation();}\
+    function syncXdpOnlyOptions(mode){const replacements=[];document.querySelectorAll('option[data-xdp-only=\"true\"]').forEach((option)=>{const available=mode==='xdp';option.disabled=!available;option.hidden=!available;});document.querySelectorAll('select[name=\"to_internet\"],select[name=\"to_network\"]').forEach((select)=>{if(select.selectedOptions[0]?.disabled){const previous=select.value;const fallback=Array.from(select.options).find((option)=>!option.disabled);if(fallback){select.value=fallback.value;replacements.push(previous+' changed to '+fallback.value);}}});const status=document.getElementById('modeSelectionMessage');if(status){status.textContent=replacements.length?replacements.join('. ')+'. Bond masters require XDP mode.':'';status.hidden=replacements.length===0;}}\
+    function syncModeSections(){const mode=document.querySelector('select[name=\"bridge_mode\"]')?.value||'linux';const visibleSection=bridgeSectionForMode(mode);document.querySelectorAll('.mode-section').forEach((section)=>{section.hidden=section.dataset.modeSection!==visibleSection;});syncXdpOnlyOptions(mode);updateCoreSetupValidation();}\
     function showBusy(message){const overlay=document.getElementById('busyOverlay');const target=document.getElementById('busyMessage');if(target&&message){target.textContent=message;}if(overlay){overlay.hidden=false;}}\
     function hideBusy(){const overlay=document.getElementById('busyOverlay');if(overlay){overlay.hidden=true;}}\
     function setSubmitDisabled(form,disabled){const button=form?.querySelector('button[type=\"submit\"]');if(button){button.disabled=!!disabled;}}\
@@ -805,19 +802,23 @@ fn selected(value: bool) -> &'static str {
     if value { " selected" } else { "" }
 }
 
+fn xdp_only_option(value: bool) -> &'static str {
+    if value { " data-xdp-only=\"true\"" } else { "" }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{render_pending_page, resolve_requested_bridge_mode, runtime_access_url};
     use lqos_config::{Config, SslConfig};
 
     #[test]
-    fn xdp_mode_is_preserved_for_existing_xdp_config() {
-        assert_eq!(resolve_requested_bridge_mode("xdp", true).unwrap(), "xdp");
+    fn xdp_mode_is_available_during_first_run() {
+        assert_eq!(resolve_requested_bridge_mode("xdp").unwrap(), "xdp");
     }
 
     #[test]
-    fn xdp_mode_is_not_available_for_new_installs() {
-        let error = resolve_requested_bridge_mode("xdp", false).unwrap_err();
+    fn unknown_bridge_mode_is_rejected() {
+        let error = resolve_requested_bridge_mode("sandwich").unwrap_err();
         assert!(error.to_string().contains("Unsupported bridge mode"));
     }
 

--- a/src/rust/lqosd/src/node_manager/js_build/src/config/network_mode_interfaces.mjs
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config/network_mode_interfaces.mjs
@@ -1,0 +1,92 @@
+export function interfaceEligibilityField(modeKey) {
+    if (modeKey === "single") return "single_interface_eligible";
+    if (modeKey === "xdp") return "xdp_bridge_eligible";
+    return "bridge_eligible";
+}
+
+export function interfaceIsEligible(candidate, modeKey) {
+    return Boolean(candidate?.[interfaceEligibilityField(modeKey)]);
+}
+
+export function bridgeModePresentation(useXdp, editingLocked = false) {
+    const presentation = {
+        modeKey: useXdp ? "xdp" : "bridge",
+        applyButtonText: useXdp ? "Save XDP Configuration" : "Apply Network Changes",
+        draftSavedMessage: useXdp
+            ? "Network mode draft saved for this browser tab. Use Save XDP Configuration to update lqos.conf; Netplan will not be changed."
+            : "Network mode draft saved for this browser tab. Use Apply Network Changes to commit both lqos.conf and Netplan together.",
+    };
+    if (editingLocked) {
+        return {
+            ...presentation,
+            bridgeMtuDisabled: true,
+            bridgeMtuHelp: "MTU cannot be changed while a network-mode operation is pending.",
+        };
+    }
+    return {
+        ...presentation,
+        bridgeMtuDisabled: useXdp,
+        bridgeMtuHelp: useXdp
+            ? "XDP mode keeps this value for later, but LibreQoS will not apply it."
+            : "Applies to the bridge members and br0.",
+    };
+}
+
+export function applyBridgeModePresentation(root, editingLocked = false) {
+    const useXdp = Boolean(root.getElementById("useXdpBridge")?.checked);
+    const presentation = bridgeModePresentation(useXdp, editingLocked);
+    const applyButton = root.getElementById("applyButton");
+    const bridgeMtu = root.getElementById("bridgeMtu");
+    const bridgeMtuHelp = root.getElementById("bridgeMtuHelp");
+    if (applyButton) applyButton.textContent = presentation.applyButtonText;
+    if (bridgeMtu) bridgeMtu.disabled = presentation.bridgeMtuDisabled;
+    if (bridgeMtuHelp) bridgeMtuHelp.textContent = presentation.bridgeMtuHelp;
+    return presentation;
+}
+
+function optionDefinitions(candidates, modeKey, selectedValue, excludedValue) {
+    const eligibilityField = interfaceEligibilityField(modeKey);
+    const options = [{ value: "", label: "Select an eligible interface" }];
+    const seen = new Set();
+
+    candidates.forEach((candidate) => {
+        const selected = candidate.name === selectedValue;
+        const eligible = interfaceIsEligible(candidate, modeKey);
+        if (!eligible && !selected) return;
+        if (excludedValue && candidate.name === excludedValue && !selected) return;
+        let label = candidate.name;
+        if (!candidate[eligibilityField]) {
+            label = `${candidate.name} (current selection; unavailable)`;
+        }
+        options.push({ value: candidate.name, label });
+        seen.add(candidate.name);
+    });
+
+    if (selectedValue && !seen.has(selectedValue)) {
+        options.push({
+            value: selectedValue,
+            label: `${selectedValue} (current selection; unavailable)`,
+        });
+    }
+    return options;
+}
+
+export function renderInterfaceOptions(
+    selectElement,
+    candidates,
+    modeKey,
+    selectedValue,
+    excludedValue = null,
+) {
+    if (!selectElement) return;
+    const ownerDocument = selectElement.ownerDocument ?? globalThis.document;
+    const options = optionDefinitions(candidates, modeKey, selectedValue, excludedValue)
+        .map(({value, label}) => {
+            const option = ownerDocument.createElement("option");
+            option.value = value;
+            option.textContent = label;
+            return option;
+        });
+    selectElement.replaceChildren(...options);
+    selectElement.value = selectedValue || "";
+}

--- a/src/rust/lqosd/src/node_manager/js_build/src/config/network_mode_interfaces.test.mjs
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config/network_mode_interfaces.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    applyBridgeModePresentation,
+    interfaceIsEligible,
+    renderInterfaceOptions,
+} from "./network_mode_interfaces.mjs";
+
+class FakeElement {
+    constructor(ownerDocument) {
+        this.ownerDocument = ownerDocument;
+        this.checked = false;
+        this.disabled = false;
+        this.textContent = "";
+        this.value = "";
+        this.children = [];
+    }
+
+    replaceChildren(...children) {
+        this.children = children;
+    }
+}
+
+function fakeDocument() {
+    const elements = new Map();
+    const root = {
+        createElement: () => new FakeElement(root),
+        getElementById: (id) => elements.get(id) ?? null,
+    };
+    for (const id of ["useXdpBridge", "applyButton", "bridgeMtu", "bridgeMtuHelp", "toInternet"]) {
+        elements.set(id, new FakeElement(root));
+    }
+    return root;
+}
+
+test("bond masters are selectable only for XDP bridge mode", () => {
+    const bond = {
+        bridge_eligible: false,
+        xdp_bridge_eligible: true,
+        single_interface_eligible: false,
+    };
+
+    assert.equal(interfaceIsEligible(bond, "xdp"), true);
+    assert.equal(interfaceIsEligible(bond, "bridge"), false);
+    assert.equal(interfaceIsEligible(bond, "single"), false);
+});
+
+test("physical interfaces keep their existing mode eligibility", () => {
+    const physical = {
+        bridge_eligible: true,
+        xdp_bridge_eligible: true,
+        single_interface_eligible: true,
+    };
+
+    assert.equal(interfaceIsEligible(physical, "xdp"), true);
+    assert.equal(interfaceIsEligible(physical, "bridge"), true);
+    assert.equal(interfaceIsEligible(physical, "single"), true);
+});
+
+test("toggling XDP changes bond options, apply action, and MTU help", () => {
+    const root = fakeDocument();
+    const candidates = [
+        {
+            name: "enp1s0",
+            bridge_eligible: true,
+            xdp_bridge_eligible: true,
+            single_interface_eligible: true,
+        },
+        {
+            name: "bond-wan",
+            bridge_eligible: false,
+            xdp_bridge_eligible: true,
+            single_interface_eligible: false,
+        },
+    ];
+    const toggle = root.getElementById("useXdpBridge");
+    const select = root.getElementById("toInternet");
+
+    let presentation = applyBridgeModePresentation(root);
+    renderInterfaceOptions(select, candidates, "bridge", "enp1s0");
+    assert.deepEqual(select.children.map((option) => option.value), ["", "enp1s0"]);
+    assert.equal(root.getElementById("applyButton").textContent, "Apply Network Changes");
+    assert.equal(root.getElementById("bridgeMtu").disabled, false);
+    assert.equal(root.getElementById("bridgeMtuHelp").textContent, "Applies to the bridge members and br0.");
+    assert.match(presentation.draftSavedMessage, /Netplan together/);
+
+    toggle.checked = true;
+    presentation = applyBridgeModePresentation(root);
+    renderInterfaceOptions(select, candidates, "xdp", "bond-wan");
+    assert.deepEqual(select.children.map((option) => option.value), ["", "enp1s0", "bond-wan"]);
+    assert.equal(root.getElementById("applyButton").textContent, "Save XDP Configuration");
+    assert.equal(root.getElementById("bridgeMtu").disabled, true);
+    assert.equal(
+        root.getElementById("bridgeMtuHelp").textContent,
+        "XDP mode keeps this value for later, but LibreQoS will not apply it.",
+    );
+    assert.match(presentation.draftSavedMessage, /Netplan will not be changed/);
+});

--- a/src/rust/lqosd/src/node_manager/js_build/src/config_interface.js
+++ b/src/rust/lqosd/src/node_manager/js_build/src/config_interface.js
@@ -1,6 +1,12 @@
 import {loadConfig, renderConfigMenu} from "./config/config_helper";
 import {hydrateDraftMtu, MTU_MAX, MTU_MIN, parseOptionalMtu} from "./config/network_mode_mtu.mjs";
 import {
+    applyBridgeModePresentation,
+    bridgeModePresentation,
+    interfaceIsEligible,
+    renderInterfaceOptions,
+} from "./config/network_mode_interfaces.mjs";
+import {
     clearNetworkModeState,
     DRAFT_KEY,
     loadNetworkModeState,
@@ -10,10 +16,8 @@ import {
 
 const NETPLAN_TRY_TIMEOUT_MS = 30_000;
 const RECONNECT_POLL_INTERVAL_MS = 2_000;
-const BRIDGE_MTU_HELP = "Applies to the bridge members and br0.";
 const SINGLE_INTERFACE_MTU_HELP = "Applies to the trunk interface.";
 const MTU_LOCKED_HELP = "MTU cannot be changed while a network-mode operation is pending.";
-const XDP_MTU_HELP = "XDP mode keeps this value for later, but LibreQoS will not apply it.";
 let currentHelperStatus = null;
 let currentInspection = null;
 let currentPendingOperation = null;
@@ -48,6 +52,14 @@ function configModeKind(config) {
     if (config?.bridge) return "bridge";
     if (config?.single_interface) return "single";
     return "unknown";
+}
+
+function applyButtonText() {
+    const useXdp = Boolean(document.getElementById("useXdpBridge")?.checked);
+    return bridgeModePresentation(
+        useXdp,
+        Boolean(currentInspection?.editing_locked),
+    ).applyButtonText;
 }
 
 function getJson(url) {
@@ -133,21 +145,10 @@ function currentBridgeMtuValue() {
 }
 
 function updateBridgeMtuState() {
-    const useXdpBridge = document.getElementById("useXdpBridge")?.checked ?? false;
-    const bridgeMtu = document.getElementById("bridgeMtu");
-    const bridgeMtuHelp = document.getElementById("bridgeMtuHelp");
-    if (!bridgeMtu || !bridgeMtuHelp) return;
     const editingLocked = Boolean(currentInspection?.editing_locked);
-    bridgeMtu.disabled = useXdpBridge || editingLocked;
-    if (editingLocked) {
-        bridgeMtuHelp.textContent = MTU_LOCKED_HELP;
-        return;
-    }
-    if (useXdpBridge) {
+    const presentation = applyBridgeModePresentation(document, editingLocked);
+    if (!editingLocked && presentation.modeKey === "xdp") {
         clearMtuFieldError("bridgeMtu", "bridgeMtuError");
-        bridgeMtuHelp.textContent = XDP_MTU_HELP;
-    } else {
-        bridgeMtuHelp.textContent = BRIDGE_MTU_HELP;
     }
 }
 
@@ -239,57 +240,27 @@ function interfaceCandidates() {
     return Array.isArray(currentInspection?.interface_candidates) ? currentInspection.interface_candidates : [];
 }
 
-function optionLabel(candidate, selectedValue) {
-    if (!candidate) return selectedValue;
-    if (candidate.bridge_eligible || candidate.single_interface_eligible) {
-        return candidate.name;
-    }
-    if (candidate.current_selection || candidate.name === selectedValue) {
-        return `${candidate.name} (current selection; unavailable)`;
-    }
-    return `${candidate.name} (unavailable)`;
-}
-
 function buildSelectOptions(selectElement, modeKey, selectedValue, excludedValue = null) {
-    if (!selectElement) return;
-    const eligibilityField = modeKey === "single" ? "single_interface_eligible" : "bridge_eligible";
-    const candidates = interfaceCandidates();
-    const options = [`<option value="">Select an eligible interface</option>`];
-    const seen = new Set();
-
-    candidates.forEach((candidate) => {
-        const selected = candidate.name === selectedValue;
-        const eligible = Boolean(candidate[eligibilityField]);
-        if (!eligible && !selected) return;
-        if (excludedValue && candidate.name === excludedValue && !selected) return;
-        options.push(
-            `<option value="${escapeHtml(candidate.name)}">${escapeHtml(optionLabel(candidate, selectedValue))}</option>`
-        );
-        seen.add(candidate.name);
-    });
-
-    if (selectedValue && !seen.has(selectedValue)) {
-        options.push(
-            `<option value="${escapeHtml(selectedValue)}">${escapeHtml(`${selectedValue} (current selection; unavailable)`)}</option>`
-        );
-    }
-
-    selectElement.innerHTML = options.join("");
-    selectElement.value = selectedValue || "";
+    renderInterfaceOptions(
+        selectElement,
+        interfaceCandidates(),
+        modeKey,
+        selectedValue,
+        excludedValue,
+    );
 }
 
 function renderInterfaceHelp(helpElementId, modeKey, selectedValues = {}) {
     const element = document.getElementById(helpElementId);
     if (!element) return;
 
-    const eligibilityField = modeKey === "single" ? "single_interface_eligible" : "bridge_eligible";
     const selectedSet = new Set(
         Object.values(selectedValues)
             .map((value) => String(value || "").trim())
             .filter(Boolean)
     );
     const unavailable = interfaceCandidates().filter((candidate) => {
-        if (candidate[eligibilityField]) return false;
+        if (interfaceIsEligible(candidate, modeKey)) return false;
         return !selectedSet.has(candidate.name);
     });
 
@@ -335,10 +306,14 @@ function wireReviewTabs() {
 
 function renderInterfaceSelectors(config = null) {
     const selected = selectedInterfaceValuesFromConfig(config || buildCandidateConfig());
-    buildSelectOptions(document.getElementById("toInternet"), "bridge", selected.toInternet, selected.toNetwork);
-    buildSelectOptions(document.getElementById("toNetwork"), "bridge", selected.toNetwork, selected.toInternet);
+    const useXdp = config?.bridge
+        ? Boolean(config.bridge.use_xdp_bridge)
+        : Boolean(document.getElementById("useXdpBridge")?.checked);
+    const bridgeModeKey = useXdp ? "xdp" : "bridge";
+    buildSelectOptions(document.getElementById("toInternet"), bridgeModeKey, selected.toInternet, selected.toNetwork);
+    buildSelectOptions(document.getElementById("toNetwork"), bridgeModeKey, selected.toNetwork, selected.toInternet);
     buildSelectOptions(document.getElementById("interface"), "single", selected.singleInterface);
-    renderInterfaceHelp("bridgeInterfaceHelp", "bridge", {
+    renderInterfaceHelp("bridgeInterfaceHelp", bridgeModeKey, {
         toInternet: selected.toInternet,
         toNetwork: selected.toNetwork,
     });
@@ -348,12 +323,9 @@ function renderInterfaceSelectors(config = null) {
 }
 
 function populateFormFromConfig(config) {
-    renderInterfaceSelectors(config);
     if (config?.bridge) {
         document.getElementById("bridgeMode").checked = true;
         document.getElementById("useXdpBridge").checked = config.bridge.use_xdp_bridge ?? true;
-        document.getElementById("toInternet").value = config.bridge.to_internet ?? "";
-        document.getElementById("toNetwork").value = config.bridge.to_network ?? "";
         document.getElementById("bridgeMtu").value = config.bridge.mtu ?? "";
     } else if (config?.single_interface) {
         document.getElementById("singleInterfaceMode").checked = true;
@@ -362,6 +334,7 @@ function populateFormFromConfig(config) {
         document.getElementById("networkVlan").value = config.single_interface.network_vlan ?? 3;
         document.getElementById("singleInterfaceMtu").value = config.single_interface.mtu ?? "";
     }
+    renderInterfaceSelectors(config);
 
     const event = new Event("change");
     document.querySelector('input[name="networkMode"]:checked')?.dispatchEvent(event);
@@ -701,6 +674,7 @@ function renderInspection(inspection) {
         }
     });
     applyButton.disabled = !inspection?.can_apply;
+    applyButton.textContent = applyButtonText();
     adoptButton.disabled = !inspection?.can_adopt;
     takeoverButton.disabled = !inspection?.can_take_over;
     updateMtuState();
@@ -810,7 +784,11 @@ function confirmDangerousChange(actionLabel, candidate) {
 function applyNetworkChanges(mode = "Apply") {
     if (!validateConfig()) return;
     const candidate = buildCandidateConfig();
-    const actionLabel = mode === "Adopt" ? "Adopt into libreqos.yaml" : mode === "TakeOver" ? "Take Over libreqos.yaml" : "Apply Network Changes";
+    const actionLabel = mode === "Adopt"
+        ? "Adopt into libreqos.yaml"
+        : mode === "TakeOver"
+            ? "Take Over libreqos.yaml"
+            : applyButtonText();
     if (!confirmDangerousChange(actionLabel, candidate)) {
         return;
     }
@@ -830,6 +808,8 @@ function applyNetworkChanges(mode = "Apply") {
                 setPendingOperation(response.operation, {
                     action_label: actionLabel,
                 });
+            } else if (response?.message) {
+                alert(response.message);
             }
             clearNetworkModeState(DRAFT_KEY);
             window.config = candidate;
@@ -843,7 +823,7 @@ function applyNetworkChanges(mode = "Apply") {
         .finally(() => {
             if (button) {
                 button.disabled = false;
-                button.textContent = "Apply Network Changes";
+                button.textContent = applyButtonText();
             }
         });
 }
@@ -936,7 +916,12 @@ function wireActions() {
             renderInterfaceSelectors();
         });
     });
-    document.getElementById("useXdpBridge").addEventListener("change", updateMtuState);
+    document.getElementById("useXdpBridge").addEventListener("change", () => {
+        renderInterfaceSelectors();
+        updateMtuState();
+        const applyButton = document.getElementById("applyButton");
+        if (applyButton) applyButton.textContent = applyButtonText();
+    });
     [
         "bridgeMtu",
         "singleInterfaceMtu",
@@ -955,7 +940,8 @@ function wireActions() {
         if (!validateConfig()) return;
         saveDraft();
         inspectCandidate();
-        alert("Network mode draft saved for this browser tab. Use Apply Network Changes to commit both lqos.conf and netplan together.");
+        const useXdp = Boolean(document.getElementById("useXdpBridge")?.checked);
+        alert(bridgeModePresentation(useXdp).draftSavedMessage);
     });
     document.getElementById("inspectButton").addEventListener("click", inspectCandidate);
     document.getElementById("applyButton").addEventListener("click", () => applyNetworkChanges("Apply"));

--- a/src/rust/lqosd/src/node_manager/js_build/test-node-manager.sh
+++ b/src/rust/lqosd/src/node_manager/js_build/test-node-manager.sh
@@ -20,6 +20,7 @@ node --test \
   "${SCRIPT_DIR}/src/config/shaped_device_wire.test.mjs" \
   "${SCRIPT_DIR}/src/config_radius_accounting_contract.test.mjs" \
   "${SCRIPT_DIR}/src/config/config_interface_mtu.test.mjs" \
+  "${SCRIPT_DIR}/src/config/network_mode_interfaces.test.mjs" \
   "${SCRIPT_DIR}/src/config/local_api_token.test.mjs" \
   "${SCRIPT_DIR}/src/config/network_mode_storage.test.mjs" \
   "${SCRIPT_DIR}/src/config/ssl_redirect.test.mjs" \

--- a/src/rust/lqosd/src/node_manager/static2/config_interface.html
+++ b/src/rust/lqosd/src/node_manager/static2/config_interface.html
@@ -34,13 +34,13 @@
 
             <div class="lqos-config-section">
                 <h6 class="lqos-config-section-title">Operating Mode</h6>
-                <div class="lqos-config-section-subtitle">Select either a two-interface bridge or a single trunk interface using VLANs. XDP bridge mode remains manual.</div>
+                <div class="lqos-config-section-subtitle">Select either a two-interface bridge or a single trunk interface using VLANs. XDP bridge mode leaves Netplan unchanged.</div>
 
                 <div class="mb-3">
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="networkMode" id="bridgeMode" value="bridge">
                         <label class="form-check-label" for="bridgeMode">Bridge Mode</label>
-                        <div class="form-text">Two physical interfaces: one facing the Internet and one facing the LAN. Linux bridge mode is the managed netplan path.</div>
+                        <div class="form-text">Two interfaces: one facing the Internet and one facing the LAN. Linux bridge mode is the managed Netplan path.</div>
                     </div>
                     <div class="form-check">
                         <input class="form-check-input" type="radio" name="networkMode" id="singleInterfaceMode" value="single">
@@ -60,23 +60,23 @@
                     <div class="mb-3 form-check">
                         <input type="checkbox" class="form-check-input" id="useXdpBridge" aria-describedby="useXdpBridgeHelp">
                         <label class="form-check-label" for="useXdpBridge">Use XDP Bridge</label>
-                        <div id="useXdpBridgeHelp" class="form-text">XDP does not write Netplan or apply Bridge MTU.</div>
+                        <div id="useXdpBridgeHelp" class="form-text">XDP does not write Netplan or apply Bridge MTU. Eligible bond masters are selectable after they are configured in Netplan; member NIC drivers must also support native XDP.</div>
                     </div>
 
                     <div class="mb-3">
                         <label for="toInternet" class="form-label">Internet-Facing Interface</label>
-                        <select class="form-select" id="toInternet">
+                        <select class="form-select" id="toInternet" aria-describedby="useXdpBridgeHelp toInternetHelp bridgeInterfaceHelp">
                             <option value="">Select an eligible interface</option>
                         </select>
-                        <div class="form-text">Eligible non-management interfaces with LibreQoS-friendly queue support.</div>
+                        <div id="toInternetHelp" class="form-text">Eligible non-management interfaces with LibreQoS-friendly queue support. XDP mode also offers eligible bond masters.</div>
                     </div>
 
                     <div class="mb-2">
                         <label for="toNetwork" class="form-label">LAN-Facing Interface</label>
-                        <select class="form-select" id="toNetwork">
+                        <select class="form-select" id="toNetwork" aria-describedby="useXdpBridgeHelp toNetworkHelp bridgeInterfaceHelp">
                             <option value="">Select an eligible interface</option>
                         </select>
-                        <div class="form-text">Pick a different eligible interface for the LAN side.</div>
+                        <div id="toNetworkHelp" class="form-text">Pick a different eligible interface for the LAN side.</div>
                     </div>
 
                     <div class="mb-2">
@@ -85,7 +85,7 @@
                         <div id="bridgeMtuHelp" class="form-text">Applies to the bridge members and br0.</div>
                         <div id="bridgeMtuError" class="invalid-feedback" role="alert"></div>
                     </div>
-                    <div id="bridgeInterfaceHelp" class="small text-secondary"></div>
+                    <div id="bridgeInterfaceHelp" class="small text-secondary" aria-live="polite"></div>
                 </div>
             </section>
         </div>


### PR DESCRIPTION
## Summary

- Allow first-run setup and Node Manager to select XDP-compatible bond masters, including 802.3ad/LACP.
- Keep XDP saves simple: update lqos.conf, leave Netplan unchanged, and require an lqosd restart for activation.
- Reject bond members, missing interfaces, L3-configured shaping bonds, and unsupported native-XDP bond modes or transmit hash policies.
- Update English and Spanish operator documentation with 802.3ad examples and validation guidance.

This uses Linux native bonded-interface XDP support. It does not add the earlier Sandwich topology or change the LibreQoS packet-processing dataplane.

## Validation

- cargo test -p lqos_config -p lqos_netplan_helper -p lqos_setup
- cargo check -p lqosd
- cargo clippy -p lqos_config -p lqos_netplan_helper -p lqos_setup -p lqosd -- -D warnings
- Node Manager test suite and build-contract checks
- cargo audit (only existing allowed warnings)
- Isolated veth/network-namespace testbed proved native driver-mode XDP attachment on an 802.3ad bond

## Testing status

Opened for broader testing. Do not merge to develop yet.